### PR TITLE
Make profiling easier to follow with static dispatch.

### DIFF
--- a/blockchain/txlookup.go
+++ b/blockchain/txlookup.go
@@ -122,11 +122,12 @@ func fetchTxStoreMain(db database.Db, txSet map[wire.ShaHash]struct{}, includeSp
 	// will return the information from the point of view of the end of the
 	// main chain.  Choose whether or not to include fully spent
 	// transactions depending on the passed flag.
-	fetchFunc := db.FetchUnSpentTxByShaList
+	var txReplyList []*database.TxListReply
 	if includeSpent {
-		fetchFunc = db.FetchTxByShaList
+		txReplyList = db.FetchTxByShaList(txList)
+	} else {
+		txReplyList = db.FetchUnSpentTxByShaList(txList)
 	}
-	txReplyList := fetchFunc(txList)
 	for _, txReply := range txReplyList {
 		// Lookup the existing results entry to modify.  Skip
 		// this reply if there is no corresponding entry in


### PR DESCRIPTION
For example, when performing a heap profile, this:

         .          .    125:   fetchFunc := db.FetchUnSpentTxByShaList
         .          .    126:   if includeSpent {
         .          .    127:           fetchFunc = db.FetchTxByShaList
         .          .    128:   }
         .     9.11MB    129:   txReplyList := fetchFunc(txList)

Now becomes this:

         .          .    125:   var txReplyList []*database.TxListReply
         .          .    126:   if includeSpent {
         .          .    127:           txReplyList = db.FetchTxByShaList(txList)
         .          .    128:   } else {
         .     8.75MB    129:           txReplyList = db.FetchUnSpentTxByShaList(txList)
         .          .    130:   }

And it's clear where the majority of our allocations are coming from.