### PR TITLE
Allow clients to cancel transaction notifications

### DIFF
--- a/btcjson/chainsvrwscmds.go
+++ b/btcjson/chainsvrwscmds.go
@@ -31,6 +31,15 @@ func NewNotifyBlocksCmd() *NotifyBlocksCmd {
 	return &NotifyBlocksCmd{}
 }
 
+// StopNotifyBlocksCmd defines the stopnotifyblocks JSON-RPC command.
+type StopNotifyBlocksCmd struct{}
+
+// NewStopNotifyBlocksCmd returns a new instance which can be used to issue a
+// stopnotifyblocks JSON-RPC command.
+func NewStopNotifyBlocksCmd() *StopNotifyBlocksCmd {
+	return &StopNotifyBlocksCmd{}
+}
+
 // NotifyNewTransactionsCmd defines the notifynewtransactions JSON-RPC command.
 type NotifyNewTransactionsCmd struct {
 	Verbose *bool `jsonrpcdefault:"false"`
@@ -45,6 +54,18 @@ func NewNotifyNewTransactionsCmd(verbose *bool) *NotifyNewTransactionsCmd {
 	return &NotifyNewTransactionsCmd{
 		Verbose: verbose,
 	}
+}
+
+// StopNotifyNewTransactionsCmd defines the stopnotifynewtransactions JSON-RPC command.
+type StopNotifyNewTransactionsCmd struct{}
+
+// NewStopNotifyNewTransactionsCmd returns a new instance which can be used to issue
+// a stopnotifynewtransactions JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewStopNotifyNewTransactionsCmd() *StopNotifyNewTransactionsCmd {
+	return &StopNotifyNewTransactionsCmd{}
 }
 
 // NotifyReceivedCmd defines the notifyreceived JSON-RPC command.
@@ -80,6 +101,32 @@ func NewNotifySpentCmd(outPoints []OutPoint) *NotifySpentCmd {
 	}
 }
 
+// StopNotifyReceivedCmd defines the stopnotifyreceived JSON-RPC command.
+type StopNotifyReceivedCmd struct {
+	Addresses []string
+}
+
+// NewStopNotifyReceivedCmd returns a new instance which can be used to issue a
+// stopnotifyreceived JSON-RPC command.
+func NewStopNotifyReceivedCmd(addresses []string) *StopNotifyReceivedCmd {
+	return &StopNotifyReceivedCmd{
+		Addresses: addresses,
+	}
+}
+
+// StopNotifySpentCmd defines the stopnotifyspent JSON-RPC command.
+type StopNotifySpentCmd struct {
+	OutPoints []OutPoint
+}
+
+// NewStopNotifySpentCmd returns a new instance which can be used to issue a
+// stopnotifyspent JSON-RPC command.
+func NewStopNotifySpentCmd(outPoints []OutPoint) *StopNotifySpentCmd {
+	return &StopNotifySpentCmd{
+		OutPoints: outPoints,
+	}
+}
+
 // RescanCmd defines the rescan JSON-RPC command.
 type RescanCmd struct {
 	BeginBlock string
@@ -111,5 +158,9 @@ func init() {
 	MustRegisterCmd("notifynewtransactions", (*NotifyNewTransactionsCmd)(nil), flags)
 	MustRegisterCmd("notifyreceived", (*NotifyReceivedCmd)(nil), flags)
 	MustRegisterCmd("notifyspent", (*NotifySpentCmd)(nil), flags)
+	MustRegisterCmd("stopnotifyblocks", (*StopNotifyBlocksCmd)(nil), flags)
+	MustRegisterCmd("stopnotifynewtransactions", (*StopNotifyNewTransactionsCmd)(nil), flags)
+	MustRegisterCmd("stopnotifyspent", (*StopNotifySpentCmd)(nil), flags)
+	MustRegisterCmd("stopnotifyreceived", (*StopNotifyReceivedCmd)(nil), flags)
 	MustRegisterCmd("rescan", (*RescanCmd)(nil), flags)
 }

--- a/btcjson/chainsvrwscmds_test.go
+++ b/btcjson/chainsvrwscmds_test.go
@@ -52,6 +52,17 @@ func TestChainSvrWsCmds(t *testing.T) {
 			unmarshalled: &btcjson.NotifyBlocksCmd{},
 		},
 		{
+			name: "stopnotifyblocks",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("stopnotifyblocks")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewStopNotifyBlocksCmd()
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"stopnotifyblocks","params":[],"id":1}`,
+			unmarshalled: &btcjson.StopNotifyBlocksCmd{},
+		},
+		{
 			name: "notifynewtransactions",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("notifynewtransactions")
@@ -78,6 +89,17 @@ func TestChainSvrWsCmds(t *testing.T) {
 			},
 		},
 		{
+			name: "stopnotifynewtransactions",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("stopnotifynewtransactions")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewStopNotifyNewTransactionsCmd()
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"stopnotifynewtransactions","params":[],"id":1}`,
+			unmarshalled: &btcjson.StopNotifyNewTransactionsCmd{},
+		},
+		{
 			name: "notifyreceived",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("notifyreceived", []string{"1Address"})
@@ -87,6 +109,19 @@ func TestChainSvrWsCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"notifyreceived","params":[["1Address"]],"id":1}`,
 			unmarshalled: &btcjson.NotifyReceivedCmd{
+				Addresses: []string{"1Address"},
+			},
+		},
+		{
+			name: "stopnotifyreceived",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("stopnotifyreceived", []string{"1Address"})
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewStopNotifyReceivedCmd([]string{"1Address"})
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"stopnotifyreceived","params":[["1Address"]],"id":1}`,
+			unmarshalled: &btcjson.StopNotifyReceivedCmd{
 				Addresses: []string{"1Address"},
 			},
 		},
