### PR TITLE
btcjson: Fix a bug in btcjson v2

### DIFF
--- a/btcjson/v2/btcjson/chainsvrwsntfns.go
+++ b/btcjson/v2/btcjson/chainsvrwsntfns.go
@@ -87,12 +87,12 @@ type BlockDetails struct {
 // RecvTxNtfn defines the recvtx JSON-RPC notification.
 type RecvTxNtfn struct {
 	HexTx string
-	Block BlockDetails
+	Block *BlockDetails
 }
 
 // NewRecvTxNtfn returns a new instance which can be used to issue a recvtx
 // JSON-RPC notification.
-func NewRecvTxNtfn(hexTx string, block BlockDetails) *RecvTxNtfn {
+func NewRecvTxNtfn(hexTx string, block *BlockDetails) *RecvTxNtfn {
 	return &RecvTxNtfn{
 		HexTx: hexTx,
 		Block: block,
@@ -102,12 +102,12 @@ func NewRecvTxNtfn(hexTx string, block BlockDetails) *RecvTxNtfn {
 // RedeemingTxNtfn defines the redeemingtx JSON-RPC notification.
 type RedeemingTxNtfn struct {
 	HexTx string
-	Block BlockDetails
+	Block *BlockDetails
 }
 
 // NewRedeemingTxNtfn returns a new instance which can be used to issue a
 // redeemingtx JSON-RPC notification.
-func NewRedeemingTxNtfn(hexTx string, block BlockDetails) *RedeemingTxNtfn {
+func NewRedeemingTxNtfn(hexTx string, block *BlockDetails) *RedeemingTxNtfn {
 	return &RedeemingTxNtfn{
 		HexTx: hexTx,
 		Block: block,

--- a/btcjson/v2/btcjson/chainsvrwsntfns_test.go
+++ b/btcjson/v2/btcjson/chainsvrwsntfns_test.go
@@ -68,12 +68,12 @@ func TestChainSvrWsNtfns(t *testing.T) {
 					Index:  0,
 					Time:   12345678,
 				}
-				return btcjson.NewRecvTxNtfn("001122", blockDetails)
+				return btcjson.NewRecvTxNtfn("001122", &blockDetails)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"recvtx","params":["001122",{"height":100000,"hash":"123","index":0,"time":12345678}],"id":null}`,
 			unmarshalled: &btcjson.RecvTxNtfn{
 				HexTx: "001122",
-				Block: btcjson.BlockDetails{
+				Block: &btcjson.BlockDetails{
 					Height: 100000,
 					Hash:   "123",
 					Index:  0,
@@ -93,12 +93,12 @@ func TestChainSvrWsNtfns(t *testing.T) {
 					Index:  0,
 					Time:   12345678,
 				}
-				return btcjson.NewRedeemingTxNtfn("001122", blockDetails)
+				return btcjson.NewRedeemingTxNtfn("001122", &blockDetails)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"redeemingtx","params":["001122",{"height":100000,"hash":"123","index":0,"time":12345678}],"id":null}`,
 			unmarshalled: &btcjson.RedeemingTxNtfn{
 				HexTx: "001122",
-				Block: btcjson.BlockDetails{
+				Block: &btcjson.BlockDetails{
 					Height: 100000,
 					Hash:   "123",
 					Index:  0,

--- a/rpcwebsocket.go
+++ b/rpcwebsocket.go
@@ -614,7 +614,7 @@ func blockDetails(block *btcutil.Block, txIndex int) *btcjson.BlockDetails {
 // with the passed parameters.
 func newRedeemingTxNotification(txHex string, index int, block *btcutil.Block) ([]byte, error) {
 	// Create and marshal the notification.
-	ntfn := btcjson.NewRedeemingTxNtfn(txHex, *blockDetails(block, index))
+	ntfn := btcjson.NewRedeemingTxNtfn(txHex, blockDetails(block, index))
 	return btcjson.MarshalCmd(nil, ntfn)
 }
 
@@ -648,7 +648,7 @@ func (m *wsNotificationManager) notifyForTxOuts(ops map[wire.OutPoint]map[chan s
 			if txHex == "" {
 				txHex = txHexString(tx)
 			}
-			ntfn := btcjson.NewRecvTxNtfn(txHex, *blockDetails(block,
+			ntfn := btcjson.NewRecvTxNtfn(txHex, blockDetails(block,
 				tx.Index()))
 
 			marshalledJSON, err := btcjson.MarshalCmd(nil, ntfn)
@@ -1639,7 +1639,7 @@ func rescanBlock(wsc *wsClient, lookups *rescanKeys, blk *btcutil.Block) {
 					txHex = txHexString(tx)
 				}
 				ntfn := btcjson.NewRecvTxNtfn(txHex,
-					*blockDetails(blk, tx.Index()))
+					blockDetails(blk, tx.Index()))
 
 				marshalledJSON, err := btcjson.MarshalCmd(nil, ntfn)
 				if err != nil {


### PR DESCRIPTION
btcjson v2 switched an optional field to mandatory which resulted
in a nil deference.  This switches it back to optional.