### PR TITLE
wire: Add func to get pkscript locs from a tx.

### DIFF
--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -108,8 +108,9 @@ func (msg *MsgBlock) Deserialize(r io.Reader) error {
 }
 
 // DeserializeTxLoc decodes r in the same manner Deserialize does, but it takes
-// a byte buffer instead of a generic reader and returns a slice containing the start and length of
-// each transaction within the raw data that is being deserialized.
+// a byte buffer instead of a generic reader and returns a slice containing the
+// start and length of each transaction within the raw data that is being
+// deserialized.
 func (msg *MsgBlock) DeserializeTxLoc(r *bytes.Buffer) ([]TxLoc, error) {
 	fullLen := r.Len()
 


### PR DESCRIPTION
This pull request provides a new function named PkScriptLocs on the MsgTx type which can be used to efficiently retrieve a list of offsets for the public key scripts for the serialized form of the transaction.

This is useful for certain applications which store fully serialized transactions and want to be able to quickly index into the serialized transaction to extract a give public key script directly thereby avoiding the need to deserialize the entire transaction.