### PR TITLE
bug averted in addrmgr.Good

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -904,12 +904,12 @@ func (a *AddrManager) Good(addr *btcwire.NetAddress) {
 			}
 		}
 	}
-	a.nNew--
 
 	if oldBucket == -1 {
 		// What? wasn't in a bucket after all.... Panic?
 		return
 	}
+	a.nNew--
 
 	bucket := a.getTriedBucket(ka.na)
 


### PR DESCRIPTION
addrmgr.Good function has a check on lines 909 to 912 as to whether the input address exists in any of the new address buckets. If it does not, the function returns. However, the function decrements nNew before performing this check. If an address was passed to Good that was not in any new address bucket, then the function would falsely decriment its count of new addresses even if Good did not remove any new address. I moved the decrement so that it is after the check.

I'm not sure how to test my pull request because I don't know how get to the case checked in lines 909 to 912.