### PR TITLE
addrmgr: Do not bias toward fresh addresses.

### DIFF
--- a/addrmgr/knownaddress.go
+++ b/addrmgr/knownaddress.go
@@ -48,7 +48,7 @@ func (ka *KnownAddress) chance() float64 {
 		lastAttempt = 0
 	}
 
-	c := 600.0 / (600.0 + lastSeen.Seconds())
+	c := 1.0
 
 	// Very recent attempts are less likely to be retried.
 	if lastAttempt > 10*time.Minute {


### PR DESCRIPTION
This change was suggested as Countermeasure 2 in Eclipse Attacks on
Bitcoin's Peer-to-Peer Network, Ethan Heilman, Alison Kendler, Aviv
Zohar, Sharon Goldberg. ePrint Archive Report 2015/263. March 2015.

This mimics Bitcoin Core commit
f68ba3f67bd500a64fb8932c6b41924ddc31d76f