### PR TITLE
Addrindex fixes

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -14,7 +14,7 @@ import (
 
 // Errors that the various database functions may return.
 var (
-	ErrAddrIndexDoesNotExist  = errors.New("address index hasn't been built up yet")
+	ErrAddrIndexDoesNotExist  = errors.New("address index hasn't been built or is an older version")
 	ErrUnsupportedAddressType = errors.New("address type is not supported " +
 		"by the address-index")
 	ErrPrevShaMissing  = errors.New("previous sha missing from database")

--- a/database/ldb/internal_test.go
+++ b/database/ldb/internal_test.go
@@ -28,7 +28,7 @@ func TestAddrIndexKeySerialization(t *testing.T) {
 	}
 
 	serializedKey := addrIndexToKey(&fakeIndex)
-	copy(packedIndex[:], serializedKey[22:34])
+	copy(packedIndex[:], serializedKey[23:35])
 	unpackedIndex := unpackTxIndex(packedIndex)
 
 	if unpackedIndex.blkHeight != fakeIndex.blkHeight {


### PR DESCRIPTION
This fixes issue #346 and makes it so that transactions are returned in order. In order to do the latter, the integers in the address index are stored as big endian rather than little endian; this requires an index rebuild and the pull request does that automatically. Unfortunately, there is a bug exposed by the index rebuild which causes a shutdown (see issue #303), which I'll be working on fixing next.