### PR TITLE
Ignore getaddr requests from outbound peers.

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -1150,6 +1150,12 @@ func (p *peer) handleGetAddrMsg(msg *wire.MsgGetAddr) {
 		return
 	}
 
+	// Do not accept getaddr requests from outbound peers.  This reduces
+	// fingerprinting attacks.
+	if !p.inbound {
+		return
+	}
+
 	// Get the current known addresses from the address manager.
 	addrCache := p.server.addrManager.AddressCache()
 


### PR DESCRIPTION
This change reduces fingerprinting attacks and
mimics Bitcoin Core commit
dca799e1db6e319fdd47e0bfdb038eab0efabb85