### PR TITLE
Add new 'dropnode' RPC command

### DIFF
--- a/btcjson/v2/btcjson/btcdextcmds.go
+++ b/btcjson/v2/btcjson/btcdextcmds.go
@@ -13,6 +13,17 @@ type DebugLevelCmd struct {
 	LevelSpec string
 }
 
+// DropNodeCmd defines the dropnode JSON-RPC command.
+type DropNodeCmd struct {
+	Addr string
+}
+
+// NewDropNodeCmd returns a new instance which can be used to issue a dropnode
+// JSON-RPC command.
+func NewDropNodeCmd(addr string) *DropNodeCmd {
+	return &DropNodeCmd{Addr: addr}
+}
+
 // NewDebugLevelCmd returns a new DebugLevelCmd which can be used to issue a
 // debuglevel JSON-RPC command.  This command is not a standard Bitcoin command.
 // It is an extension for btcd.
@@ -45,6 +56,7 @@ func init() {
 	flags := UsageFlag(0)
 
 	MustRegisterCmd("debuglevel", (*DebugLevelCmd)(nil), flags)
+	MustRegisterCmd("dropnode", (*DropNodeCmd)(nil), flags)
 	MustRegisterCmd("getbestblock", (*GetBestBlockCmd)(nil), flags)
 	MustRegisterCmd("getcurrentnet", (*GetCurrentNetCmd)(nil), flags)
 }

