### PR TITLE
Fix 'add/delnode' type switch evaluation in server

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -364,11 +364,11 @@ func handleAddNode(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (in
 	var err error
 	switch c.SubCmd {
 	case "add":
-		err = s.server.AddAddr(addr, true)
+		err = s.server.ConnectNode(addr, true)
 	case "remove":
-		err = s.server.RemoveAddr(addr)
+		err = s.server.RemoveNodeByAddr(addr)
 	case "onetry":
-		err = s.server.AddAddr(addr, false)
+		err = s.server.ConnectNode(addr, false)
 	default:
 		return nil, &btcjson.RPCError{
 			Code:    btcjson.ErrRPCInvalidParameter,


### PR DESCRIPTION
* The cases for the 'addnode' command were previously
   stacked on top the new cases for the 'node' command.
   The intended behavior was to create a fall through and
   handle both commands. However, trying to use this
   syntax with a type switch caused the first case to be
   ignored.
* The 'addnode' cases are now handled separately from the
   'node' commands in the server.