### PR TITLE
Added tests for addrmgr.KnownAddress

### DIFF
--- a/addrmgr/internal_test.go
+++ b/addrmgr/internal_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2013-2015 Conformal Systems LLC.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package addrmgr
+
+import (
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+)
+
+func TstKnownAddressIsBad(ka *KnownAddress) bool {
+	return ka.isBad()
+}
+
+func TstKnownAddressChance(ka *KnownAddress) float64 {
+	return ka.chance()
+}
+
+func TstNewKnownAddress(na *wire.NetAddress, attempts int,
+	lastattempt, lastsuccess time.Time, tried bool, refs int) *KnownAddress {
+	return &KnownAddress{na: na, attempts: attempts, lastattempt: lastattempt,
+		lastsuccess: lastsuccess, tried: tried, refs: refs}
+}

--- a/addrmgr/knownaddress.go
+++ b/addrmgr/knownaddress.go
@@ -51,12 +51,12 @@ func (ka *KnownAddress) chance() float64 {
 	c := 1.0
 
 	// Very recent attempts are less likely to be retried.
-	if lastAttempt > 10*time.Minute {
+	if lastAttempt < 10*time.Minute {
 		c *= 0.01
 	}
 
 	// Failed attempts deprioritise.
-	for i := ka.attempts; i < 0; i++ {
+	for i := ka.attempts; i > 0; i-- {
 		c /= 1.5
 	}
 
@@ -82,7 +82,7 @@ func (ka *KnownAddress) isBad() bool {
 	}
 
 	// Over a month old?
-	if ka.na.Timestamp.After(time.Now().Add(-1 * numMissingDays * time.Hour * 24)) {
+	if ka.na.Timestamp.Before(time.Now().Add(-1 * numMissingDays * time.Hour * 24)) {
 		return true
 	}
 

--- a/addrmgr/knownaddress_test.go
+++ b/addrmgr/knownaddress_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2013-2015 Conformal Systems LLC.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package addrmgr_test
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/addrmgr"
+	"github.com/btcsuite/btcd/wire"
+)
+
+func TestChance(t *testing.T) {
+	var tests = []struct {
+		addr     *addrmgr.KnownAddress
+		expected float64
+	}{
+		{
+			//Test normal case
+			addrmgr.TstNewKnownAddress(&wire.NetAddress{Timestamp: time.Now().Add(-35 * time.Second)},
+				0, time.Now().Add(-30*time.Minute), time.Now(), false, 0),
+			1.0,
+		}, {
+			//Test case in which lastseen < 0
+			addrmgr.TstNewKnownAddress(&wire.NetAddress{Timestamp: time.Now().Add(20 * time.Second)},
+				0, time.Now().Add(-30*time.Minute), time.Now(), false, 0),
+			1.0,
+		}, {
+			//Test case in which lastattempt < 0
+			addrmgr.TstNewKnownAddress(&wire.NetAddress{Timestamp: time.Now().Add(-35 * time.Second)},
+				0, time.Now().Add(30*time.Minute), time.Now(), false, 0),
+			1.0 * .01,
+		}, {
+			//Test case in which lastattempt < ten minutes
+			addrmgr.TstNewKnownAddress(&wire.NetAddress{Timestamp: time.Now().Add(-35 * time.Second)},
+				0, time.Now().Add(-5*time.Minute), time.Now(), false, 0),
+			1.0 * .01,
+		}, {
+			//Test case with several failed attempts.
+			addrmgr.TstNewKnownAddress(&wire.NetAddress{Timestamp: time.Now().Add(-35 * time.Second)},
+				2, time.Now().Add(-30*time.Minute), time.Now(), false, 0),
+			1 / 1.5 / 1.5,
+		},
+	}
+
+	err := .0001
+	for i, test := range tests {
+		chance := addrmgr.TstKnownAddressChance(test.addr)
+		if math.Abs(test.expected-chance) >= err {
+			t.Errorf("case %d: got %f, expected %f", i, chance, test.expected)
+		}
+	}
+}
+
+func TestIsBad(t *testing.T) {
+	future := time.Now().Add(35 * time.Minute)
+	monthOld := time.Now().Add(-43 * time.Hour * 24)
+	secondsOld := time.Now().Add(-2 * time.Second)
+	minutesOld := time.Now().Add(-27 * time.Minute)
+	hoursOld := time.Now().Add(-5 * time.Hour)
+	zeroTime, _ := time.Parse("Jan 1, 1970 at 0:00am (GMT)", "Jan 1, 1970 at 0:00am (GMT)")
+
+	futureNa := &wire.NetAddress{Timestamp: future}
+	minutesOldNa := &wire.NetAddress{Timestamp: minutesOld}
+	monthOldNa := &wire.NetAddress{Timestamp: monthOld}
+	currentNa := &wire.NetAddress{Timestamp: secondsOld}
+
+	//Test addresses that have been tried in the last minute.
+	if addrmgr.TstKnownAddressIsBad(addrmgr.TstNewKnownAddress(futureNa, 3, secondsOld, zeroTime, false, 0)) {
+		t.Errorf("test case 1: addresses that have been tried in the last minute are not bad.")
+	}
+	if addrmgr.TstKnownAddressIsBad(addrmgr.TstNewKnownAddress(monthOldNa, 3, secondsOld, zeroTime, false, 0)) {
+		t.Errorf("test case 2: addresses that have been tried in the last minute are not bad.")
+	}
+	if addrmgr.TstKnownAddressIsBad(addrmgr.TstNewKnownAddress(currentNa, 3, secondsOld, zeroTime, false, 0)) {
+		t.Errorf("test case 3: addresses that have been tried in the last minute are not bad.")
+	}
+	if addrmgr.TstKnownAddressIsBad(addrmgr.TstNewKnownAddress(currentNa, 3, secondsOld, monthOld, true, 0)) {
+		t.Errorf("test case 4: addresses that have been tried in the last minute are not bad.")
+	}
+	if addrmgr.TstKnownAddressIsBad(addrmgr.TstNewKnownAddress(currentNa, 2, secondsOld, secondsOld, true, 0)) {
+		t.Errorf("test case 5: addresses that have been tried in the last minute are not bad.")
+	}
+
+	//Test address that claims to be from the future.
+	if !addrmgr.TstKnownAddressIsBad(addrmgr.TstNewKnownAddress(futureNa, 0, minutesOld, hoursOld, true, 0)) {
+		t.Errorf("test case 6: addresses that claim to be from the future are bad.")
+	}
+
+	//Test address that has not been seen in over a month.
+	if !addrmgr.TstKnownAddressIsBad(addrmgr.TstNewKnownAddress(monthOldNa, 0, minutesOld, hoursOld, true, 0)) {
+		t.Errorf("test case 7: addresses more than a month old are bad.")
+	}
+
+	//It has failed at least three times and never succeeded.
+	if !addrmgr.TstKnownAddressIsBad(addrmgr.TstNewKnownAddress(minutesOldNa, 3, minutesOld, zeroTime, true, 0)) {
+		t.Errorf("test case 8: addresses that have never succeeded are bad.")
+	}
+
+	//It has failed ten times in the last week
+	if !addrmgr.TstKnownAddressIsBad(addrmgr.TstNewKnownAddress(minutesOldNa, 10, minutesOld, monthOld, true, 0)) {
+		t.Errorf("test case 9: addresses that have not succeeded in too long are bad.")
+	}
+
+	//Test an address that should work.
+	if addrmgr.TstKnownAddressIsBad(addrmgr.TstNewKnownAddress(minutesOldNa, 2, minutesOld, hoursOld, true, 0)) {
+		t.Errorf("test case 10: This should be a valid address.")
+	}
+}


### PR DESCRIPTION
I have made tests for knownaddresses.go. This meant making an internal_test.go file to expose chance() and isBad(). I have tested both functions in accordance with the comments given for each of them. Both functions turned out to be buggy and required fixes. 

A comment for chance() says "Very recent attempts are less likely to be retried." However, the if clause below only affects c if the last attempt was NOT very recent, or greater than 10 minutes. The way this function works now is that very recent attempts are MORE likely to be retried! 

The next comment for chance() says "Failed attempts deprioritise." However, the for loop says "for i := ka.attempts; i < 0; i++" However, ka.attempts is supposed to be zero or greater. It will not ordinarily be negative. This means that the loop never actually executes. 

Now, as for isBad(), the comment says "isBad returns true if the address in question has not been tried in the last minute and meets one of the following criteria:
2) It hasn't been seen in over a month"
However, the line of code that checks for this checks whether the address is LESS than a month old and then returns true if it is. This marks the address as bad for the opposite reason it should! 

The tests I made cover all branches of chance() and isBad(). 