### PR TITLE
Add new 'node' RPC command

### DIFF
--- a/btcjson/v2/btcjson/btcdextcmds.go
+++ b/btcjson/v2/btcjson/btcdextcmds.go
@@ -7,6 +7,42 @@
 
 package btcjson
 
+// NodeSubCmd defines the type used in the addnode JSON-RPC command for the
+// sub command field.
+type NodeSubCmd string
+
+const (
+	// NConnect indicates the specified host that should be connected to.
+	NConnect NodeSubCmd = "connect"
+
+	// NRemove indicates the specified peer that should be removed as a
+	// persistent peer.
+	NRemove NodeSubCmd = "remove"
+
+	// NDisconnect indicates the specified peer should be disonnected.
+	NDisconnect NodeSubCmd = "disconnect"
+)
+
+// NodeCmd defines the dropnode JSON-RPC command.
+type NodeCmd struct {
+	SubCmd        NodeSubCmd `jsonrpcusage:"\"connect|remove|disconnect\""`
+	Target        string
+	ConnectSubCmd *string `jsonrpcusage:"\"perm|temp\""`
+}
+
+// NewNodeCmd returns a new instance which can be used to issue a `node`
+// JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewNodeCmd(subCmd NodeSubCmd, target string, connectSubCmd *string) *NodeCmd {
+	return &NodeCmd{
+		SubCmd:        subCmd,
+		Target:        target,
+		ConnectSubCmd: connectSubCmd,
+	}
+}
+
 // DebugLevelCmd defines the debuglevel JSON-RPC command.  This command is not a
 // standard Bitcoin command.  It is an extension for btcd.
 type DebugLevelCmd struct {
@@ -45,6 +81,7 @@ func init() {
 	flags := UsageFlag(0)
 
 	MustRegisterCmd("debuglevel", (*DebugLevelCmd)(nil), flags)
+	MustRegisterCmd("node", (*NodeCmd)(nil), flags)
 	MustRegisterCmd("getbestblock", (*GetBestBlockCmd)(nil), flags)
 	MustRegisterCmd("getcurrentnet", (*GetCurrentNetCmd)(nil), flags)
 }

--- a/btcjson/v2/btcjson/btcdextcmds_test.go
+++ b/btcjson/v2/btcjson/btcdextcmds_test.go
@@ -43,6 +43,64 @@ func TestBtcdExtCmds(t *testing.T) {
 			},
 		},
 		{
+			name: "node",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("node", btcjson.NRemove, "1.1.1.1")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewNodeCmd("remove", "1.1.1.1", nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"node","params":["remove","1.1.1.1"],"id":1}`,
+			unmarshalled: &btcjson.NodeCmd{
+				SubCmd: btcjson.NRemove,
+				Target: "1.1.1.1",
+			},
+		},
+		{
+			name: "node",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("node", btcjson.NDisconnect, "1.1.1.1")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewNodeCmd("disconnect", "1.1.1.1", nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"node","params":["disconnect","1.1.1.1"],"id":1}`,
+			unmarshalled: &btcjson.NodeCmd{
+				SubCmd: btcjson.NDisconnect,
+				Target: "1.1.1.1",
+			},
+		},
+		{
+			name: "node",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("node", btcjson.NConnect, "1.1.1.1", "perm")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewNodeCmd("connect", "1.1.1.1", btcjson.String("perm"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"node","params":["connect","1.1.1.1","perm"],"id":1}`,
+			unmarshalled: &btcjson.NodeCmd{
+				SubCmd:        btcjson.NConnect,
+				Target:        "1.1.1.1",
+				ConnectSubCmd: btcjson.String("perm"),
+			},
+		},
+		{
+			name: "node",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("node", btcjson.NConnect, "1.1.1.1", "temp")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewNodeCmd("connect", "1.1.1.1", btcjson.String("temp"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"node","params":["connect","1.1.1.1","temp"],"id":1}`,
+			unmarshalled: &btcjson.NodeCmd{
+				SubCmd:        btcjson.NConnect,
+				Target:        "1.1.1.1",
+				ConnectSubCmd: btcjson.String("temp"),
+			},
+		},
+		{
 			name: "getbestblock",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("getbestblock")

--- a/docs/json_rpc_api.md
+++ b/docs/json_rpc_api.md
@@ -186,7 +186,7 @@ the method name for further details such as parameter and return information.
 |   |   |
 |---|---|
 |Method|addnode|
-|Parameters|1. peer (string, required) - ip address and port of the peer tooperate on<br />2. command (string, required) - `add` to add a persistent peer, `remove` to remove a persistent peer, or `onetry` to try a single connection to a peer|
+|Parameters|1. peer (string, required) - ip address and port of the peer to operate on<br />2. command (string, required) - `add` to add a persistent peer, `remove` to remove a persistent peer, or `onetry` to try a single connection to a peer|
 |Description|Attempts to add or remove a persistent peer.|
 |Returns|Nothing|
 [Return to Overview](#MethodOverview)<br />
@@ -553,6 +553,8 @@ The following is an overview of the RPC methods which are implemented by btcd, b
 |2|[getbestblock](#getbestblock)|Y|Get block height and hash of best block in the main chain.|None|
 |3|[getcurrentnet](#getcurrentnet)|Y|Get bitcoin network btcd is running on.|None|
 |4|[searchrawtransactions](#searchrawtransactions)|Y|Query for transactions related to a particular address.|None|
+|5|[node](#node)|N|Attempts to add or remove a peer. |None|
+
 
 <a name="ExtMethodDetails" />
 **6.2 Method Details**<br />
@@ -606,6 +608,18 @@ The following is an overview of the RPC methods which are implemented by btcd, b
 |Returns (verbose=0)|`[ (json array of strings)` <br/>&nbsp;&nbsp; `"serializedtx", ... hex-encoded bytes of the serialized transaction` <br/>`]` |
 |Returns (verbose=1)|`[ (array of json objects)` <br/> &nbsp;&nbsp; `{ (json object)`<br />&nbsp;&nbsp;`"hex": "data",  (string) hex-encoded transaction`<br />&nbsp;&nbsp;`"txid": "hash",  (string) the hash of the transaction`<br />&nbsp;&nbsp;`"version": n,  (numeric) the transaction version`<br />&nbsp;&nbsp;`"locktime": n,  (numeric) the transaction lock time`<br />&nbsp;&nbsp;`"vin": [  (array of json objects) the transaction inputs as json objects`<br />&nbsp;&nbsp;<font color="orange">For coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"coinbase": "data",  (string) the hex-dencoded bytes of the signature script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": n,  (numeric) the script sequence number`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;<font color="orange">For non-coinbase transactions:</font><br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"txid": "hash", (string) the hash of the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"vout": n, (numeric) the index of the output being redeemed from the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptSig": { (json object) the signature script used to redeem the origin transaction`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "asm", (string) disassembly of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "data",  (string) hex-encoded bytes of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"sequence": n,  (numeric) the script sequence number`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}, ...`<br />&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`"vout": [  (array of json objects) the transaction outputs as json objects`<br />&nbsp;&nbsp;&nbsp;&nbsp;`{ (json object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"value": n, (numeric) the value in BTC`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"n": n, (numeric) the index of this transaction output`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"scriptPubKey": { (json object) the public key script used to pay coins`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"asm": "asm",  (string) disassembly of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"hex": "data", (string) hex-encoded bytes of the script`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"reqSigs": n,  (numeric) the number of required signatures`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"type": "scripttype" (string) the type of the script (e.g. 'pubkeyhash')`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"addresses": [ (json array of string) the bitcoin addresses associated with this output`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"address",  (string) the bitcoin address`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`...`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;&nbsp;&nbsp;`}, ...`<br /> &nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp; `"blockhash":"hash" Hash of the block the transaction is part of.` <br /> &nbsp;&nbsp; `"confirmations":n,  Number of numeric confirmations of block.` <br /> &nbsp;&nbsp;&nbsp;`"time":t, Transaction time in seconds since the epoch.` <br /> &nbsp;&nbsp;&nbsp;`"blocktime":t, Block time in seconds since the epoch.`<br />`},...`<br/> `]`|
 [Return to Overview](#ExtMethodOverview)<br />
+
+***
+
+<a name="node"/>
+
+|   |   |
+|---|---|
+|Method|node|
+|Parameters|1. command (string, required) - `connect` to add a peer (defaults to temporary), `remove` to remove a persistent peer, or `disconnect` to remove all matching non-persistent peers <br /> 2. peer (string, required) - ip address and port, or ID of the peer to operate on<br /> 3. connection type (string, optional) - `perm` indicates the peer should be added as a permanent peer, `temp` indicates a connection should only be attempted once. |
+|Description|Attempts to add or remove a peer.|
+|Returns|Nothing|
+[Return to Overview](#MethodOverview)<br />
 
 ***
 

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -33,6 +33,12 @@ var helpDescsEnUS = map[string]string{
 	"addnode-addr":      "IP address and port of the peer to operate on",
 	"addnode-subcmd":    "'add' to add a persistent peer, 'remove' to remove a persistent peer, or 'onetry' to try a single connection to a peer",
 
+	// NodeCmd help.
+	"node--synopsis":     "Attempts to add or remove a peer.",
+	"node-subcmd":        "'disconnect' to remove all matching non-persistent peers, 'remove' to remove a persistent peer, or 'connect' to connect to a peer",
+	"node-target":        "Either the IP address and port of the peer to operate on, or a valid peer ID.",
+	"node-connectsubcmd": "'perm' to make the connected peer a permanent one, 'temp' to try a single connect to a peer",
+
 	// TransactionInput help.
 	"transactioninput-txid": "The hash of the input transaction",
 	"transactioninput-vout": "The specific output of the input transaction to redeem",
@@ -521,6 +527,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getrawtransaction":     []interface{}{(*string)(nil), (*btcjson.TxRawResult)(nil)},
 	"gettxout":              []interface{}{(*btcjson.GetTxOutResult)(nil)},
 	"getwork":               []interface{}{(*btcjson.GetWorkResult)(nil), (*bool)(nil)},
+	"node":                  nil,
 	"help":                  []interface{}{(*string)(nil), (*string)(nil)},
 	"ping":                  nil,
 	"searchrawtransactions": []interface{}{(*string)(nil), (*[]btcjson.TxRawResult)(nil)},


### PR DESCRIPTION
This PR adds new JSON-RPC command: `node`. `node` allows a node operator full control over the peers their node is connect to.
A call to the new `node` RPC can take the following forms:
  * `btcctl node connect <addr> perm` (will attempt connect to a peer and mark it was permanent) 
  * `btcctl node connect <addr> temp` (will attempt to connect to a peer)
  * `btcctl node disconnect <addr or ID>` (will attempt to remove an outgoing or incoming peer)
  * `btcctl node remove <addr or ID>` (will attempt to remove a permanent peer)

This PR replaces #336. 
This aims to fix #79 by adding a new command that can disconnect any (inbound or outbound) non-persistent peer. 