### PR TITLE
txscript: export StandardVerifyFlags

### DIFF
--- a/mempool.go
+++ b/mempool.go
@@ -1216,7 +1216,7 @@ func (mp *txMemPool) maybeAcceptTransaction(tx *btcutil.Tx, isNew, rateLimit boo
 	// Verify crypto signatures for each input and reject the transaction if
 	// any don't verify.
 	err = blockchain.ValidateTransactionScripts(tx, txStore,
-		standardScriptVerifyFlags)
+		txscript.StandardVerifyFlags)
 	if err != nil {
 		if cerr, ok := err.(blockchain.RuleError); ok {
 			return nil, chainRuleError(cerr)

--- a/mining.go
+++ b/mining.go
@@ -38,20 +38,6 @@ const (
 	// and is used to monitor BIP16 support as well as blocks that are
 	// generated via btcd.
 	coinbaseFlags = "/P2SH/btcd/"
-
-	// standardScriptVerifyFlags are the script flags which are used when
-	// executing transaction scripts to enforce additional checks which
-	// are required for the script to be considered standard.  These checks
-	// help reduce issues related to transaction malleability as well as
-	// allow pay-to-script hash transactions.  Note these flags are
-	// different than what is required for the consensus rules in that they
-	// are more strict.
-	standardScriptVerifyFlags = txscript.ScriptBip16 |
-		txscript.ScriptVerifyDERSignatures |
-		txscript.ScriptVerifyStrictEncoding |
-		txscript.ScriptVerifyMinimalData |
-		txscript.ScriptStrictMultiSig |
-		txscript.ScriptDiscourageUpgradableNops
 )
 
 // txPrioItem houses a transaction along with extra information that allows the
@@ -667,7 +653,7 @@ mempoolLoop:
 			continue
 		}
 		err = blockchain.ValidateTransactionScripts(tx, blockTxStore,
-			standardScriptVerifyFlags)
+			txscript.StandardVerifyFlags)
 		if err != nil {
 			minrLog.Tracef("Skipping tx %s due to error in "+
 				"ValidateTransactionScripts: %v", tx.Sha(), err)

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -634,6 +634,23 @@ const (
 	// ScriptVerifyStrictEncoding defines that signature scripts and
 	// public keys must follow the strict encoding requirements.
 	ScriptVerifyStrictEncoding
+
+	// StandardVerifyFlags are the script flags which are used when
+	// executing transaction scripts to enforce additional checks which
+	// are required for the script to be considered standard.  These checks
+	// help reduce issues related to transaction malleability as well as
+	// allow pay-to-script hash transactions.  Note these flags are
+	// different than what is required for the consensus rules in that they
+	// are more strict.
+	//
+	// TODO: These flags do not belong here.  These flags belong in a
+	// policy package.
+	StandardVerifyFlags = ScriptBip16 |
+		ScriptVerifyDERSignatures |
+		ScriptVerifyStrictEncoding |
+		ScriptVerifyMinimalData |
+		ScriptStrictMultiSig |
+		ScriptDiscourageUpgradableNops
 )
 
 // NewScript returns a new script engine for the provided tx and input idx with


### PR DESCRIPTION
By exporting StandardVerifyFlags, clients can ensure they create
transactions that btcd will accept into its mempool.

This flag doesn't belong in txscript.  It belongs in a
policy package.  However, this is currently the least worse place.