### PR TITLE
btcjson: Remove NewOutPointFromWire and wire dep.

### DIFF
--- a/btcjson/v2/btcjson/chainsvrwscmds.go
+++ b/btcjson/v2/btcjson/chainsvrwscmds.go
@@ -7,10 +7,6 @@
 
 package btcjson
 
-import (
-	"github.com/btcsuite/btcd/wire"
-)
-
 // AuthenticateCmd defines the authenticate JSON-RPC command.
 type AuthenticateCmd struct {
 	Username   string
@@ -69,15 +65,6 @@ func NewNotifyReceivedCmd(addresses []string) *NotifyReceivedCmd {
 type OutPoint struct {
 	Hash  string `json:"hash"`
 	Index uint32 `json:"index"`
-}
-
-// NewOutPointFromWire creates a new OutPoint from the OutPoint structure
-// of the btcwire package.
-func NewOutPointFromWire(op *wire.OutPoint) *OutPoint {
-	return &OutPoint{
-		Hash:  op.Hash.String(),
-		Index: op.Index,
-	}
 }
 
 // NotifySpentCmd defines the notifyspent JSON-RPC command.

--- a/btcjson/v2/btcjson/chainsvrwscmds_test.go
+++ b/btcjson/v2/btcjson/chainsvrwscmds_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcjson/v2/btcjson"
-	"github.com/btcsuite/btcd/wire"
 )
 
 // TestChainSvrWsCmds tests all of the chain server websocket-specific commands
@@ -112,9 +111,10 @@ func TestChainSvrWsCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				addrs := []string{"1Address"}
-				hash, _ := wire.NewShaHashFromStr("123")
-				op := wire.NewOutPoint(hash, 0)
-				ops := []btcjson.OutPoint{*btcjson.NewOutPointFromWire(op)}
+				ops := []btcjson.OutPoint{{
+					Hash:  "0000000000000000000000000000000000000000000000000000000000000123",
+					Index: 0,
+				}}
 				return btcjson.NewRescanCmd("123", addrs, ops, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"rescan","params":["123",["1Address"],[{"hash":"0000000000000000000000000000000000000000000000000000000000000123","index":0}]],"id":1}`,


### PR DESCRIPTION
This pull request removes the `NewOutPointFromWire` function from the `btcjson` version 2 package so it can be used without needing the wire package as a dependency.  It also updates the tests accordingly.

This results in the package only depending on core Go packages.

Closes #401.