### PR TITLE
Fixed up GetRawTransaction and updated GetBlock to handle verbose

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -966,7 +966,7 @@ func createTxRawResult(net btcwire.BitcoinNet, txSha string, mtx *btcwire.MsgTx,
 
 	for i, v := range txOutList {
 		voutList[i].N = i
-		voutList[i].Value = float64(v.Value) / 100000000
+		voutList[i].Value = float64(v.Value) / btcutil.SatoshiPerBitcoin
 
 		_, addrhash, err := btcscript.ScriptToAddrHash(v.PkScript)
 		if err != nil {


### PR DESCRIPTION
Updated handleGetRawTransaction to populate all the fields required to
match bitcoind.  It still doesn't handle MULTISIG addresses correctly.

Changed handleGetBlock to implement new optional verbose (default true)
flag and also added a verboseTx flag to return TxRawDefault instead of
Txid.  When verbose=false, GetBlock returns hex-encoded wire bytes for
the block.

This pull request depends on conformal/btcjson#10.
