### PR TITLE
Deterministic signatures according to RFC6979

### DIFF
--- a/btcec/example_test.go
+++ b/btcec/example_test.go
@@ -34,16 +34,14 @@ func Example_signMessage() {
 	}
 
 	// Serialize and display the signature.
-	//
-	// NOTE: This is commented out for the example since the signature
-	// produced uses random numbers and therefore will always be different.
-	//fmt.Printf("Serialized Signature: %x\n", signature.Serialize())
+	fmt.Printf("Serialized Signature: %x\n", signature.Serialize())
 
 	// Verify the signature for the message using the public key.
 	verified := signature.Verify(messageHash, pubKey)
 	fmt.Printf("Signature Verified? %v\n", verified)
 
 	// Output:
+	// Serialized Signature: 304402201008e236fa8cd0f25df4482dddbb622e8a8b26ef0ba731719458de3ccd93805b022032f8ebe514ba5f672466eba334639282616bb3c2f0ab09998037513d1f9e3d6d
 	// Signature Verified? true
 }
 
@@ -68,6 +66,7 @@ func Example_verifySignature() {
 	sigBytes, err := hex.DecodeString("30450220090ebfb3690a0ff115bb1b38b" +
 		"8b323a667b7653454f1bccb06d4bbdca42c2079022100ec95778b51e707" +
 		"1cb1205f8bde9af6592fc978b0452dafe599481c46d6b2e479")
+
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/btcec/internal_test.go
+++ b/btcec/internal_test.go
@@ -69,3 +69,8 @@ func (curve *KoblitzCurve) TstDoubleJacobian(x1, y1, z1, x3, y3, z3 *fieldVal) {
 func NewFieldVal() *fieldVal {
 	return new(fieldVal)
 }
+
+// TstNonceRFC6979 makes the nonceRFC6979 function available to the test package.
+func TstNonceRFC6979(privkey *big.Int, hash []byte) *big.Int {
+	return nonceRFC6979(privkey, hash)
+}

--- a/btcec/privkey.go
+++ b/btcec/privkey.go
@@ -53,14 +53,12 @@ func (p *PrivateKey) ToECDSA() *ecdsa.PrivateKey {
 	return (*ecdsa.PrivateKey)(p)
 }
 
-// Sign wraps ecdsa.Sign to sign the provided hash (which should be the result
-// of hashing a larger message) using the private key.
+// Sign generates an ECDSA signature for the provided hash (which should be the result
+// of hashing a larger message) using the private key. Produced signature
+// is deterministic (same message and same key yield the same signature) and canonical
+// in accordance with RFC6979 and BIP0062.
 func (p *PrivateKey) Sign(hash []byte) (*Signature, error) {
-	r, s, err := ecdsa.Sign(rand.Reader, p.ToECDSA(), hash)
-	if err != nil {
-		return nil, err
-	}
-	return &Signature{R: r, S: s}, nil
+	return signRFC6979(p, hash)
 }
 
 // PrivKeyBytesLen defines the length in bytes of a serialized private key.

--- a/btcec/signature.go
+++ b/btcec/signature.go
@@ -5,11 +5,16 @@
 package btcec
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/hmac"
 	"errors"
 	"fmt"
+	"hash"
 	"math/big"
+
+	"github.com/btcsuite/fastsha256"
 )
 
 // Errors returned by canonicalPadding.
@@ -24,10 +29,17 @@ type Signature struct {
 	S *big.Int
 }
 
-// curve order and halforder, used to tame ECDSA malleability (see BIP-0062)
 var (
+	// Curve order and halforder, used to tame ECDSA malleability (see BIP-0062)
 	order     = new(big.Int).Set(S256().N)
 	halforder = new(big.Int).Rsh(order, 1)
+
+	// Used in RFC6979 implementation when testing the nonce for correctness
+	one = big.NewInt(1)
+
+	// oneInitializer is used to fill a byte slice with byte 0x01.  It is provided
+	// here to avoid the need to create it multiple times.
+	oneInitializer = []byte{0x01}
 )
 
 // Serialize returns the ECDSA signature in the more strict DER format.  Note
@@ -395,4 +407,126 @@ func RecoverCompact(curve *KoblitzCurve, signature,
 	}
 
 	return key, ((signature[0] - 27) & 4) == 4, nil
+}
+
+// signRFC6979 generates a deterministic ECDSA signature according to RFC 6979 and BIP 62.
+func signRFC6979(privateKey *PrivateKey, hash []byte) (*Signature, error) {
+
+	privkey := privateKey.ToECDSA()
+	N := order
+	k := nonceRFC6979(privkey.D, hash)
+	inv := new(big.Int).ModInverse(k, N)
+	r, _ := privkey.Curve.ScalarBaseMult(k.Bytes())
+	if r.Cmp(N) == 1 {
+		r.Sub(r, N)
+	}
+
+	if r.Sign() == 0 {
+		return nil, errors.New("calculated R is zero")
+	}
+
+	e := hashToInt(hash, privkey.Curve)
+	s := new(big.Int).Mul(privkey.D, r)
+	s.Add(s, e)
+	s.Mul(s, inv)
+	s.Mod(s, N)
+
+	if s.Cmp(halforder) == 1 {
+		s.Sub(N, s)
+	}
+	if s.Sign() == 0 {
+		return nil, errors.New("calculated S is zero")
+	}
+	return &Signature{R: r, S: s}, nil
+}
+
+// nonceRFC6979 generates an ECDSA nonce (`k`) deterministically according to RFC 6979.
+// It takes a 32-byte hash as an input and returns 32-byte nonce to be used in ECDSA algorithm.
+func nonceRFC6979(privkey *big.Int, hash []byte) *big.Int {
+
+	curve := S256()
+	q := curve.Params().N
+	x := privkey
+	alg := fastsha256.New
+
+	qlen := q.BitLen()
+	holen := alg().Size()
+	rolen := (qlen + 7) >> 3
+	bx := append(int2octets(x, rolen), bits2octets(hash, curve, rolen)...)
+
+	// Step B
+	v := bytes.Repeat(oneInitializer, holen)
+
+	// Step C (Go zeroes the all allocated memory)
+	k := make([]byte, holen)
+
+	// Step D
+	k = mac(alg, k, append(append(v, 0x00), bx...))
+
+	// Step E
+	v = mac(alg, k, v)
+
+	// Step F
+	k = mac(alg, k, append(append(v, 0x01), bx...))
+
+	// Step G
+	v = mac(alg, k, v)
+
+	// Step H
+	for {
+		// Step H1
+		var t []byte
+
+		// Step H2
+		for len(t)*8 < qlen {
+			v = mac(alg, k, v)
+			t = append(t, v...)
+		}
+
+		// Step H3
+		secret := hashToInt(t, curve)
+		if secret.Cmp(one) >= 0 && secret.Cmp(q) < 0 {
+			return secret
+		}
+		k = mac(alg, k, append(v, 0x00))
+		v = mac(alg, k, v)
+	}
+}
+
+// mac returns an HMAC of the given key and message.
+func mac(alg func() hash.Hash, k, m []byte) []byte {
+	h := hmac.New(alg, k)
+	h.Write(m)
+	return h.Sum(nil)
+}
+
+// https://tools.ietf.org/html/rfc6979#section-2.3.3
+func int2octets(v *big.Int, rolen int) []byte {
+	out := v.Bytes()
+
+	// left pad with zeros if it's too short
+	if len(out) < rolen {
+		out2 := make([]byte, rolen)
+		copy(out2[rolen-len(out):], out)
+		return out2
+	}
+
+	// drop most significant bytes if it's too long
+	if len(out) > rolen {
+		out2 := make([]byte, rolen)
+		copy(out2, out[len(out)-rolen:])
+		return out2
+	}
+
+	return out
+}
+
+// https://tools.ietf.org/html/rfc6979#section-2.3.4
+func bits2octets(in []byte, curve elliptic.Curve, rolen int) []byte {
+	z1 := hashToInt(in, curve)
+	z2 := new(big.Int).Sub(z1, curve.Params().N)
+	if z2.Sign() < 0 {
+		return int2octets(z1, rolen)
+	}
+	return int2octets(z2, rolen)
 }

