### PR TITLE
fixed bug that could cause an infinite loop.

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -762,7 +762,9 @@ func (a *AddrManager) GetAddress(class string, newBias int) *KnownAddress {
 		(100.0 - float64(newBias))
 	newCorrelation := math.Sqrt(float64(a.nNew)) * float64(newBias)
 
-	if ((newCorrelation + triedCorrelation) * a.rand.Float64()) <
+	// If there are tried vectors but no new vectors, automatically select from tried
+	// vectors. Otherwise choose which to select from according to the random rule.
+	if a.nNew == 0 || ((newCorrelation+triedCorrelation)*a.rand.Float64()) <
 		triedCorrelation {
 		// Tried entry.
 		large := 1 << 30


### PR DESCRIPTION
An unlikely scenario would cause GetAddress to enter an infinite loop. Suppose there are addresses in the tried bucket but none in the new bucket, and suppose newBias is less than 100. Then triedCorrelation will be positive but newCorrelation will be zero. This means that ((newCorrelation+triedCorrelation)*a.rand.Float64()) < triedCorrelation
can evaluate to false. When this happens, the program will try to find a new address to return forever because there are no new addresses. 

Therefore, I have added the check a.nNew == 0 to the if clause here so that it now says 
if a.nNew == 0 || ((newCorrelation+triedCorrelation)*a.rand.Float64()) < triedCorrelation {

This will ensure that GetAddress always returns a tried address if there are no new addresses. 