### PR TITLE
Remove comments interpreted as settings

### DIFF
--- a/sample-btcd.conf
+++ b/sample-btcd.conf
@@ -96,18 +96,30 @@
 ; NOTE: The default port is modified by some options such as 'testnet', so it is
 ; recommended to not specify a port and allow a proper default to be chosen
 ; unless you have a specific reason to do otherwise.
-; listen=               ; all interfaces on default port (this is the default)
-; listen=0.0.0.0        ; all ipv4 interfaces on default port
-; listen=::             ; all ipv6 interfaces on default port
-; listen=:8333          ; all interfaces on port 8333
-; listen=0.0.0.0:8333   ; all ipv4 interfaces on port 8333
-; listen=[::]:8333      ; all ipv6 interfaces on port 8333
-; listen=127.0.0.1:8333 ; only ipv4 localhost on port 8333
-; listen=[::1]:8333     ; only ipv6 localhost on port 8333
-; listen=127.0.0.1:8336 ; only ipv4 localhost on non-standard port 8336
-; listen=:8336          ; all interfaces on non-standard port 8336
-; listen=0.0.0.0:8336   ; all ipv4 interfaces on non-standard port 8336
-; listen=[::]:8336      ; all ipv6 interfaces on non-standard port 8336
+; All interfaces on default port (this is the default):
+;  listen=
+; All ipv4 interfaces on default port:
+;  listen=0.0.0.0
+; All ipv6 interfaces on default port:
+;   listen=::
+; All interfaces on port 8333:
+;   listen=:8333
+; All ipv4 interfaces on port 8333:
+;   listen=0.0.0.0:8333
+; All ipv6 interfaces on port 8333:
+;   listen=[::]:8333
+; Only ipv4 localhost on port 8333:
+;   listen=127.0.0.1:8333
+; Only ipv6 localhost on port 8333:
+;   listen=[::1]:8333
+; Only ipv4 localhost on non-standard port 8336:
+;   listen=127.0.0.1:8336
+; All interfaces on non-standard port 8336:
+;   listen=:8336
+; All ipv4 interfaces on non-standard port 8336:
+;   listen=0.0.0.0:8336
+; All ipv6 interfaces on non-standard port 8336:
+;   listen=[::]:8336
 
 ; Disable listening for incoming connections.  This will override all listeners.
 ; nolisten=1
@@ -130,18 +142,30 @@
 ; line.  NOTE: The default port is modified by some options such as 'testnet',
 ; so it is recommended to not specify a port and allow a proper default to be
 ; chosen unless you have a specific reason to do otherwise.
-; rpclisten=               ; all interfaces on default port (this is the default)
-; rpclisten=0.0.0.0        ; all ipv4 interfaces on default port
-; rpclisten=::             ; all ipv6 interfaces on default port
-; rpclisten=:8334          ; all interfaces on port 8334
-; rpclisten=0.0.0.0:8334   ; all ipv4 interfaces on port 8334
-; rpclisten=[::]:8334      ; all ipv6 interfaces on port 8334
-; rpclisten=127.0.0.1:8334 ; only ipv4 localhost on port 8334
-; rpclisten=[::1]:8334     ; only ipv6 localhost on port 8334
-; rpclisten=127.0.0.1:8337 ; only ipv4 localhost on non-standard port 8337
-; rpclisten=:8337          ; all interfaces on non-standard port 8337
-; rpclisten=0.0.0.0:8337   ; all ipv4 interfaces on non-standard port 8337
-; rpclisten=[::]:8337      ; all ipv6 interfaces on non-standard port 8337
+; All interfaces on default port (this is the default):
+;   rpclisten=
+; All ipv4 interfaces on default port:
+;   rpclisten=0.0.0.0
+; All ipv6 interfaces on default port:
+;   rpclisten=::
+; All interfaces on port 8334:
+;   rpclisten=:8334
+; All ipv4 interfaces on port 8334:
+;   rpclisten=0.0.0.0:8334
+; All ipv6 interfaces on port 8334:
+;   rpclisten=[::]:8334
+; Only ipv4 localhost on port 8334:
+;   rpclisten=127.0.0.1:8334
+; Only ipv6 localhost on port 8334:
+;   rpclisten=[::1]:8334
+; Only ipv4 localhost on non-standard port 8337:
+;   rpclisten=127.0.0.1:8337
+; All interfaces on non-standard port 8337:
+;   rpclisten=:8337
+; All ipv4 interfaces on non-standard port 8337:
+;   rpclisten=0.0.0.0:8337
+; All ipv6 interfaces on non-standard port 8337:
+;   rpclisten=[::]:8337
 
 ; Specify the maximum number of concurrent RPC clients for standard connections.
 ; rpcmaxclients=10


### PR DESCRIPTION
in go-flags/ini_private.go in function readIni there is no mechanism for adding inline comments.  Only comments that have a semicolon as the first non-whitespace character are ignored.  

According to Wikipedia http://en.wikipedia.org/wiki/INI_file#Comments inline comments are not universally supported.  

This change adds some white space for readability, but name := strings.TrimSpace(line[1 : len(line)-1]) removes accidental whitespace left in later.
