### PR TITLE
Make NOP1-NOP10 opcode execution non-standard.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -48,7 +48,8 @@ const (
 	// are more strict.
 	standardScriptVerifyFlags = btcscript.ScriptBip16 |
 		btcscript.ScriptCanonicalSignatures |
-		btcscript.ScriptStrictMultiSig
+		btcscript.ScriptStrictMultiSig |
+		btcscript.ScriptDiscourageUpgradableNops
 )
 
 // txPrioItem houses a transaction along with extra information that allows the


### PR DESCRIPTION
This commit makes use of the new `ScriptDiscourageUpgradableNops` flag to reject execution of NOP1 through NOP10 for transactions that are considered standard.

This mirrors the behavior added to Bitcoin Core via pull request 5000.