--- a/btcec/signature_test.go
+++ b/btcec/signature_test.go
@@ -7,11 +7,13 @@ package btcec_test
 import (
 	"bytes"
 	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"testing"
 
 	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/fastsha256"
 )
 
 type signatureTest struct {
@@ -19,6 +21,19 @@ type signatureTest struct {
 	sig     []byte
 	der     bool
 	isValid bool
+}
+
+// decodeHex decodes the passed hex string and returns the resulting bytes.  It
+// panics if an error occurs.  This is only used in the tests as a helper since
+// the only way it can fail is if there is an error in the test source code.
+func decodeHex(hexStr string) []byte {
+	b, err := hex.DecodeString(hexStr)
+	if err != nil {
+		panic("invalid hex string in test source: err " + err.Error() +
+			", hex: " + hexStr)
+	}
+
+	return b
 }
 
 var signatureTests = []signatureTest{
@@ -489,5 +504,87 @@ func TestSignCompact(t *testing.T) {
 		}
 		compressed := i%2 != 0
 		testSignCompact(t, name, btcec.S256(), data, compressed)
+	}
+}
+
+func TestRFC6979(t *testing.T) {
+	// Test vectors matching Trezor and CoreBitcoin implementations.
+	// - https://github.com/trezor/trezor-crypto/blob/9fea8f8ab377dc514e40c6fd1f7c89a74c1d8dc6/tests.c#L432-L453
+	// - https://github.com/oleganza/CoreBitcoin/blob/e93dd71207861b5bf044415db5fa72405e7d8fbc/CoreBitcoin/BTCKey%2BTests.m#L23-L49
+	tests := []struct {
+		key       string
+		msg       string
+		nonce     string
+		signature string
+	}{
+		{
+			"cca9fbcc1b41e5a95d369eaa6ddcff73b61a4efaa279cfc6567e8daa39cbaf50",
+			"sample",
+			"2df40ca70e639d89528a6b670d9d48d9165fdc0febc0974056bdce192b8e16a3",
+			"3045022100af340daf02cc15c8d5d08d7735dfe6b98a474ed373bdb5fbecf7571be52b384202205009fb27f37034a9b24b707b7c6b79ca23ddef9e25f7282e8a797efe53a8f124",
+		},
+		{
+			// This signature hits the case when S is higher than halforder.
+			// If S is not canonicalized (lowered by halforder), this test will fail.
+			"0000000000000000000000000000000000000000000000000000000000000001",
+			"Satoshi Nakamoto",
+			"8f8a276c19f4149656b280621e358cce24f5f52542772691ee69063b74f15d15",
+			"3045022100934b1ea10a4b3c1757e2b0c017d0b6143ce3c9a7e6a4a49860d7a6ab210ee3d802202442ce9d2b916064108014783e923ec36b49743e2ffa1c4496f01a512aafd9e5",
+		},
+		{
+			"fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140",
+			"Satoshi Nakamoto",
+			"33a19b60e25fb6f4435af53a3d42d493644827367e6453928554f43e49aa6f90",
+			"3045022100fd567d121db66e382991534ada77a6bd3106f0a1098c231e47993447cd6af2d002206b39cd0eb1bc8603e159ef5c20a5c8ad685a45b06ce9bebed3f153d10d93bed5",
+		},
+		{
+			"f8b8af8ce3c7cca5e300d33939540c10d45ce001b8f252bfbc57ba0342904181",
+			"Alan Turing",
+			"525a82b70e67874398067543fd84c83d30c175fdc45fdeee082fe13b1d7cfdf1",
+			"304402207063ae83e7f62bbb171798131b4a0564b956930092b33b07b395615d9ec7e15c022058dfcc1e00a35e1572f366ffe34ba0fc47db1e7189759b9fb233c5b05ab388ea",
+		},
+		{
+			"0000000000000000000000000000000000000000000000000000000000000001",
+			"All those moments will be lost in time, like tears in rain. Time to die...",
+			"38aa22d72376b4dbc472e06c3ba403ee0a394da63fc58d88686c611aba98d6b3",
+			"30450221008600dbd41e348fe5c9465ab92d23e3db8b98b873beecd930736488696438cb6b0220547fe64427496db33bf66019dacbf0039c04199abb0122918601db38a72cfc21",
+		},
+		{
+			"e91671c46231f833a6406ccbea0e3e392c76c167bac1cb013f6f1013980455c2",
+			"There is a computer disease that anybody who works with computers knows about. It's a very serious disease and it interferes completely with the work. The trouble with computers is that you 'play' with them!",
+			"1f4b84c23a86a221d233f2521be018d9318639d5b8bbd6374a8a59232d16ad3d",
+			"3045022100b552edd27580141f3b2a5463048cb7cd3e047b97c9f98076c32dbdf85a68718b0220279fa72dd19bfae05577e06c7c0c1900c371fcd5893f7e1d56a37d30174671f6",
+		},
+	}
+
+	for i, test := range tests {
+		privKey, _ := btcec.PrivKeyFromBytes(btcec.S256(), decodeHex(test.key))
+		hash := fastsha256.Sum256([]byte(test.msg))
+
+		// Ensure deterministically generated nonce is the expected value.
+		gotNonce := btcec.TstNonceRFC6979(privKey.D, hash[:]).Bytes()
+		wantNonce := decodeHex(test.nonce)
+		if !bytes.Equal(gotNonce, wantNonce) {
+			t.Errorf("NonceRFC6979 #%d (%s): Nonce is incorrect: "+
+				"%x (expected %x)", i, test.msg, gotNonce,
+				wantNonce)
+			continue
+		}
+
+		// Ensure deterministically generated signature is the expected value.
+		gotSig, err := privKey.Sign(hash[:])
+		if err != nil {
+			t.Errorf("Sign #%d (%s): unexpected error: %v", i,
+				test.msg, err)
+			continue
+		}
+		gotSigBytes := gotSig.Serialize()
+		wantSigBytes := decodeHex(test.signature)
+		if !bytes.Equal(gotSigBytes, wantSigBytes) {
+			t.Errorf("Sign #%d (%s): mismatched signature: %x "+
+				"(expected %x)", i, test.msg, gotSigBytes,
+				wantSigBytes)
+			continue
+		}
 	}
 }


### PR DESCRIPTION
See https://github.com/btcsuite/btcd/issues/358 for discussion.

The test vectors are the same as in [Trezor](https://github.com/trezor/trezor-crypto/blob/9fea8f8ab377dc514e40c6fd1f7c89a74c1d8dc6/tests.c#L432-L453) and [CoreBitcoin](https://github.com/oleganza/CoreBitcoin/blob/e93dd71207861b5bf044415db5fa72405e7d8fbc/CoreBitcoin/BTCKey%2BTests.m#L23-L49) implementations and cover both the raw nonce (k) and the complete DER-encoded signature (which must have canonical S).