### PR TITLE
Use goleveldb Has() API.

### DIFF
--- a/database/ldb/block.go
+++ b/database/ldb/block.go
@@ -202,14 +202,9 @@ func (db *LevelDb) ExistsSha(sha *btcwire.ShaHash) (bool, error) {
 // returns true if it is present in the database.
 // CALLED WITH LOCK HELD
 func (db *LevelDb) blkExistsSha(sha *btcwire.ShaHash) (bool, error) {
-	_, err := db.getBlkLoc(sha)
-	switch err {
-	case nil:
-		return true, nil
-	case leveldb.ErrNotFound, database.ErrBlockShaMissing:
-		return false, nil
-	}
-	return false, err
+	key := shaBlkToKey(sha)
+
+	return db.lDb.Has(key, db.ro)
 }
 
 // FetchBlockShaByHeight returns a block hash based on its height in the

--- a/database/ldb/tx.go
+++ b/database/ldb/tx.go
@@ -187,14 +187,9 @@ func (db *LevelDb) ExistsTxSha(txsha *btcwire.ShaHash) (bool, error) {
 // existsTxSha returns if the given tx sha exists in the database.o
 // Must be called with the db lock held.
 func (db *LevelDb) existsTxSha(txSha *btcwire.ShaHash) (bool, error) {
-	_, _, _, _, err := db.getTxData(txSha)
-	switch err {
-	case nil:
-		return true, nil
-	case leveldb.ErrNotFound:
-		return false, nil
-	}
-	return false, err
+	key := shaTxToKey(txSha)
+
+	return db.lDb.Has(key, db.ro)
 }
 
 // FetchTxByShaList returns the most recent tx of the name fully spent or not


### PR DESCRIPTION
This change converts the leveldb database's ExistsSha() and
ExistsTxSha to use the goleveldb API.  Has() only returns if
the key exists and does not need to read the entire value into
memory resulting in less disk i/o and much less GC.