### PR TITLE
[btcec] Consistency and general cleanup in btcec. 

### DIFF
--- a/btcec/field.go
+++ b/btcec/field.go
@@ -641,7 +641,7 @@ func (f *fieldVal) MulInt(val uint) *fieldVal {
 // Mul multiplies the passed value to the existing field value and stores the
 // result in f.  Note that this function can overflow if multiplying any
 // of the individual words exceeds a max uint32.  In practice, this means the
-// magnitude of either value invovled in the multiplication must be a max of
+// magnitude of either value involved in the multiplication must be a max of
 // 8.
 //
 // The field value is returned to support chaining.  This enables syntax like:
@@ -653,7 +653,7 @@ func (f *fieldVal) Mul(val *fieldVal) *fieldVal {
 // Mul2 multiplies the passed two field values together and stores the result
 // result in f.  Note that this function can overflow if multiplying any of
 // the individual words exceeds a max uint32.  In practice, this means the
-// magnitude of either value invovled in the multiplication must be a max of
+// magnitude of either value involved in the multiplication must be a max of
 // 8.
 //
 // The field value is returned to support chaining.  This enables syntax like:

--- a/btcec/secp256k1.go
+++ b/btcec/secp256k1.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 Conformal Systems LLC.
+// Copyright (c) 2015 Conformal Systems LLC.
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 


### PR DESCRIPTION
This pull request contains various modifications for code and comment consistency in the btcec package:
- Call out references at the top and reference them by their identifier in the other comments
- Remove a TODO that no longer applies
- Add comments to the fields in the KoblitzCurve struct and reorder them slightly
- Make comments wrap to 80
- Cleanup code that was far exceeding col 80 (only function declarations typically do this)
- Extend block comments to use as much of the 80 cols as available
- Add a bit more explanation in a couple of places
- Update copyright year on secp256k1.go
- Fix a couple of typos in the comments