### PR TITLE
btcctl: Support - argument to read from stdin.

### DIFF
--- a/cmd/btcctl/config.go
+++ b/cmd/btcctl/config.go
@@ -190,6 +190,11 @@ func loadConfig() (*config, []string, error) {
 	if err != nil {
 		if e, ok := err.(*flags.Error); ok && e.Type == flags.ErrHelp {
 			fmt.Fprintln(os.Stderr, err)
+			fmt.Fprintln(os.Stderr, "")
+			fmt.Fprintln(os.Stderr, "The special parameter `-` "+
+				"indicates that a parameter should be read "+
+				"from the\nnext unread line from standard "+
+				"input.")
 			return nil, nil, err
 		}
 	}


### PR DESCRIPTION
This pull request modifies the argument handling for btcctl to treat a parameter that is a single dash as an indicator to read that paramter from stdin instead.

This change allows commands, such as the submitblock, to accept data piped from stdin for any parameter.  This, in turn, allows large arguments, such as blocks, which can often be too big for a single argument due to Operating System limitations to be submitted by putting them into a file and redirecting stdin.

For example:
```bash
$ btcctl submitblock - <block.hex
$ cat block.hex | btcctl submitblock -

$ btcctl sendrawtransaction - <tx.hex
$ cat tx.hex | btcctl sendrawtransaction -
```