### PR TITLE
Remove account defaults for wallet requests.

### DIFF
--- a/btcjson/v2/btcjson/walletsvrcmds.go
+++ b/btcjson/v2/btcjson/walletsvrcmds.go
@@ -11,7 +11,7 @@ package btcjson
 type AddMultisigAddressCmd struct {
 	NRequired int
 	Keys      []string
-	Account   *string `jsonrpcdefault:"\"\""`
+	Account   *string
 }
 
 // NewAddMultisigAddressCmd returns a new instance which can be used to issue a
@@ -135,8 +135,8 @@ func NewGetAddressesByAccountCmd(account string) *GetAddressesByAccountCmd {
 
 // GetBalanceCmd defines the getbalance JSON-RPC command.
 type GetBalanceCmd struct {
-	Account *string `jsonrpcdefault:"\"*\""`
-	MinConf *int    `jsonrpcdefault:"1"`
+	Account *string
+	MinConf *int `jsonrpcdefault:"1"`
 }
 
 // NewGetBalanceCmd returns a new instance which can be used to issue a
@@ -153,7 +153,7 @@ func NewGetBalanceCmd(account *string, minConf *int) *GetBalanceCmd {
 
 // GetNewAddressCmd defines the getnewaddress JSON-RPC command.
 type GetNewAddressCmd struct {
-	Account *string `jsonrpcdefault:"\"\""`
+	Account *string
 }
 
 // NewGetNewAddressCmd returns a new instance which can be used to issue a
@@ -169,7 +169,7 @@ func NewGetNewAddressCmd(account *string) *GetNewAddressCmd {
 
 // GetRawChangeAddressCmd defines the getrawchangeaddress JSON-RPC command.
 type GetRawChangeAddressCmd struct {
-	Account *string `jsonrpcdefault:"\"\""`
+	Account *string
 }
 
 // NewGetRawChangeAddressCmd returns a new instance which can be used to issue a
@@ -240,8 +240,8 @@ func NewGetTransactionCmd(txHash string, includeWatchOnly *bool) *GetTransaction
 // ImportPrivKeyCmd defines the importprivkey JSON-RPC command.
 type ImportPrivKeyCmd struct {
 	PrivKey string
-	Label   *string `jsonrpcdefault:"\"\""`
-	Rescan  *bool   `jsonrpcdefault:"true"`
+	Label   *string
+	Rescan  *bool `jsonrpcdefault:"true"`
 }
 
 // NewImportPrivKeyCmd returns a new instance which can be used to issue a

--- a/btcjson/v2/btcjson/walletsvrcmds_test.go
+++ b/btcjson/v2/btcjson/walletsvrcmds_test.go
@@ -42,7 +42,7 @@ func TestWalletSvrCmds(t *testing.T) {
 			unmarshalled: &btcjson.AddMultisigAddressCmd{
 				NRequired: 2,
 				Keys:      []string{"031234", "035678"},
-				Account:   btcjson.String(""),
+				Account:   nil,
 			},
 		},
 		{
@@ -177,7 +177,7 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getbalance","params":[],"id":1}`,
 			unmarshalled: &btcjson.GetBalanceCmd{
-				Account: btcjson.String("*"),
+				Account: nil,
 				MinConf: btcjson.Int(1),
 			},
 		},
@@ -219,7 +219,7 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getnewaddress","params":[],"id":1}`,
 			unmarshalled: &btcjson.GetNewAddressCmd{
-				Account: btcjson.String(""),
+				Account: nil,
 			},
 		},
 		{
@@ -245,7 +245,7 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getrawchangeaddress","params":[],"id":1}`,
 			unmarshalled: &btcjson.GetRawChangeAddressCmd{
-				Account: btcjson.String(""),
+				Account: nil,
 			},
 		},
 		{
@@ -356,7 +356,7 @@ func TestWalletSvrCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"importprivkey","params":["abc"],"id":1}`,
 			unmarshalled: &btcjson.ImportPrivKeyCmd{
 				PrivKey: "abc",
-				Label:   btcjson.String(""),
+				Label:   nil,
 				Rescan:  btcjson.Bool(true),
 			},
 		},

--- a/btcjson/v2/btcjson/walletsvrwscmds.go
+++ b/btcjson/v2/btcjson/walletsvrwscmds.go
@@ -22,8 +22,8 @@ func NewCreateEncryptedWalletCmd(passphrase string) *CreateEncryptedWalletCmd {
 
 // ExportWatchingWalletCmd defines the exportwatchingwallet JSON-RPC command.
 type ExportWatchingWalletCmd struct {
-	Account  *string `jsonrpcdefault:"\"\""`
-	Download *bool   `jsonrpcdefault:"false"`
+	Account  *string
+	Download *bool `jsonrpcdefault:"false"`
 }
 
 // NewExportWatchingWalletCmd returns a new instance which can be used to issue
@@ -40,7 +40,7 @@ func NewExportWatchingWalletCmd(account *string, download *bool) *ExportWatching
 
 // GetUnconfirmedBalanceCmd defines the getunconfirmedbalance JSON-RPC command.
 type GetUnconfirmedBalanceCmd struct {
-	Account *string `jsonrpcdefault:"\"\""`
+	Account *string
 }
 
 // NewGetUnconfirmedBalanceCmd returns a new instance which can be used to issue
@@ -58,7 +58,7 @@ func NewGetUnconfirmedBalanceCmd(account *string) *GetUnconfirmedBalanceCmd {
 // command.
 type ListAddressTransactionsCmd struct {
 	Addresses []string
-	Account   *string `jsonrpcdefault:"\"\""`
+	Account   *string
 }
 
 // NewListAddressTransactionsCmd returns a new instance which can be used to
@@ -75,7 +75,7 @@ func NewListAddressTransactionsCmd(addresses []string, account *string) *ListAdd
 
 // ListAllTransactionsCmd defines the listalltransactions JSON-RPC command.
 type ListAllTransactionsCmd struct {
-	Account *string `jsonrpcdefault:"\"\""`
+	Account *string
 }
 
 // NewListAllTransactionsCmd returns a new instance which can be used to issue a

--- a/btcjson/v2/btcjson/walletsvrwscmds_test.go
+++ b/btcjson/v2/btcjson/walletsvrwscmds_test.go
@@ -50,7 +50,7 @@ func TestWalletSvrWsCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"exportwatchingwallet","params":[],"id":1}`,
 			unmarshalled: &btcjson.ExportWatchingWalletCmd{
-				Account:  btcjson.String(""),
+				Account:  nil,
 				Download: btcjson.Bool(false),
 			},
 		},
@@ -93,7 +93,7 @@ func TestWalletSvrWsCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getunconfirmedbalance","params":[],"id":1}`,
 			unmarshalled: &btcjson.GetUnconfirmedBalanceCmd{
-				Account: btcjson.String(""),
+				Account: nil,
 			},
 		},
 		{
@@ -120,7 +120,7 @@ func TestWalletSvrWsCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"listaddresstransactions","params":[["1Address"]],"id":1}`,
 			unmarshalled: &btcjson.ListAddressTransactionsCmd{
 				Addresses: []string{"1Address"},
-				Account:   btcjson.String(""),
+				Account:   nil,
 			},
 		},
 		{
@@ -148,7 +148,7 @@ func TestWalletSvrWsCmds(t *testing.T) {
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"listalltransactions","params":[],"id":1}`,
 			unmarshalled: &btcjson.ListAllTransactionsCmd{
-				Account: btcjson.String(""),
+				Account: nil,
 			},
 		},
 		{


### PR DESCRIPTION
btcwallet will need to check whether these requests were unset, so defaults cannot be automatically filled in by btcjson.

~~This currently depends on several unmerged btcwallet PRs so it cannot be merged at this time.~~ ready