### PR TITLE
blockchain: Split block and header validation.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -4,11 +4,7 @@
 
 package blockchain
 
-import (
-	"fmt"
-
-	"github.com/btcsuite/btcutil"
-)
+import "github.com/btcsuite/btcutil"
 
 // maybeAcceptBlock potentially accepts a block into the memory block chain.
 // It performs several validation checks which depend on its position within
@@ -16,11 +12,12 @@ import (
 // through ProcessBlock before calling this function with it.
 //
 // The flags modify the behavior of this function as follows:
-//  - BFFastAdd: The somewhat expensive BIP0034 validation is not performed.
 //  - BFDryRun: The memory chain index will not be pruned and no accept
 //    notification will be sent since the block is not being accepted.
+//
+// The flags are also passed to checkBlockContext and connectBestChain.  See
+// their documentation for how the flags modify their behavior.
 func (b *BlockChain) maybeAcceptBlock(block *btcutil.Block, flags BehaviorFlags) error {
-	fastAdd := flags&BFFastAdd == BFFastAdd
 	dryRun := flags&BFDryRun == BFDryRun
 
 	// Get a block node for the block previous to this one.  Will be nil
@@ -39,111 +36,11 @@ func (b *BlockChain) maybeAcceptBlock(block *btcutil.Block, flags BehaviorFlags)
 	}
 	block.SetHeight(blockHeight)
 
-	blockHeader := &block.MsgBlock().Header
-	if !fastAdd {
-		// Ensure the difficulty specified in the block header matches
-		// the calculated difficulty based on the previous block and
-		// difficulty retarget rules.
-		expectedDifficulty, err := b.calcNextRequiredDifficulty(prevNode,
-			block.MsgBlock().Header.Timestamp)
-		if err != nil {
-			return err
-		}
-		blockDifficulty := blockHeader.Bits
-		if blockDifficulty != expectedDifficulty {
-			str := "block difficulty of %d is not the expected value of %d"
-			str = fmt.Sprintf(str, blockDifficulty, expectedDifficulty)
-			return ruleError(ErrUnexpectedDifficulty, str)
-		}
-
-		// Ensure the timestamp for the block header is after the
-		// median time of the last several blocks (medianTimeBlocks).
-		medianTime, err := b.calcPastMedianTime(prevNode)
-		if err != nil {
-			log.Errorf("calcPastMedianTime: %v", err)
-			return err
-		}
-		if !blockHeader.Timestamp.After(medianTime) {
-			str := "block timestamp of %v is not after expected %v"
-			str = fmt.Sprintf(str, blockHeader.Timestamp,
-				medianTime)
-			return ruleError(ErrTimeTooOld, str)
-		}
-
-		// Ensure all transactions in the block are finalized.
-		for _, tx := range block.Transactions() {
-			if !IsFinalizedTransaction(tx, blockHeight,
-				blockHeader.Timestamp) {
-				str := fmt.Sprintf("block contains "+
-					"unfinalized transaction %v", tx.Sha())
-				return ruleError(ErrUnfinalizedTx, str)
-			}
-		}
-
-	}
-
-	// Ensure chain matches up to predetermined checkpoints.
-	blockHash := block.Sha()
-	if !b.verifyCheckpoint(blockHeight, blockHash) {
-		str := fmt.Sprintf("block at height %d does not match "+
-			"checkpoint hash", blockHeight)
-		return ruleError(ErrBadCheckpoint, str)
-	}
-
-	// Find the previous checkpoint and prevent blocks which fork the main
-	// chain before it.  This prevents storage of new, otherwise valid,
-	// blocks which build off of old blocks that are likely at a much easier
-	// difficulty and therefore could be used to waste cache and disk space.
-	checkpointBlock, err := b.findPreviousCheckpoint()
+	// The block must pass all of the validation rules which depend on the
+	// position of the block within the block chain.
+	err = b.checkBlockContext(block, prevNode, flags)
 	if err != nil {
 		return err
-	}
-	if checkpointBlock != nil && blockHeight < checkpointBlock.Height() {
-		str := fmt.Sprintf("block at height %d forks the main chain "+
-			"before the previous checkpoint at height %d",
-			blockHeight, checkpointBlock.Height())
-		return ruleError(ErrForkTooOld, str)
-	}
-
-	if !fastAdd {
-		// Reject version 2 blocks once a majority of the network has
-		// upgraded.  This is part of BIP0066.
-		if blockHeader.Version < 3 && b.isMajorityVersion(3, prevNode,
-			b.chainParams.BlockRejectNumRequired) {
-
-			str := "new blocks with version %d are no longer valid"
-			str = fmt.Sprintf(str, blockHeader.Version)
-			return ruleError(ErrBlockVersionTooOld, str)
-		}
-
-		// Reject version 1 blocks once a majority of the network has
-		// upgraded.  This is part of BIP0034.
-		if blockHeader.Version < 2 && b.isMajorityVersion(2, prevNode,
-			b.chainParams.BlockRejectNumRequired) {
-
-			str := "new blocks with version %d are no longer valid"
-			str = fmt.Sprintf(str, blockHeader.Version)
-			return ruleError(ErrBlockVersionTooOld, str)
-		}
-
-		// Ensure coinbase starts with serialized block heights for
-		// blocks whose version is the serializedHeightVersion or
-		// newer once a majority of the network has upgraded.  This is
-		// part of BIP0034.
-		if ShouldHaveSerializedBlockHeight(blockHeader) &&
-			b.isMajorityVersion(serializedHeightVersion, prevNode,
-				b.chainParams.BlockEnforceNumRequired) {
-
-			expectedHeight := int64(0)
-			if prevNode != nil {
-				expectedHeight = prevNode.height + 1
-			}
-			coinbaseTx := block.Transactions()[0]
-			err := checkSerializedHeight(coinbaseTx, expectedHeight)
-			if err != nil {
-				return err
-			}
-		}
 	}
 
 	// Prune block nodes which are no longer needed before creating
@@ -157,7 +54,8 @@ func (b *BlockChain) maybeAcceptBlock(block *btcutil.Block, flags BehaviorFlags)
 
 	// Create a new block node for the block and add it to the in-memory
 	// block chain (could be either a side chain or the main chain).
-	newNode := newBlockNode(blockHeader, blockHash, blockHeight)
+	blockHeader := &block.MsgBlock().Header
+	newNode := newBlockNode(blockHeader, block.Sha(), blockHeight)
 	if prevNode != nil {
 		newNode.parent = prevNode
 		newNode.height = blockHeight


### PR DESCRIPTION
This pull request refactors the consensus rule checks for block headers and blocks in the blockchain package into separate functions.  These changes contain no modifications to consensus rules and the code still passes all block consensus tests.  It is only a refactoring.

This is being done to help pave the way toward supporting concurrent downloads.  While the package already supports headers-first mode up through the latest checkpoint through the use of the BFFastAdd flag and hard-coded checkpoints, it currently only works when downloading from a single peer.  In order to support concurrent downloads from multiple peers, the ability for the caller to do things such as independently checking a block header (both context-free and full-context checks) will be needed.

There are several more changes that will be necessary to support concurrent downloads as well, such as making the package concurrent safe, modifying it to make use of the new database API, etc.  Those changes are planned for future commits.