### PR TITLE
Fixed handleRescan to return final nil result message

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1298,6 +1298,7 @@ func handleRescan(s *rpcServer, cmd btcjson.Cmd,
 		}
 	}
 
+	reply.Result = nil
 	mreply, _ := json.Marshal(reply)
 	walletNotification <- mreply
 


### PR DESCRIPTION
Currently, if there's a transaction sent during the rescan operation, the last transaction will be sent to the client again instead of sending the empty result (signaling rescan complete).

I've pushed a one-liner change to match the behavior that btcwallet expects.
