### PR TITLE
Add new option --nobloom.

### DIFF
--- a/config.go
+++ b/config.go
@@ -112,6 +112,7 @@ type config struct {
 	BlockMaxSize       uint32        `long:"blockmaxsize" description:"Maximum block size in bytes to be used when creating a block"`
 	BlockPrioritySize  uint32        `long:"blockprioritysize" description:"Size in bytes for high-priority/low-fee transactions when creating a block"`
 	GetWorkKeys        []string      `long:"getworkkey" description:"DEPRECATED -- Use the --miningaddr option instead"`
+	NoBloom            bool          `long:"nobloom" description:"Disable bloom filtering (BIP0037) support"`
 	AddrIndex          bool          `long:"addrindex" description:"Build and maintain a full address index. Currently only supported by leveldb."`
 	DropAddrIndex      bool          `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up, and the exits."`
 	onionlookup        func(string) ([]net.IP, error)

--- a/doc.go
+++ b/doc.go
@@ -93,6 +93,7 @@ Application Options:
       --blockprioritysize= Size in bytes for high-priority/low-fee transactions
                            when creating a block (50000)
       --getworkkey=        DEPRECATED -- Use the --miningaddr option instead
+      --nobloom=           Disable bloom filtering (BIP0037) support
       --addrindex=         Build and maintain a full address index. Currently
                            only supported by leveldb.
       --dropaddrindex=     Deletes the address-based transaction index from the

--- a/sample-btcd.conf
+++ b/sample-btcd.conf
@@ -54,6 +54,7 @@
 ; externalip=1.2.3.4
 ; externalip=2002::1234
 
+
 ; ******************************************************************************
 ; Summary of 'addpeer' versus 'connect'.
 ;
@@ -139,6 +140,12 @@
 ; Disable listening for incoming connections.  This will override all listeners.
 ; nolisten=1
 
+; Disable bloom filtering (BIP0037) support.  Bloom filtering is very CPU
+; intensive, so you may want to trade lower CPU utilization for higher
+; bandwidth usage.  However, this will also raise both CPU utilization and
+; bandwidth usage for SPV clients.
+; nobloom=1
+
 
 ; ------------------------------------------------------------------------------
 ; RPC server options - The following options control the built-in RPC server
@@ -203,6 +210,7 @@
 ; the default).
 ; notls=1
 
+
 ; ------------------------------------------------------------------------------
 ; Optional Transaction Indexes
 ; ------------------------------------------------------------------------------
@@ -211,6 +219,7 @@
 ; addrindex=1
 ; Delete the entire address index on start up, then exit.
 ; dropaddrindex=0
+
 
 ; ------------------------------------------------------------------------------
 ; Coin Generation (Mining) Settings - The following options control the


### PR DESCRIPTION
Add a new configuration option --nobloom that disables bloom
filtering (BIP0037) support.  Bloom filtering is very CPU
intensive, so a user might wish to specify this option to lower
CPU utilization at the cost of increased bandwidth usage.  However,
this option also increases both CPU utilization and bandwidth usage
for SPV clients.

refs #172