### PR TITLE
Use correct error name in handleGetRawTransaction.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2413,11 +2413,11 @@ func handleGetRawTransaction(s *rpcServer, cmd btcjson.Cmd, closeChan <-chan str
 		}
 	}
 
-	rawTxn, jsonErr := createTxRawResult(s.server.netParams, c.Txid, mtx,
+	rawTxn, err := createTxRawResult(s.server.netParams, c.Txid, mtx,
 		blk, maxidx, blksha)
 	if err != nil {
 		rpcsLog.Errorf("Cannot create TxRawResult for txSha=%s: %v", txSha, err)
-		return nil, jsonErr
+		return nil, err
 	}
 	return *rawTxn, nil
 }


### PR DESCRIPTION
This commit corrects the error check from the createTxRawResult call in
handleGetRawTransaction.  It was previously given a different name which
resulted in the wrong error being checked.

Fixes #196.
