### PR TITLE
[btcec] Move the btcec benchmarks into the main package.

### DIFF
--- a/btcec/bench_test.go
+++ b/btcec/bench_test.go
@@ -2,26 +2,22 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package btcec_test
+package btcec
 
-import (
-	"testing"
-
-	"github.com/btcsuite/btcd/btcec"
-)
+import "testing"
 
 // BenchmarkAddJacobian benchmarks the secp256k1 curve addJacobian function with
 // Z values of 1 so that the associated optimizations are used.
 func BenchmarkAddJacobian(b *testing.B) {
 	b.StopTimer()
-	x1 := btcec.NewFieldVal().SetHex("34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6")
-	y1 := btcec.NewFieldVal().SetHex("0b71ea9bd730fd8923f6d25a7a91e7dd7728a960686cb5a901bb419e0f2ca232")
-	z1 := btcec.NewFieldVal().SetHex("1")
-	x2 := btcec.NewFieldVal().SetHex("34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6")
-	y2 := btcec.NewFieldVal().SetHex("0b71ea9bd730fd8923f6d25a7a91e7dd7728a960686cb5a901bb419e0f2ca232")
-	z2 := btcec.NewFieldVal().SetHex("1")
-	x3, y3, z3 := btcec.NewFieldVal(), btcec.NewFieldVal(), btcec.NewFieldVal()
-	curve := btcec.S256()
+	x1 := new(fieldVal).SetHex("34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6")
+	y1 := new(fieldVal).SetHex("0b71ea9bd730fd8923f6d25a7a91e7dd7728a960686cb5a901bb419e0f2ca232")
+	z1 := new(fieldVal).SetHex("1")
+	x2 := new(fieldVal).SetHex("34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6")
+	y2 := new(fieldVal).SetHex("0b71ea9bd730fd8923f6d25a7a91e7dd7728a960686cb5a901bb419e0f2ca232")
+	z2 := new(fieldVal).SetHex("1")
+	x3, y3, z3 := new(fieldVal), new(fieldVal), new(fieldVal)
+	curve := S256()
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		curve.TstAddJacobian(x1, y1, z1, x2, y2, z2, x3, y3, z3)
@@ -33,14 +29,14 @@ func BenchmarkAddJacobian(b *testing.B) {
 // Z=1 aren't used.
 func BenchmarkAddJacobianNotZOne(b *testing.B) {
 	b.StopTimer()
-	x1 := btcec.NewFieldVal().SetHex("d3e5183c393c20e4f464acf144ce9ae8266a82b67f553af33eb37e88e7fd2718")
-	y1 := btcec.NewFieldVal().SetHex("5b8f54deb987ec491fb692d3d48f3eebb9454b034365ad480dda0cf079651190")
-	z1 := btcec.NewFieldVal().SetHex("2")
-	x2 := btcec.NewFieldVal().SetHex("91abba6a34b7481d922a4bd6a04899d5a686f6cf6da4e66a0cb427fb25c04bd4")
-	y2 := btcec.NewFieldVal().SetHex("03fede65e30b4e7576a2abefc963ddbf9fdccbf791b77c29beadefe49951f7d1")
-	z2 := btcec.NewFieldVal().SetHex("3")
-	x3, y3, z3 := btcec.NewFieldVal(), btcec.NewFieldVal(), btcec.NewFieldVal()
-	curve := btcec.S256()
+	x1 := new(fieldVal).SetHex("d3e5183c393c20e4f464acf144ce9ae8266a82b67f553af33eb37e88e7fd2718")
+	y1 := new(fieldVal).SetHex("5b8f54deb987ec491fb692d3d48f3eebb9454b034365ad480dda0cf079651190")
+	z1 := new(fieldVal).SetHex("2")
+	x2 := new(fieldVal).SetHex("91abba6a34b7481d922a4bd6a04899d5a686f6cf6da4e66a0cb427fb25c04bd4")
+	y2 := new(fieldVal).SetHex("03fede65e30b4e7576a2abefc963ddbf9fdccbf791b77c29beadefe49951f7d1")
+	z2 := new(fieldVal).SetHex("3")
+	x3, y3, z3 := new(fieldVal), new(fieldVal), new(fieldVal)
+	curve := S256()
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		curve.TstAddJacobian(x1, y1, z1, x2, y2, z2, x3, y3, z3)
@@ -51,7 +47,7 @@ func BenchmarkAddJacobianNotZOne(b *testing.B) {
 // function.
 func BenchmarkScalarBaseMult(b *testing.B) {
 	k := fromHex("d74bf844b0862475103d96a611cf2d898447e288d34b360bc885cb8ce7c00575")
-	curve := btcec.S256()
+	curve := S256()
 	for i := 0; i < b.N; i++ {
 		curve.ScalarBaseMult(k.Bytes())
 	}
@@ -61,7 +57,7 @@ func BenchmarkScalarBaseMult(b *testing.B) {
 // function with abnormally large k values.
 func BenchmarkScalarBaseMultLarge(b *testing.B) {
 	k := fromHex("d74bf844b0862475103d96a611cf2d898447e288d34b360bc885cb8ce7c005751111111011111110")
-	curve := btcec.S256()
+	curve := S256()
 	for i := 0; i < b.N; i++ {
 		curve.ScalarBaseMult(k.Bytes())
 	}
@@ -72,7 +68,7 @@ func BenchmarkScalarMult(b *testing.B) {
 	x := fromHex("34f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6")
 	y := fromHex("0b71ea9bd730fd8923f6d25a7a91e7dd7728a960686cb5a901bb419e0f2ca232")
 	k := fromHex("d74bf844b0862475103d96a611cf2d898447e288d34b360bc885cb8ce7c00575")
-	curve := btcec.S256()
+	curve := S256()
 	for i := 0; i < b.N; i++ {
 		curve.ScalarMult(x, y, k.Bytes())
 	}
@@ -82,7 +78,7 @@ func BenchmarkScalarMult(b *testing.B) {
 func BenchmarkNAF(b *testing.B) {
 	k := fromHex("d74bf844b0862475103d96a611cf2d898447e288d34b360bc885cb8ce7c00575")
 	for i := 0; i < b.N; i++ {
-		btcec.NAF(k.Bytes())
+		NAF(k.Bytes())
 	}
 }
 
@@ -92,15 +88,15 @@ func BenchmarkSigVerify(b *testing.B) {
 	b.StopTimer()
 	// Randomly generated keypair.
 	// Private key: 9e0699c91ca1e3b7e3c9ba71eb71c89890872be97576010fe593fbf3fd57e66d
-	pubKey := btcec.PublicKey{
-		Curve: btcec.S256(),
+	pubKey := PublicKey{
+		Curve: S256(),
 		X:     fromHex("d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab"),
 		Y:     fromHex("ab65528eefbb8057aa85d597258a3fbd481a24633bc9b47a9aa045c91371de52"),
 	}
 
 	// Double sha256 of []byte{0x01, 0x02, 0x03, 0x04}
 	msgHash := fromHex("8de472e2399610baaa7f84840547cd409434e31f5d3bd71e4d947f283874f9c0")
-	sig := btcec.Signature{
+	sig := Signature{
 		R: fromHex("fef45d2892953aa5bbcdb057b5e98b208f1617a7498af7eb765574e29b5d9c2c"),
 		S: fromHex("d47563f52aac6b04b55de236b7c515eb9311757db01e02cff079c3ca6efb063f"),
 	}

--- a/btcec/btcec_test.go
+++ b/btcec/btcec_test.go
@@ -602,18 +602,6 @@ func TestScalarMult(t *testing.T) {
 	}
 }
 
-//TODO: test more curves?
-func BenchmarkBaseMult(b *testing.B) {
-	b.ResetTimer()
-	s256 := btcec.S256()
-	e := s256BaseMultTests[0] //TODO: check, used to be 25 instead of 0, but it's probably ok
-	k, _ := new(big.Int).SetString(e.k, 16)
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		s256.ScalarBaseMult(k.Bytes())
-	}
-}
-
 // Test this curve's usage with the ecdsa package.
 
 func testKeyGeneration(t *testing.T, c *btcec.KoblitzCurve, tag string) {


### PR DESCRIPTION
The benchmarks are still only compiled when running 'go test' so this has no effect on regular usage.  This is being done because benchmarks often need access to internal state.

Normal tests are kept in a separate package since they also serve to exercise the public API, and by intentionally making it more difficult to reach into the internals, it helps ensure the public API is sanely usable.

Since the benchmarks can now access the internals directly, this commit also removes the functions which exposed the internals to the test package from internal_test.go which were only used by the benchmarks.

Also, it removes a duplicate benchmark.