### PR TITLE
Relay inv msgs now include underlying data object

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1131,7 +1131,7 @@ func (b *blockManager) handleNotifyMsg(notification *btcchain.Notification) {
 
 		// Generate the inventory vector and relay it.
 		iv := btcwire.NewInvVect(btcwire.InvTypeBlock, hash)
-		b.server.RelayInventory(iv)
+		b.server.RelayInventory(iv, nil)
 
 	// A block has been connected to the main block chain.
 	case btcchain.NTBlockConnected:

--- a/mempool.go
+++ b/mempool.go
@@ -1123,7 +1123,7 @@ func (mp *txMemPool) processOrphans(hash *btcwire.ShaHash) error {
 				// Generate and relay the inventory vector for the
 				// newly accepted transaction.
 				iv := btcwire.NewInvVect(btcwire.InvTypeTx, tx.Sha())
-				mp.server.RelayInventory(iv)
+				mp.server.RelayInventory(iv, tx)
 			} else {
 				// Transaction is still an orphan.
 				// TODO(jrick): This removeOrphan call is
@@ -1175,7 +1175,7 @@ func (mp *txMemPool) ProcessTransaction(tx *btcutil.Tx, allowOrphan, rateLimit b
 	if len(missingParents) == 0 {
 		// Generate the inventory vector and relay it.
 		iv := btcwire.NewInvVect(btcwire.InvTypeTx, tx.Sha())
-		mp.server.RelayInventory(iv)
+		mp.server.RelayInventory(iv, tx)
 
 		// Accept any orphan transactions that depend on this
 		// transaction (they may no longer be orphans if all inputs

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2999,7 +2999,7 @@ func handleSendRawTransaction(s *rpcServer, cmd btcjson.Cmd, closeChan <-chan st
 	// We keep track of all the sendrawtransaction request txs so that we
 	// can rebroadcast them if they don't make their way into a block.
 	iv := btcwire.NewInvVect(btcwire.InvTypeTx, tx.Sha())
-	s.server.AddRebroadcastInventory(iv)
+	s.server.AddRebroadcastInventory(iv, tx)
 
 	return tx.Sha().String(), nil
 }


### PR DESCRIPTION
When an inv is to be sent to the server for relaying, the sender already has access to the underlying data. So instead of requiring the relay to look up the data by hash, the data is now coupled in the relay request message.

Previously, forcing the relay to look up the data itself led to an occasional deadlock between the `mempool` and `server` as detailed in: #231. This PR purpotes to eliminate any possiblity for deadlock by implementing [davecgh's proposed solution](https://github.com/btcsuite/btcd/issues/231#issuecomment-71876668). 