### PR TITLE
Create and use a new SOCKS5 subpackage.

### DIFF
--- a/config.go
+++ b/config.go
@@ -19,10 +19,10 @@ import (
 	"github.com/btcsuite/btcd/database"
 	_ "github.com/btcsuite/btcd/database/ldb"
 	_ "github.com/btcsuite/btcd/database/memdb"
+	"github.com/btcsuite/btcd/socks5"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	flags "github.com/btcsuite/go-flags"
-	"github.com/btcsuite/go-socks/socks"
 )
 
 const (
@@ -91,6 +91,7 @@ type config struct {
 	Proxy              string        `long:"proxy" description:"Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
 	ProxyUser          string        `long:"proxyuser" description:"Username for proxy server"`
 	ProxyPass          string        `long:"proxypass" default-mask:"-" description:"Password for proxy server"`
+	ProxyRandomize     bool          `long:"proxyrandomize" description:"Randomize user credentials for each proxy connection. This enables Tor stream isolation"`
 	OnionProxy         string        `long:"onion" description:"Connect to tor hidden services via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
 	OnionProxyUser     string        `long:"onionuser" description:"Username for onion proxy server"`
 	OnionProxyPass     string        `long:"onionpass" default-mask:"-" description:"Password for onion proxy server"`
@@ -714,11 +715,13 @@ func loadConfig() (*config, []string, error) {
 	cfg.dial = net.Dial
 	cfg.lookup = net.LookupIP
 	if cfg.Proxy != "" {
-		proxy := &socks.Proxy{
-			Addr:     cfg.Proxy,
-			Username: cfg.ProxyUser,
-			Password: cfg.ProxyPass,
+		proxy, err := socks5.New(cfg.Proxy, cfg.ProxyUser,
+			cfg.ProxyPass)
+		if err != nil {
+			return nil, nil, err
 		}
+		proxy.SetRandomized(cfg.ProxyRandomize)
+
 		cfg.dial = proxy.Dial
 		if !cfg.NoOnion {
 			cfg.lookup = func(host string) ([]net.IP, error) {
@@ -736,14 +739,14 @@ func loadConfig() (*config, []string, error) {
 	// This allows .onion address traffic to be routed through a different
 	// proxy than normal traffic.
 	if cfg.OnionProxy != "" {
-		cfg.oniondial = func(a, b string) (net.Conn, error) {
-			proxy := &socks.Proxy{
-				Addr:     cfg.OnionProxy,
-				Username: cfg.OnionProxyUser,
-				Password: cfg.OnionProxyPass,
-			}
-			return proxy.Dial(a, b)
+		onionProxy, err := socks5.New(cfg.OnionProxy,
+			cfg.OnionProxyUser, cfg.OnionProxyPass)
+		if err != nil {
+			return nil, nil, err
 		}
+		onionProxy.SetRandomized(cfg.ProxyRandomize)
+
+		cfg.oniondial = onionProxy.Dial
 		cfg.onionlookup = func(host string) ([]net.IP, error) {
 			return torLookupIP(host, cfg.OnionProxy)
 		}

--- a/doc.go
+++ b/doc.go
@@ -58,6 +58,7 @@ Application Options:
       --proxy=             Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)
       --proxyuser=         Username for proxy server
       --proxypass=         Password for proxy server
+      --proxyrandomize     Randomize user credentials for each proxy connection. This enables Tor stream isolation
       --onion=             Connect to tor hidden services via SOCKS5 proxy (eg.
                            127.0.0.1:9050)
       --onionuser=         Username for onion proxy server

--- a/peer.go
+++ b/peer.go
@@ -22,7 +22,6 @@ import (
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/bloom"
-	"github.com/btcsuite/go-socks/socks"
 	"github.com/davecgh/go-spew/spew"
 )
 
@@ -89,17 +88,6 @@ func newNetAddress(addr net.Addr, services wire.ServiceFlag) (*wire.NetAddress, 
 	if tcpAddr, ok := addr.(*net.TCPAddr); ok {
 		ip := tcpAddr.IP
 		port := uint16(tcpAddr.Port)
-		na := wire.NewNetAddressIPPort(ip, port, services)
-		return na, nil
-	}
-
-	// addr will be a socks.ProxiedAddr when using a proxy.
-	if proxiedAddr, ok := addr.(*socks.ProxiedAddr); ok {
-		ip := net.ParseIP(proxiedAddr.Host)
-		if ip == nil {
-			ip = net.ParseIP("0.0.0.0")
-		}
-		port := uint16(proxiedAddr.Port)
 		na := wire.NewNetAddressIPPort(ip, port, services)
 		return na, nil
 	}

--- a/sample-btcd.conf
+++ b/sample-btcd.conf
@@ -41,6 +41,10 @@
 ; onionuser=
 ; onionpass=
 
+; Randomize proxy user credentials.  This enables Tor stream isolation making
+; it more difficult to correlate connections.
+; proxyrandomize=1
+
 ; Use Universal Plug and Play (UPnP) to automatically open the listen port
 ; and obtain the external IP address from supported devices.  NOTE: This option
 ; will have no effect if exernal IP addresses are specified.

--- a/socks5/README.md
+++ b/socks5/README.md
@@ -1,0 +1,54 @@
+socks5
+==========
+
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
+(https://travis-ci.org/btcsuite/btcd) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+
+Package socks5 implements SOCKS5 proxy connection handling.
+Package socks5 is licensed under the liberal ISC license.
+
+## Documentation
+
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcd/socks5)
+
+Full `go doc` style documentation for the project can be viewed online without
+installing this package by using the GoDoc site here:
+http://godoc.org/github.com/btcsuite/btcd/socks5
+
+You can also view the documentation locally once the package is installed with
+the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
+http://localhost:6060/pkg/github.com/btcsuite/btcd/socks5
+
+## Installation
+
+```bash
+$ go get github.com/btcsuite/btcd/socks5
+```
+
+## GPG Verification Key
+
+All official release tags are signed by Conformal so users can ensure the code
+has not been tampered with and is coming from Conformal.  To verify the
+signature perform the following:
+
+- Download the public key from the Conformal website at
+  https://opensource.conformal.com/GIT-GPG-KEY-conformal.txt
+
+- Import the public key into your GPG keyring:
+  ```bash
+  gpg --import GIT-GPG-KEY-conformal.txt
+  ```
+
+- Verify the release tag with the following command where `TAG_NAME` is a
+  placeholder for the specific tag:
+  ```bash
+  git tag -v TAG_NAME
+  ```
+
+## License
+
+
+Package socks5 is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/socks5/socks5.go
+++ b/socks5/socks5.go
@@ -1,0 +1,281 @@
+// Copyright (c) 2015 Conformal Systems LLC.
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package socks5
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"math/rand"
+	"net"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const (
+	protocolVersion = 5
+
+	addressTypeIPv4   = 1
+	addressTypeDomain = 3
+	addressTypeIPv6   = 4
+
+	authNone             = 0
+	authGssAPI           = 1
+	authUsernamePassword = 2
+	authUnavailable      = 0xff
+
+	commandTCPConnect   = 1
+	commandTCPBind      = 2
+	commandUDPAssociate = 3
+)
+
+var (
+	// ErrAuthFailed is returned on authentication failures.
+	ErrAuthFailed = errors.New("authentication failed")
+
+	// ErrInvalidProxyResponse is returned when the proxy server
+	// sends an invalid proxy response.
+	ErrInvalidProxyResponse = errors.New("invalid proxy response")
+
+	// ErrNoAcceptableAuthMethod is returned when the proxy server
+	// does not contain any acceptable authentication methods.
+	ErrNoAcceptableAuthMethod = errors.New("no acceptable authentication method")
+
+	statusRequestGranted          = byte(0)
+	statusGeneralFailure          = byte(1)
+	statusConnectionNotAllowed    = byte(2)
+	statusNetworkUnreachable      = byte(3)
+	statusHostUnreachable         = byte(4)
+	statusConnectionRefused       = byte(5)
+	statusTTLExpired              = byte(6)
+	statusCommandNotSupport       = byte(7)
+	statusAddressTypeNotSupported = byte(8)
+
+	statusErrors = map[byte]error{
+		statusGeneralFailure:          errors.New("general failure"),
+		statusConnectionNotAllowed:    errors.New("connection not allowed by ruleset"),
+		statusNetworkUnreachable:      errors.New("network unreachable"),
+		statusHostUnreachable:         errors.New("host unreachable"),
+		statusConnectionRefused:       errors.New("connection refused by destination host"),
+		statusTTLExpired:              errors.New("TTL expired"),
+		statusCommandNotSupport:       errors.New("command not supported / protocol error"),
+		statusAddressTypeNotSupported: errors.New("address type not supported"),
+	}
+)
+
+// Socks5 houses information regarding a socks5 instance.
+type Socks5 struct {
+	mtx        sync.Mutex
+	addr       string
+	host       string
+	port       string
+	user       string
+	pass       string
+	randomized bool // random user credentials
+}
+
+// Dial attempts to connect to the passed address via a proxy
+// server.
+func (s *Socks5) Dial(network, addr string) (net.Conn, error) {
+	remoteHost, strPort, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+	remotePort, err := strconv.Atoi(strPort)
+	if err != nil {
+		return nil, err
+	}
+
+	s.mtx.Lock()
+	var user, pass string
+	if s.randomized {
+		r := rand.New(rand.NewSource(time.Now().UnixNano()))
+		user = fmt.Sprintf("%08d", r.Int63())
+		pass = fmt.Sprintf("%08d", r.Int63())
+	} else {
+		user = s.user
+		pass = s.pass
+	}
+	paddr := s.addr
+	s.mtx.Unlock()
+
+	conn, err := net.Dial("tcp", paddr)
+	if err != nil {
+		return nil, err
+	}
+
+	if s.user != "" {
+		buf := []byte{
+			protocolVersion,
+			2, // number of authentication methods
+			authNone,
+			authUsernamePassword,
+		}
+		_, err = conn.Write(buf)
+	} else {
+		buf := []byte{
+			protocolVersion,
+			1, // number of authencation methods
+			authNone,
+		}
+		_, err = conn.Write(buf)
+	}
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	var res [2]byte
+	if _, err := io.ReadFull(conn, res[:]); err != nil {
+		conn.Close()
+		return nil, err
+	}
+	if res[0] != protocolVersion {
+		conn.Close()
+		return nil, ErrInvalidProxyResponse
+	}
+
+	switch res[1] {
+	case authGssAPI:
+		err = ErrNoAcceptableAuthMethod
+	case authNone:
+		// Do nothing
+	case authUnavailable:
+		err = ErrNoAcceptableAuthMethod
+	case authUsernamePassword:
+		buf := make([]byte, 3+len(user)+len(pass))
+		buf[0] = 1 // version
+		buf[1] = byte(len(user))
+		copy(buf[2:], user)
+		buf[2+len(user)] = byte(len(pass))
+		copy(buf[2+len(user)+1:], pass)
+		if _, err = conn.Write(buf); err != nil {
+			conn.Close()
+			return nil, err
+		}
+		if _, err = io.ReadFull(conn, buf[:2]); err != nil {
+			conn.Close()
+			return nil, err
+		}
+		if buf[0] != 1 { // version
+			err = ErrInvalidProxyResponse
+		} else if buf[1] != 0 { // 0 = success
+			err = ErrAuthFailed
+		}
+	default:
+		err = ErrInvalidProxyResponse
+	}
+
+	if err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	// Command and connection request.
+	buf := make([]byte, 5+len(remoteHost)+2)
+	buf[0] = protocolVersion
+	buf[1] = commandTCPConnect
+	buf[2] = 0 // reserved
+	buf[3] = addressTypeDomain
+	buf[4] = byte(len(remoteHost))
+	copy(buf[5:], remoteHost)
+	buf[5+len(remoteHost)] = byte(remotePort >> 8)
+	buf[6+len(remoteHost)] = byte(remotePort & 0xff)
+	if _, err := conn.Write(buf); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	// Server response
+	var res2 [4]byte
+	if _, err := io.ReadFull(conn, res2[:]); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	if res2[0] != protocolVersion {
+		conn.Close()
+		return nil, ErrInvalidProxyResponse
+	}
+	if res2[1] != statusRequestGranted {
+		conn.Close()
+		err := statusErrors[res2[1]]
+		if err == nil {
+			err = ErrInvalidProxyResponse
+		}
+		return nil, err
+	}
+
+	switch res2[3] {
+	case addressTypeDomain:
+		var domainLen [1]byte
+		if _, err := io.ReadFull(conn, domainLen[:]); err != nil {
+			conn.Close()
+			return nil, err
+		}
+		b := make([]byte, int(domainLen[0]))
+		if _, err := io.ReadFull(conn, b); err != nil {
+			conn.Close()
+			return nil, err
+		}
+	case addressTypeIPv4:
+		var b [4]byte
+		if _, err := io.ReadFull(conn, b[:]); err != nil {
+			conn.Close()
+			return nil, err
+		}
+	case addressTypeIPv6:
+		var b [16]byte
+		if _, err := io.ReadFull(conn, b[:]); err != nil {
+			conn.Close()
+			return nil, err
+		}
+	default:
+		conn.Close()
+		return nil, ErrInvalidProxyResponse
+	}
+
+	if _, err := io.ReadFull(conn, res2[:2]); err != nil {
+		conn.Close()
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+// IsRandomized returns whether or not proxy user credentials
+// are randomized.
+func (s *Socks5) IsRandomized() bool {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	return s.randomized
+}
+
+// SetRandomized sets whether or not proxy user credentials should
+// be randomized.
+func (s *Socks5) SetRandomized(randomized bool) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	s.randomized = randomized
+}
+
+// New returns a new Socks5 instance.
+func New(addr string, user, pass string) (*Socks5, error) {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Socks5{
+		addr: addr,
+		host: host,
+		port: port,
+		user: user,
+		pass: pass,
+	}, nil
+}


### PR DESCRIPTION
The new SOCKS5 subpackage includes all the existing funcationality
plus supports Tor stream isolation.  This can be acheived by using
the --proxyrandomize option.

Idea from Wladimir J. van der Laan via Bitcoin Core:
https://github.com/bitcoin/bitcoin/pull/5911