### PR TITLE
Use ScriptVerifyMinimalData

### DIFF
--- a/mempool.go
+++ b/mempool.go
@@ -274,16 +274,6 @@ func checkTransactionStandard(tx *btcutil.Tx, height int64) error {
 				"script is not push only", i)
 			return txRuleError(wire.RejectNonstandard, str)
 		}
-
-		// Each transaction input signature script must only contain
-		// canonical data pushes.  A canonical data push is one where
-		// the minimum possible number of bytes is used to represent
-		// the data push as possible.
-		if !txscript.HasCanonicalPushes(txIn.SignatureScript) {
-			str := fmt.Sprintf("transaction input %d: signature "+
-				"script has a non-canonical data push", i)
-			return txRuleError(wire.RejectNonstandard, str)
-		}
 	}
 
 	// None of the output public key scripts can be a non-standard script or

--- a/mining.go
+++ b/mining.go
@@ -48,6 +48,7 @@ const (
 	// are more strict.
 	standardScriptVerifyFlags = txscript.ScriptBip16 |
 		txscript.ScriptVerifyDERSignatures |
+		txscript.ScriptVerifyMinimalData |
 		txscript.ScriptStrictMultiSig |
 		txscript.ScriptDiscourageUpgradableNops
 )

--- a/txscript/internal_test.go
+++ b/txscript/internal_test.go
@@ -22,6 +22,14 @@ import (
 // test package.
 const TstMaxScriptSize = maxScriptSize
 
+// TstHasCanoncialPushes makes the internal isCanonicalPush function available
+// to the test package.
+var TstHasCanonicalPushes = canonicalPush
+
+// TstParseScript makes the internal parseScript function available to the
+// test package.
+var TstParseScript = parseScript
+
 // this file is present to export some internal interfaces so that we can
 // test them reliably.
 

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -484,26 +484,6 @@ func canonicalPush(pop parsedOpcode) bool {
 	return true
 }
 
-// HasCanonicalPushes returns whether or not the passed script only contains
-// canonical data pushes.  A canonical data push one where the fewest number of
-// bytes possible to encode the size of the data being pushed is used.  This
-// includes using the small integer opcodes for single byte data that can be
-// represented directly.
-func HasCanonicalPushes(script []byte) bool {
-	pops, err := parseScript(script)
-	if err != nil {
-		return false
-	}
-
-	for _, pop := range pops {
-		if !canonicalPush(pop) {
-			return false
-		}
-	}
-
-	return true
-}
-
 // GetScriptClass returns the class of the script passed. If the script does not
 // parse then NonStandardTy will be returned.
 func GetScriptClass(script []byte) ScriptClass {

--- a/txscript/script_test.go
+++ b/txscript/script_test.go
@@ -106,9 +106,16 @@ func TestStandardPushes(t *testing.T) {
 			t.Errorf("StandardPushesTests IsPushOnlyScript test #%d failed: %x\n", i, script)
 			continue
 		}
-		if result := txscript.HasCanonicalPushes(script); !result {
-			t.Errorf("StandardPushesTests HasCanonicalPushes test #%d failed: %x\n", i, script)
+		pops, err := txscript.TstParseScript(script)
+		if err != nil {
+			t.Errorf("StandardPushesTests #%d failed to TstParseScript: %v", i, err)
 			continue
+		}
+		for _, pop := range pops {
+			if result := txscript.TstHasCanonicalPushes(pop); !result {
+				t.Errorf("StandardPushesTests TstHasCanonicalPushes test #%d failed: %x\n", i, script)
+				break
+			}
 		}
 	}
 	for i := 0; i <= txscript.MaxScriptElementSize; i++ {
@@ -123,9 +130,16 @@ func TestStandardPushes(t *testing.T) {
 			t.Errorf("StandardPushesTests IsPushOnlyScript test #%d failed: %x\n", i, script)
 			continue
 		}
-		if result := txscript.HasCanonicalPushes(script); !result {
-			t.Errorf("StandardPushesTests HasCanonicalPushes test #%d failed: %x\n", i, script)
+		pops, err := txscript.TstParseScript(script)
+		if err != nil {
+			t.Errorf("StandardPushesTests #%d failed to TstParseScript: %v", i, err)
 			continue
+		}
+		for _, pop := range pops {
+			if result := txscript.TstHasCanonicalPushes(pop); !result {
+				t.Errorf("StandardPushesTests TstHasCanonicalPushes test #%d failed: %x\n", i, script)
+				break
+			}
 		}
 	}
 }
@@ -4750,10 +4764,20 @@ func TestHasCanonicalPushes(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		if txscript.HasCanonicalPushes(test.script) != test.expected {
-			t.Errorf("HasCanonicalPushes #%d (%s) wrong result\n"+
-				"got: %v\nwant: %v", i, test.name, true,
-				test.expected)
+		pops, err := txscript.TstParseScript(test.script)
+		if err != nil {
+			if test.expected {
+				t.Errorf("StandardPushesTests #%d failed to TstParseScript: %v", i, err)
+			}
+			continue
+		}
+		for _, pop := range pops {
+			if txscript.TstHasCanonicalPushes(pop) != test.expected {
+				t.Errorf("TstHasCanonicalPushes #%d (%s) wrong result\n"+
+					"got: %v\nwant: %v", i, test.name, true,
+					test.expected)
+				break
+			}
 		}
 	}
 }


### PR DESCRIPTION
Additionally, drop HasCanoncialPushes as ScriptVerifyMinimalData
offers more complete checks.