### PR TITLE
txscript: Remove unneeded param from NewScript.

### DIFF
--- a/blockchain/scriptval.go
+++ b/blockchain/scriptval.go
@@ -83,8 +83,8 @@ out:
 			// Create a new script engine for the script pair.
 			sigScript := txIn.SignatureScript
 			pkScript := originMsgTx.TxOut[originTxIndex].PkScript
-			engine, err := txscript.NewScript(sigScript, pkScript,
-				txVI.txInIndex, txVI.tx.MsgTx(), v.flags)
+			engine, err := txscript.NewScript(pkScript,
+				txVI.tx.MsgTx(), txVI.txInIndex, v.flags)
 			if err != nil {
 				str := fmt.Sprintf("failed to parse input "+
 					"%s:%d which references output %s:%d - "+

--- a/txscript/example_test.go
+++ b/txscript/example_test.go
@@ -164,8 +164,8 @@ func ExampleSignTxOutput() {
 	flags := txscript.ScriptBip16 | txscript.ScriptVerifyDERSignatures |
 		txscript.ScriptStrictMultiSig |
 		txscript.ScriptDiscourageUpgradableNops
-	s, err := txscript.NewScript(redeemTx.TxIn[0].SignatureScript,
-		originTx.TxOut[0].PkScript, 0, redeemTx, flags)
+	s, err := txscript.NewScript(originTx.TxOut[0].PkScript, redeemTx, 0,
+		flags)
 	if err != nil {
 		fmt.Println(err)
 		return

--- a/txscript/internal_test.go
+++ b/txscript/internal_test.go
@@ -4202,7 +4202,7 @@ func TestBitcoindInvalidTests(t *testing.T) {
 			continue
 		}
 		tx := createSpendingTx(scriptSig, scriptPubKey)
-		s, err := NewScript(scriptSig, scriptPubKey, 0, tx, flags)
+		s, err := NewScript(scriptPubKey, tx, 0, flags)
 		if err == nil {
 			if err := s.Execute(); err == nil {
 				t.Errorf("%s test succeeded when it "+
@@ -4254,7 +4254,7 @@ func TestBitcoindValidTests(t *testing.T) {
 			continue
 		}
 		tx := createSpendingTx(scriptSig, scriptPubKey)
-		s, err := NewScript(scriptSig, scriptPubKey, 0, tx, flags)
+		s, err := NewScript(scriptPubKey, tx, 0, flags)
 		if err != nil {
 			t.Errorf("%s failed to create script: %v", name, err)
 			continue
@@ -4391,8 +4391,7 @@ testloop:
 					k, i, test)
 				continue testloop
 			}
-			s, err := NewScript(txin.SignatureScript, pkScript, k,
-				tx.MsgTx(), flags)
+			s, err := NewScript(pkScript, tx.MsgTx(), k, flags)
 			if err != nil {
 				t.Errorf("test (%d:%v:%d) failed to create "+
 					"script: %v", i, test, k, err)
@@ -4537,8 +4536,7 @@ testloop:
 			// These are meant to fail, so as soon as the first
 			// input fails the transaction has failed. (some of the
 			// test txns have good inputs, too..
-			s, err := NewScript(txin.SignatureScript, pkScript, k,
-				tx.MsgTx(), flags)
+			s, err := NewScript(pkScript, tx.MsgTx(), k, flags)
 			if err != nil {
 				continue testloop
 			}

--- a/txscript/opcode_test.go
+++ b/txscript/opcode_test.go
@@ -507,9 +507,7 @@ func TestScripts(t *testing.T) {
 			flags = txscript.ScriptVerifyDERSignatures
 		}
 		mockTx.TxOut[0].PkScript = test.script
-		sigScript := mockTx.TxIn[0].SignatureScript
-		engine, err := txscript.NewScript(sigScript, test.script, 0,
-			mockTx, flags)
+		engine, err := txscript.NewScript(test.script, mockTx, 0, flags)
 		if err == nil {
 			err = engine.Execute()
 		}
@@ -4285,8 +4283,7 @@ func testOpcode(t *testing.T, test *detailedTest) {
 
 	tx.TxOut[0].PkScript = test.script
 
-	engine, err := txscript.NewScript(tx.TxIn[0].SignatureScript,
-		tx.TxOut[0].PkScript, 0, tx, 0)
+	engine, err := txscript.NewScript(tx.TxOut[0].PkScript, tx, 0, 0)
 	if err != nil {
 		if err != test.expectedReturn {
 			t.Errorf("Error return not expected %s: %v %v",


### PR DESCRIPTION
This pull request removes the unnecessary sigScript parameter from the txscript.NewScript function.  This has bothered me for a while because it can and really should be obtained from the provided transaction and input index.  The way it was, the passed script could technically be different than what is in the transaction.  Obviously that would be an improper use of the API, but it's safer and more convenient to simply pull it from the provided transaction and index.

Also, since the function signature is changing anyways, make the input index parameter come after the transaction which it references.