@@ -101,6 +136,20 @@ func TestChainSvrWsCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"notifyspent","params":[[{"hash":"123","index":0}]],"id":1}`,
 			unmarshalled: &btcjson.NotifySpentCmd{
+				OutPoints: []btcjson.OutPoint{{Hash: "123", Index: 0}},
+			},
+		},
+		{
+			name: "stopnotifyspent",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("stopnotifyspent", `[{"hash":"123","index":0}]`)
+			},
+			staticCmd: func() interface{} {
+				ops := []btcjson.OutPoint{{Hash: "123", Index: 0}}
+				return btcjson.NewStopNotifySpentCmd(ops)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"stopnotifyspent","params":[[{"hash":"123","index":0}]],"id":1}`,
+			unmarshalled: &btcjson.StopNotifySpentCmd{
 				OutPoints: []btcjson.OutPoint{{Hash: "123", Index: 0}},
 			},
 		},

--- a/docs/json_rpc_api.md
+++ b/docs/json_rpc_api.md
@@ -649,10 +649,14 @@ user.  Click the method name for further details such as parameter and return in
 |---|------|-----------|-------------|
 |1|[authenticate](#authenticate)|Authenticate the connection against the username and passphrase configured for the RPC server.<br /><font color="orange">NOTE: This is only required if an HTTP Authorization header is not being used.</font>|None|
 |2|[notifyblocks](#notifyblocks)|Send notifications when a block is connected or disconnected from the best chain.|[blockconnected](#blockconnected) and [blockdisconnected](#blockdisconnected)|
-|3|[notifyreceived](#notifyreceived)|Send notifications when a txout spends to an address.|[recvtx](#recvtx) and [redeemingtx](#redeemingtx)|
-|4|[notifyspent](#notifyspent)|Send notification when a txout is spent.|[redeemingtx](#redeemingtx)|
-|5|[rescan](#rescan)|Rescan block chain for transactions to addresses and spent transaction outpoints.|[recvtx](#recvtx), [redeemingtx](#redeemingtx), [rescanprogress](#rescanprogress), and [rescanfinished](#rescanfinished) |
-|6|[notifynewtransactions](#notifynewtransactions)|Send notifications for all new transactions as they are accepted into the mempool.|[txaccepted](#txaccepted) or [txacceptedverbose](#txacceptedverbose)|
+|3|[stopnotifyblocks](#stopnotifyblocks)|Cancel registered notifications for whenever a block is connected or disconnected from the main (best) chain. |None|
+|4|[notifyreceived](#notifyreceived)|Send notifications when a txout spends to an address.|[recvtx](#recvtx) and [redeemingtx](#redeemingtx)|
+|5|[stopnotifyreceived](#stopnotifyreceived)|Cancel registered notifications for when a txout spends to any of the passed addresses.|None|
+|6|[notifyspent](#notifyspent)|Send notification when a txout is spent.|[redeemingtx](#redeemingtx)|
+|7|[stopnotifyspent](#stopnotifyspent)|Cancel registered spending notifications for each passed outpoint.|None|
+|8|[rescan](#rescan)|Rescan block chain for transactions to addresses and spent transaction outpoints.|[recvtx](#recvtx), [redeemingtx](#redeemingtx), [rescanprogress](#rescanprogress), and [rescanfinished](#rescanfinished) |
+|9|[notifynewtransactions](#notifynewtransactions)|Send notifications for all new transactions as they are accepted into the mempool.|[txaccepted](#txaccepted) or [txacceptedverbose](#txacceptedverbose)|
+|10|[stopnotifynewtransactions](#stopnotifynewtransactions)|Stop sending either a txaccepted or a txacceptedverbose notification when a new transaction is accepted into the mempool.|None|
 
 <a name="WSExtMethodDetails" />
 **7.2 Method Details**<br />
@@ -667,6 +671,8 @@ user.  Click the method name for further details such as parameter and return in
 |Returns|Success: Nothing<br />Failure: Nothing (websocket disconnected)|
 [Return to Overview](#ExtensionRequestOverview)<br />
 
+***
+
 <a name="notifyblocks"/>
 
 |   |   |
@@ -675,6 +681,18 @@ user.  Click the method name for further details such as parameter and return in
 |Notifications|[blockconnected](#blockconnected) and [blockdisconnected](#blockdisconnected)|
 |Parameters|None|
 |Description|Request notifications for whenever a block is connected or disconnected from the main (best) chain.|
+|Returns|Nothing|
+[Return to Overview](#ExtensionRequestOverview)<br />
+
+***
+<a name="stopnotifyblocks"/>
+
+|   |   |
+|---|---|
+|Method|stopnotifyblocks|
+|Notifications|None|
+|Parameters|None|
+|Description|Cancel sending notifications for whenever a block is connected or disconnected from the main (best) chain.|
 |Returns|Nothing|
 [Return to Overview](#ExtensionRequestOverview)<br />
 
@@ -693,6 +711,19 @@ user.  Click the method name for further details such as parameter and return in
 
 ***
 
+<a name="stopnotifyreceived"/>
+
+|   |   |
+|---|---|
+|Method|stopnotifyreceived|
+|Notifications|None|
+|Parameters|1. Addresses (JSON array, required)<br />&nbsp;`[ (json array of strings)`<br />&nbsp;&nbsp;`"bitcoinaddress", (string) the bitcoin address`<br />&nbsp;&nbsp;`...`<br />&nbsp;`]`|
+|Description|Cancel registered receive notifications for each passed address.|
+|Returns|Nothing|
+[Return to Overview](#ExtensionRequestOverview)<br />
+
+***
+
 <a name="notifyspent"/>
 
 |   |   |
@@ -701,6 +732,19 @@ user.  Click the method name for further details such as parameter and return in
 |Notifications|[redeemingtx](#redeemingtx)|
 |Parameters|1. Outpoints (JSON array, required)<br />&nbsp;`[ (JSON array)`<br />&nbsp;&nbsp;`{ (JSON object)`<br />&nbsp;&nbsp;&nbsp;`"hash":"data", (string) the hex-encoded bytes of the outpoint hash`<br />&nbsp;&nbsp;&nbsp;`"index":n (numeric) the txout index of the outpoint`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />&nbsp;`]`|
 |Description|Send a redeemingtx notification when a transaction spending an outpoint appears in mempool (if relayed to this btcd instance) and when such a transaction first appears in a newly-attached block.|
+|Returns|Nothing|
+[Return to Overview](#ExtensionRequestOverview)<br />
+
+***
+
+<a name="stopnotifyspent"/>
+
+|   |   |
+|---|---|
+|Method|stopnotifyspent|
+|Notifications|None|
+|Parameters|1. Outpoints (JSON array, required)<br />&nbsp;`[ (JSON array)`<br />&nbsp;&nbsp;`{ (JSON object)`<br />&nbsp;&nbsp;&nbsp;`"hash":"data", (string) the hex-encoded bytes of the outpoint hash`<br />&nbsp;&nbsp;&nbsp;`"index":n (numeric) the txout index of the outpoint`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />&nbsp;`]`|
+|Description|Cancel registered spending notifications for each passed outpoint.|
 |Returns|Nothing|
 [Return to Overview](#ExtensionRequestOverview)<br />
 
@@ -727,6 +771,19 @@ user.  Click the method name for further details such as parameter and return in
 |Notifications|[txaccepted](#txaccepted) or [txacceptedverbose](#txacceptedverbose)|
 |Parameters|1. verbose (boolean, optional, default=false) - specifies which type of notification to receive.  If verbose is true, then the caller receives [txacceptedverbose](#txacceptedverbose), otherwise the caller receives [txaccepted](#txaccepted)|
 |Description|Send either a [txaccepted](#txaccepted) or a [txacceptedverbose](#txacceptedverbose) notification when a new transaction is accepted into the mempool.|
+|Returns|Nothing|
+[Return to Overview](#ExtensionRequestOverview)<br />
+
+***
+
+<a name="stopnotifynewtransactions"/>
+
+|   |   |
+|---|---|
+|Method|stopnotifynewtransactions|
+|Notifications|None|
+|Parameters|None|
+|Description|Stop sending either a [txaccepted](#txaccepted) or a [txacceptedverbose](#txacceptedverbose) notification when a new transaction is accepted into the mempool.|
 |Returns|Nothing|
 [Return to Overview](#ExtensionRequestOverview)<br />
 

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -475,14 +475,24 @@ var helpDescsEnUS = map[string]string{
 	// NotifyBlocksCmd help.
 	"notifyblocks--synopsis": "Request notifications for whenever a block is connected or disconnected from the main (best) chain.",
 
+	// StopNotifyBlocksCmd help.
+	"stopnotifyblocks--synopsis": "Cancel registered notifications for whenever a block is connected or disconnected from the main (best) chain.",
+
 	// NotifyNewTransactionsCmd help.
 	"notifynewtransactions--synopsis": "Send either a txaccepted or a txacceptedverbose notification when a new transaction is accepted into the mempool.",
 	"notifynewtransactions-verbose":   "Specifies which type of notification to receive. If verbose is true, then the caller receives txacceptedverbose, otherwise the caller receives txaccepted",
+
+	// StopNotifyNewTransactionsCmd help.
+	"stopnotifynewtransactions--synopsis": "Stop sending either a txaccepted or a txacceptedverbose notification when a new transaction is accepted into the mempool.",
 
 	// NotifyReceivedCmd help.
 	"notifyreceived--synopsis": "Send a recvtx notification when a transaction added to mempool or appears in a newly-attached block contains a txout pkScript sending to any of the passed addresses.\n" +
 		"Matching outpoints are automatically registered for redeemingtx notifications.",
 	"notifyreceived-addresses": "List of address to receive notifications about",
+
+	// StopNotifyReceivedCmd help.
+	"stopnotifyreceived--synopsis": "Cancel registered receive notifications for each passed address.",
+	"stopnotifyreceived-addresses": "List of address to cancel receive notifications for",
 
 	// OutPoint help.
 	"outpoint-hash":  "The hex-encoded bytes of the outpoint hash",
@@ -491,6 +501,10 @@ var helpDescsEnUS = map[string]string{
 	// NotifySpentCmd help.
 	"notifyspent--synopsis": "Send a redeemingtx notification when a transaction spending an outpoint appears in mempool (if relayed to this btcd instance) and when such a transaction first appears in a newly-attached block.",
 	"notifyspent-outpoints": "List of transaction outpoints to monitor.",
+
+	// StopNotifySpentCmd help.
+	"stopnotifyspent--synopsis": "Cancel registered spending notifications for each passed outpoint.",
+	"stopnotifyspent-outpoints": "List of transaction outpoints to stop monitoring.",
 
 	// Rescan help.
 	"rescan--synopsis": "Rescan block chain for transactions to addresses.\n" +
@@ -547,11 +561,15 @@ var rpcResultTypes = map[string][]interface{}{
 	"verifymessage":         []interface{}{(*bool)(nil)},
 
 	// Websocket commands.
-	"notifyblocks":          nil,
-	"notifynewtransactions": nil,
-	"notifyreceived":        nil,
-	"notifyspent":           nil,
-	"rescan":                nil,
+	"notifyblocks":              nil,
+	"stopnotifyblocks":          nil,
+	"notifynewtransactions":     nil,
+	"stopnotifynewtransactions": nil,
+	"notifyreceived":            nil,
+	"stopnotifyreceived":        nil,
+	"notifyspent":               nil,
+	"stopnotifyspent":           nil,
+	"rescan":                    nil,
 }
 
 // helpCacher provides a concurrent safe type that provides help and usage for


### PR DESCRIPTION
This PR aims to address #122 by providing JSON-RPC methods allowing clients to cancel received and spent notifications. 

Note: before this can be properly integrated into `btcwallet`, `btcrpcclient` will need to be updated to use `btcjsonv2`. 