### PR TITLE
Remove transactions from orphan pool.

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1138,14 +1138,16 @@ func (b *blockManager) handleNotifyMsg(notification *btcchain.Notification) {
 		}
 
 		// Remove all of the transactions (except the coinbase) in the
-		// connected block from the transaction pool.  Also, remove any
+		// connected block from the transaction pool.  Secondly, remove any
 		// transactions which are now double spends as a result of these
-		// new transactions.  Note that removing a transaction from
+		// new transactions.  Finally, remove any transaction that is
+		// no longer an orphan.  Note that removing a transaction from
 		// pool also removes any transactions which depend on it,
 		// recursively.
 		for _, tx := range block.Transactions()[1:] {
 			b.server.txMemPool.RemoveTransaction(tx)
 			b.server.txMemPool.RemoveDoubleSpends(tx)
+			b.server.txMemPool.RemoveOrphan(tx.Sha())
 		}
 
 		if r := b.server.rpcServer; r != nil {

--- a/mempool.go
+++ b/mempool.go
@@ -396,9 +396,8 @@ func calcMinRequiredTxRelayFee(serializedSize int64) int64 {
 	return minFee
 }
 
-// removeOrphan removes the passed orphan transaction from the orphan pool and
-// previous orphan index.
-//
+// removeOrphan is the internal function which implements the public
+// RemoveOrphan.  See the comment for RemoveOrphan for more details.
 // This function MUST be called with the mempool lock held (for writes).
 func (mp *txMemPool) removeOrphan(txHash *btcwire.ShaHash) {
 	// Nothing to do if passed tx is not an orphan.
@@ -428,6 +427,15 @@ func (mp *txMemPool) removeOrphan(txHash *btcwire.ShaHash) {
 
 	// Remove the transaction from the orphan pool.
 	delete(mp.orphans, *txHash)
+}
+
+// RemoveOrphan removes the passed orphan transaction from the orphan pool and
+// previous orphan index.
+// This function is safe for concurrent access.
+func (mp *txMemPool) RemoveOrphan(txHash *btcwire.ShaHash) {
+	mp.Lock()
+	mp.removeOrphan(txHash)
+	mp.Unlock()
 }
 
 // limitNumOrphans limits the number of orphan transactions by evicting a random


### PR DESCRIPTION
This change removes transactions in a newly connected block
from the orphan pool if they exist.  This helps keep memory
usage lower.
