### PR TITLE
txscript: Remove ScriptCanonicalSignatures

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -47,7 +47,7 @@ const (
 	// different than what is required for the consensus rules in that they
 	// are more strict.
 	standardScriptVerifyFlags = txscript.ScriptBip16 |
-		txscript.ScriptCanonicalSignatures |
+		txscript.ScriptVerifyDERSignatures |
 		txscript.ScriptStrictMultiSig |
 		txscript.ScriptDiscourageUpgradableNops
 )

--- a/txscript/example_test.go
+++ b/txscript/example_test.go
@@ -166,7 +166,7 @@ func ExampleSignTxOutput() {
 
 	// Prove that the transaction has been validly signed by executing the
 	// script pair.
-	flags := txscript.ScriptBip16 | txscript.ScriptCanonicalSignatures |
+	flags := txscript.ScriptBip16 | txscript.ScriptVerifyDERSignatures |
 		txscript.ScriptStrictMultiSig |
 		txscript.ScriptDiscourageUpgradableNops
 	s, err := txscript.NewScript(redeemTx.TxIn[0].SignatureScript,

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -1807,7 +1807,7 @@ func opcodeCheckSig(op *parsedOpcode, s *Script) error {
 	}
 
 	var signature *btcec.Signature
-	if s.der || s.verifyStrictEncoding || s.verifyDERSignatures {
+	if s.verifyStrictEncoding || s.verifyDERSignatures {
 		signature, err = btcec.ParseDERSignature(sigStr, btcec.S256())
 	} else {
 		signature, err = btcec.ParseSignature(sigStr, btcec.S256())
@@ -1967,7 +1967,7 @@ func opcodeCheckMultiSig(op *parsedOpcode, s *Script) error {
 
 			// Parse the signature.
 			var err error
-			if s.der || s.verifyStrictEncoding || s.verifyDERSignatures {
+			if s.verifyStrictEncoding || s.verifyDERSignatures {
 				parsedSig, err = btcec.ParseDERSignature(signature,
 					btcec.S256())
 			} else {

--- a/txscript/opcode_test.go
+++ b/txscript/opcode_test.go
@@ -19,7 +19,7 @@ func TestScripts(t *testing.T) {
 
 	tests := []struct {
 		script     []byte
-		canonical  bool
+		strictSigs bool
 		shouldPass bool
 		shouldFail error
 	}{
@@ -383,7 +383,6 @@ func TestScripts(t *testing.T) {
 			0x8a, 0x06, 0x26, 0xf1, 0xba, 0xde, 0xd5, 0xc7, 0x2a, 0x70,
 			0x4f, 0x7e, 0x6c, 0xd8, 0x4c,
 			txscript.OP_1, txscript.OP_CHECKMULTISIG},
-			canonical:  false,
 			shouldPass: false},
 		{script: []byte{txscript.OP_1, txscript.OP_1, txscript.OP_DATA_65,
 			0x04, 0xae, 0x1a, 0x62, 0xfe, 0x09, 0xc5, 0xf5, 0x1b, 0x13,
@@ -394,7 +393,7 @@ func TestScripts(t *testing.T) {
 			0x8a, 0x06, 0x26, 0xf1, 0xba, 0xde, 0xd5, 0xc7, 0x2a, 0x70,
 			0x4f, 0x7e, 0x6c, 0xd8, 0x4c,
 			txscript.OP_1, txscript.OP_CHECKMULTISIG},
-			canonical:  true,
+			strictSigs: true,
 			shouldPass: false},
 		/* up here because no defined error case. */
 		{script: []byte{txscript.OP_1, txscript.OP_1, txscript.OP_DATA_65,
@@ -504,8 +503,8 @@ func TestScripts(t *testing.T) {
 	for i, test := range tests {
 		// Parse and execute the test script.
 		var flags txscript.ScriptFlags
-		if test.canonical {
-			flags = txscript.ScriptCanonicalSignatures
+		if test.strictSigs {
+			flags = txscript.ScriptVerifyDERSignatures
 		}
 		mockTx.TxOut[0].PkScript = test.script
 		sigScript := mockTx.TxIn[0].SignatureScript

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -210,7 +210,6 @@ type Script struct {
 	condStack                []int
 	numOps                   int
 	bip16                    bool     // treat execution as pay-to-script-hash
-	der                      bool     // enforce DER encoding
 	strictMultiSig           bool     // verify multisig stack item is zero length
 	discourageUpgradableNops bool     // NOP1 to NOP10 are reserved for future soft-fork upgrades
 	verifyStrictEncoding     bool     // verify strict encoding of signatures
@@ -623,20 +622,6 @@ const (
 	// pay-to-script hash transactions will be fully validated.
 	ScriptBip16 ScriptFlags = 1 << iota
 
-	// ScriptCanonicalSignatures defines whether additional canonical
-	// signature checks are performed when parsing a signature.
-	//
-	// Canonical (DER) signatures are not required in the tx rules for
-	// block acceptance, but are checked in recent versions of bitcoind
-	// when accepting transactions to the mempool.  Non-canonical (valid
-	// BER but not valid DER) transactions can potentially be changed
-	// before mined into a block, either by adding extra padding or
-	// flipping the sign of the R or S value in the signature, creating a
-	// transaction that still validates and spends the inputs, but is not
-	// recognized by creator of the transaction.  Performing a canonical
-	// check enforces script signatures use a unique DER format.
-	ScriptCanonicalSignatures
-
 	// ScriptStrictMultiSig defines whether to verify the stack item
 	// used by CHECKMULTISIG is zero length.
 	ScriptStrictMultiSig
@@ -702,9 +687,6 @@ func NewScript(scriptSig []byte, scriptPubKey []byte, txidx int, tx *wire.MsgTx,
 			return nil, ErrStackP2SHNonPushOnly
 		}
 		m.bip16 = true
-	}
-	if flags&ScriptCanonicalSignatures == ScriptCanonicalSignatures {
-		m.der = true
 	}
 	if flags&ScriptStrictMultiSig == ScriptStrictMultiSig {
 		m.strictMultiSig = true

--- a/txscript/script_test.go
+++ b/txscript/script_test.go
@@ -136,7 +136,7 @@ type txTest struct {
 	pkScript      []byte              // output script of previous tx
 	idx           int                 // tx idx to be run.
 	bip16         bool                // is bip16 active?
-	canonicalSigs bool                // should signatures be validated as canonical?
+	strictSigs    bool                // should signatures be validated as strict?
 	parseErr      error               // failure of NewScript
 	err           error               // Failure of Executre
 	shouldFail    bool                // Execute should fail with nonspecified error.
@@ -843,10 +843,10 @@ var txTests = []txTest{
 			txscript.OP_EQUALVERIFY,
 			txscript.OP_CHECKSIG,
 		},
-		idx:           0,
-		canonicalSigs: true,
-		shouldFail:    true,
-		nSigOps:       1,
+		idx:        0,
+		strictSigs: true,
+		shouldFail: true,
+		nSigOps:    1,
 		scriptInfo: txscript.ScriptInfo{
 			PkScriptClass:  txscript.PubKeyHashTy,
 			NumInputs:      2,
@@ -1619,8 +1619,8 @@ func testTx(t *testing.T, test txTest) {
 	if test.bip16 {
 		flags |= txscript.ScriptBip16
 	}
-	if test.canonicalSigs {
-		flags |= txscript.ScriptCanonicalSignatures
+	if test.strictSigs {
+		flags |= txscript.ScriptVerifyDERSignatures
 	}
 	engine, err := txscript.NewScript(
 		test.tx.TxIn[test.idx].SignatureScript, test.pkScript,
@@ -2867,7 +2867,7 @@ nexttest:
 		}
 
 		// Validate tx input scripts
-		scriptFlags := txscript.ScriptBip16 | txscript.ScriptCanonicalSignatures
+		scriptFlags := txscript.ScriptBip16 | txscript.ScriptVerifyDERSignatures
 		for j, txin := range tx.TxIn {
 			engine, err := txscript.NewScript(txin.SignatureScript,
 				SigScriptTests[i].inputs[j].txout.PkScript,
@@ -3297,7 +3297,7 @@ func checkScripts(msg string, tx *wire.MsgTx, idx int,
 	sigScript, pkScript []byte) error {
 	engine, err := txscript.NewScript(sigScript, pkScript, idx, tx,
 		txscript.ScriptBip16|
-			txscript.ScriptCanonicalSignatures)
+			txscript.ScriptVerifyDERSignatures)
 	if err != nil {
 		return fmt.Errorf("failed to make script engine for %s: %v",
 			msg, err)


### PR DESCRIPTION
Remove ScriptCanonicalSignatures and use the new
ScriptVerifyDERSignatures flag.  The ScriptVerifyDERSignatures
flag accomplishes the same functionality.