### PR TITLE
Always ping the remote peer.

### DIFF
--- a/server.go
+++ b/server.go
@@ -408,11 +408,10 @@ func (s *server) handleQuery(querymsg interface{}, state *peerState) {
 				BanScore:       0,
 				SyncNode:       p == syncPeer,
 			}
-			info.PingTime = float64(p.lastPingMicros)
+			info.PingTime = float64(p.lastPingResponse.Nanoseconds() / 1000)
 			if p.lastPingNonce != 0 {
-				wait := float64(time.Now().Sub(p.lastPingTime).Nanoseconds())
-				// We actually want microseconds.
-				info.PingWait = wait / 1000
+				wait := time.Since(p.lastPingTime).Nanoseconds() / 1000
+				info.PingWait = float64(wait)
 			}
 			p.StatsMtx.Unlock()
 			infos = append(infos, info)


### PR DESCRIPTION
This commit unconditionally sends a ping to the remote peer every
pingInterval time (currently 2 minutes).  Additionally, if the remote
peer's protocol version is greater than btcwire.BIP0031Version, the
remote peer must send a pong in response to the ping.  A timer is
setup for such peers and will disconnect the peer if a response is
not received in pingTimeoutMinutes (currently 1 minute).