### PR TITLE
introduce a backoff behavior for peers that are not permitting connectio...

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -1234,6 +1234,7 @@ func newOutboundPeer(s *server, addr string, persistent bool) *peer {
 				// Connection was successful so log it and start peer.
 				log.Infof("[SRVR] Connected to %s", conn.RemoteAddr())
 				p.conn = conn
+				p.retrycount = 0
 				p.Start()
 			} else {
 				p.server.donePeers <- p


### PR DESCRIPTION
...ns

with help from davec

o implement peer { retrycount int64 ..
o count connect failures per peer
o calculate backoff as 10s \* retrycount / 2
