### PR TITLE
mempool: Loosen restrictions for resurrected txns.

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1162,7 +1162,7 @@ func (b *blockManager) handleNotifyMsg(notification *blockchain.Notification) {
 		// the transaction pool.
 		for _, tx := range block.Transactions()[1:] {
 			_, err := b.server.txMemPool.MaybeAcceptTransaction(tx,
-				false, true)
+				false, false)
 			if err != nil {
 				// Remove the transaction and all transactions
 				// that depend on it if it wasn't accepted into

--- a/mempool.go
+++ b/mempool.go
@@ -1180,8 +1180,10 @@ func (mp *txMemPool) maybeAcceptTransaction(tx *btcutil.Tx, isNew, rateLimit boo
 	}
 
 	// Require that free transactions have sufficient priority to be mined
-	// in the next block.
-	if !cfg.NoRelayPriority && txFee < minFee {
+	// in the next block.  Transactions which are being added back to the
+	// memory pool from blocks that have been disconnected during a reorg
+	// are exempted.
+	if isNew && !cfg.NoRelayPriority && txFee < minFee {
 		txD := &TxDesc{
 			Tx:     tx,
 			Added:  time.Now(),


### PR DESCRIPTION
This modifies the recently added code which rejects free/low-fee transactions with insufficient priority to ignore resurrected transactions from disconnected blocks.  It also exempts resurrected transactions from the free/low-fee rate limiting.