### PR TITLE
Reject free/low-fee transactions with insufficient priority.

### DIFF
--- a/config.go
+++ b/config.go
@@ -103,6 +103,7 @@ type config struct {
 	DebugLevel         string        `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 	Upnp               bool          `long:"upnp" description:"Use UPnP to map our listening port outside of NAT"`
 	FreeTxRelayLimit   float64       `long:"limitfreerelay" description:"Limit relay of transactions with no transaction fee to the given amount in thousands of bytes per minute"`
+	NoRelayPriority    bool          `long:"norelaypriority" description:"Do not require free or low-fee transactions to have high priority for relaying"`
 	Generate           bool          `long:"generate" description:"Generate (mine) bitcoins using the CPU"`
 	MiningAddrs        []string      `long:"miningaddr" description:"Add the specified payment address to the list of addresses to use for generated blocks -- At least one address is required if the generate option is set"`
 	BlockMinSize       uint32        `long:"blockminsize" description:"Mininum block size in bytes to be used when creating a block"`


### PR DESCRIPTION
By default, have the mempool reject free and low-fee transactions that
have insufficient priority to be mined in the next block.

Addtionally, add a new configuration option, -norelaypriority, to
disable the check.