--- a/btcjson/v2/btcjson/btcdextcmds_test.go
+++ b/btcjson/v2/btcjson/btcdextcmds_test.go
@@ -43,6 +43,19 @@ func TestBtcdExtCmds(t *testing.T) {
 			},
 		},
 		{
+			name: "dropnode",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("dropnode", "1.1.1.1")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewDropNodeCmd("1.1.1.1")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"dropnode","params":["1.1.1.1"],"id":1}`,
+			unmarshalled: &btcjson.DropNodeCmd{
+				Addr: "1.1.1.1",
+			},
+		},
+		{
 			name: "getbestblock",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("getbestblock")

--- a/docs/json_rpc_api.md
+++ b/docs/json_rpc_api.md
@@ -183,7 +183,7 @@ the method name for further details such as parameter and return information.
 |   |   |
 |---|---|
 |Method|addnode|
-|Parameters|1. peer (string, required) - ip address and port of the peer tooperate on<br />2. command (string, required) - `add` to add a persistent peer, `remove` to remove a persistent peer, or `onetry` to try a single connection to a peer|
+|Parameters|1. peer (string, required) - ip address and port of the peer to operate on<br />2. command (string, required) - `add` to add a persistent peer, `remove` to remove a persistent peer, or `onetry` to try a single connection to a peer|
 |Description|Attempts to add or remove a persistent peer.|
 |Returns|Nothing|
 [Return to Overview](#MethodOverview)<br />
@@ -550,6 +550,7 @@ The following is an overview of the RPC methods which are implemented by btcd, b
 |2|[getbestblock](#getbestblock)|Get block height and hash of best block in the main chain.|None|
 |3|[getcurrentnet](#getcurrentnet)|Get bitcoin network btcd is running on.|None|
 |4|[searchrawtransactions](#searchrawtransactions)|Query for transactions related to a particular address.|None|
+|5|[dropnode](#dropnode)|Attempts to remove a non-persistent peer.|None|
 
 <a name="ExtMethodDetails" />
 **6.2 Method Details**<br />
@@ -603,6 +604,18 @@ The following is an overview of the RPC methods which are implemented by btcd, b
 |Returns (verbose=0)|`[ (json array of strings)` <br/>&nbsp;&nbsp; `"serializedtx", ... hex-encoded bytes of the serialized transaction` <br/>`]` |
 |Returns (verbose=1)|`[ (array of json objects)` <br/> &nbsp;&nbsp; `{ (json object)`<br />&nbsp;&nbsp;`"hex": "data",  (string) hex-encoded transaction`<br />&nbsp;&nbsp;`"txid": "hash",  (string) the hash of the transaction`<br />&nbsp;&nbsp;`"version": n,  (numeric) the transaction version`<br />&nbsp;&nbsp;`"locktime": n,  (numeric) the transaction lock time`<br />&nbsp;&nbsp;`"vin": [  (array of json objects) the transaction inputs as json objects`<br />&nbsp;&nbsp;<font color="orange">For coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"coinbase": "data",  (string) the hex-dencoded bytes of the signature script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": n,  (numeric) the script sequence number`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;<font color="orange">For non-coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"txid": "hash", (string) the hash of the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"vout": n, (numeric) the index of the output being redeemed from the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptSig": { (json object) the signature script used to redeem the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "asm", (string) disassembly of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "data",  (string) hex-encoded bytes of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": n,  (numeric) the script sequence number`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}, ...`<br />&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`"vout": [  (array of json objects) the transaction outputs as json objects`<br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"value": n, (numeric) the value in BTC`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"n": n, (numeric) the index of this transaction output`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptPubKey": { (json object) the public key script used to pay coins`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "asm",  (string) disassembly of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "data", (string) hex-encoded bytes of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"reqSigs": n,  (numeric) the number of required signatures`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"type": "scripttype" (string) the type of the script (e.g. 'pubkeyhash')`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"addresses": [ (json array of string) the bitcoin addresses associated with this output`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"address",  (string) the bitcoin address`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`...`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}, ...`<br /> &nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp; `"blockhash":"hash" Hash of the block the transaction is part of.` <br /> &nbsp;&nbsp; `"confirmations":n,  Number of numeric confirmations of block.` <br /> &nbsp;&nbsp;&nbsp;`"time":t, Transaction time in seconds since the epoch.` <br /> &nbsp;&nbsp;&nbsp;`"blocktime":t, Block time in seconds since the epoch.`<br />`},...`<br/> `]`|
 [Return to Overview](#ExtMethodOverview)<br />
+
+***
+
+<a name="dropnode"/>
+
+|   |   |
+|---|---|
+|Method|dropnode|
+|Parameters|1. peer (string, required) - ip address and port of the peer to operate on|
+|Description|Attempts to remove a non-persistent peer.|
+|Returns|Nothing|
+[Return to Overview](#MethodOverview)<br />
 
 ***
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -129,6 +129,7 @@ type commandHandler func(*rpcServer, interface{}, <-chan struct{}) (interface{},
 var rpcHandlers map[string]commandHandler
 var rpcHandlersBeforeInit = map[string]commandHandler{
 	"addnode":               handleAddNode,
+	"dropnode":              handleDropNode,
 	"createrawtransaction":  handleCreateRawTransaction,
 	"debuglevel":            handleDebugLevel,
 	"decoderawtransaction":  handleDecodeRawTransaction,
@@ -338,6 +339,22 @@ func handleAddNode(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (in
 
 	if err != nil {
 		return nil, internalRPCError(err.Error(), "")
+	}
+	// no data returned unless an error.
+	return nil, nil
+}
+
+// handleDropNode handles dropnode commands.
+func handleDropNode(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
+	c := cmd.(*btcjson.DropNodeCmd)
+
+	addr := normalizeAddress(c.Addr, activeNetParams.DefaultPort)
+
+	if err := s.server.DropAddr(addr); err != nil {
+		return nil, btcjson.RPCError{
+			Code:    btcjson.ErrRPCInternal.Code,
+			Message: err.Error(),
+		}
 	}
 
 	// no data returned unless an error.

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -33,6 +33,10 @@ var helpDescsEnUS = map[string]string{
 	"addnode-addr":      "IP address and port of the peer to operate on",
 	"addnode-subcmd":    "'add' to add a persistent peer, 'remove' to remove a persistent peer, or 'onetry' to try a single connection to a peer",
 
+	// DropNodeCmd help.
+	"dropnode--synopsis": "Attempts to remove a peer.",
+	"dropnode-addr":      "IP address and port of the peer to operate on",
+
 	// TransactionInput help.
 	"transactioninput-txid": "The hash of the input transaction",
 	"transactioninput-vout": "The specific output of the input transaction to redeem",
@@ -494,6 +498,7 @@ var helpDescsEnUS = map[string]string{
 // pointer to the type (or nil to indicate no return value).
 var rpcResultTypes = map[string][]interface{}{
 	"addnode":               nil,
+	"dropnode":              nil,
 	"createrawtransaction":  []interface{}{(*string)(nil)},
 	"debuglevel":            []interface{}{(*string)(nil), (*string)(nil)},
 	"decoderawtransaction":  []interface{}{(*btcjson.TxRawDecodeResult)(nil)},

--- a/server.go
+++ b/server.go
@@ -371,6 +371,11 @@ type delNodeMsg struct {
 	reply chan error
 }
 
+type dropNodeMsg struct {
+	addr  string
+	reply chan error
+}
+
 type getAddedNodesMsg struct {
 	reply chan []*peer
 }
@@ -447,27 +452,39 @@ func (s *server) handleQuery(querymsg interface{}, state *peerState) {
 		}
 
 	case delNodeMsg:
-		found := false
-		for e := state.persistentPeers.Front(); e != nil; e = e.Next() {
-			peer := e.Value.(*peer)
-			if peer.addr == msg.addr {
-				// Keep group counts ok since we remove from
-				// the list now.
-				state.outboundGroups[addrmgr.GroupKey(peer.na)]--
-				// This is ok because we are not continuing
-				// to iterate so won't corrupt the loop.
-				state.persistentPeers.Remove(e)
-				peer.Disconnect()
-				found = true
-				break
-			}
-		}
+		found := disconnectPeer(state.persistentPeers, msg.addr, func(p *peer) {
+			// Keep group counts ok since we remove from
+			// the list now.
+			state.outboundGroups[addrmgr.GroupKey(p.na)]--
+		})
 
 		if found {
 			msg.reply <- nil
 		} else {
 			msg.reply <- errors.New("peer not found")
 		}
+
+	case dropNodeMsg:
+		// Check inbound peers. We pass an empty callback since we don't
+		// require any additional actions on disconnect for inbound peers.
+		found := disconnectPeer(state.peers, msg.addr, func(p *peer) {})
+		if found {
+			msg.reply <- nil
+			return
+		}
+
+		// Check outbound peers.
+		found = disconnectPeer(state.outboundPeers, msg.addr, func(p *peer) {
+			// Keep group counts ok since we remove from
+			// the list now.
+			state.outboundGroups[addrmgr.GroupKey(p.na)]--
+		})
+		if found {
+			msg.reply <- nil
+			return
+		}
+
+		msg.reply <- errors.New("peer not found")
 
 	// Request a list of the persistent (added) peers.
 	case getAddedNodesMsg:
@@ -479,6 +496,26 @@ func (s *server) handleQuery(querymsg interface{}, state *peerState) {
 		}
 		msg.reply <- peers
 	}
+}
+
+// disconnectPeer attempts to drop the connection of a tageted peer in the
+// passed peer list. This function returns true on success and false if the
+// peer is unable to be located. If the peer is found, the passed callback
+// function `whenFound' called with the peer as the argument before it is
+// removed from the peerList and is disconnected from the server
+func disconnectPeer(peerList *list.List, targetAddr string, whenFound func(*peer)) bool {
+	for e := peerList.Front(); e != nil; e = e.Next() {
+		peer := e.Value.(*peer)
+		if peer.addr == targetAddr {
+			// This is ok because we are not continuing
+			// to iterate so won't corrupt the loop.
+			whenFound(peer)
+			peerList.Remove(e)
+			peer.Disconnect()
+			return true
+		}
+	}
+	return false
 }
 
 // listenHandler is the main listener which accepts incoming connections for the
@@ -785,6 +822,16 @@ func (s *server) RemoveAddr(addr string) error {
 	replyChan := make(chan error)
 
 	s.query <- delNodeMsg{addr: addr, reply: replyChan}
+
+	return <-replyChan
+}
+
+// DropAddr removes `addr` from the list of all peers if present.
+// An error will be returned if the peer was not found.
+func (s *server) DropAddr(addr string) error {
+	replyChan := make(chan error)
+
+	s.query <- dropNodeMsg{addr: addr, reply: replyChan}
 
 	return <-replyChan
 }


### PR DESCRIPTION
This PR adds new JSON-RPC command: `dropnode`. 

This aims to fix #79 by adding a new command that can disconnect any (inbound or outbound) non-persistent peer. 