### PR TITLE
Fix listtransactions/gettransaction result structs.

### DIFF
--- a/btcjson/helpers.go
+++ b/btcjson/helpers.go
@@ -60,6 +60,14 @@ func Uint64(v uint64) *uint64 {
 	return p
 }
 
+// Float64 is a helper routine that allocates a new float64 value to store v and
+// returns a pointer to it.  This is useful when assigning optional parameters.
+func Float64(v float64) *float64 {
+	p := new(float64)
+	*p = v
+	return p
+}
+
 // String is a helper routine that allocates a new string value to store v and
 // returns a pointer to it.  This is useful when assigning optional parameters.
 func String(v string) *string {

--- a/btcjson/walletsvrresults.go
+++ b/btcjson/walletsvrresults.go
@@ -5,12 +5,18 @@
 package btcjson
 
 // GetTransactionDetailsResult models the details data from the gettransaction command.
+//
+// This models the "short" version of the ListTransactionsResult type, which
+// excludes fields common to the transaction.  These common fields are instead
+// part of the GetTransactionResult.
 type GetTransactionDetailsResult struct {
-	Account  string  `json:"account"`
-	Address  string  `json:"address,omitempty"`
-	Category string  `json:"category"`
-	Amount   float64 `json:"amount"`
-	Fee      float64 `json:"fee,omitempty"`
+	Account           string   `json:"account"`
+	Address           string   `json:"address,omitempty"`
+	Amount            float64  `json:"amount"`
+	Category          string   `json:"category"`
+	InvolvesWatchOnly bool     `json:"involveswatchonly,omitempty"`
+	Fee               *float64 `json:"fee,omitempty"`
+	Vout              uint32   `json:"vout"`
 }
 
 // GetTransactionResult models the data from the gettransaction command.
@@ -52,22 +58,24 @@ type InfoWalletResult struct {
 
 // ListTransactionsResult models the data from the listtransactions command.
 type ListTransactionsResult struct {
-	Account         string   `json:"account"`
-	Address         string   `json:"address,omitempty"`
-	Category        string   `json:"category"`
-	Amount          float64  `json:"amount"`
-	Fee             float64  `json:"fee"`
-	Confirmations   int64    `json:"confirmations"`
-	Generated       bool     `json:"generated,omitempty"`
-	BlockHash       string   `json:"blockhash,omitempty"`
-	BlockIndex      int64    `json:"blockindex,omitempty"`
-	BlockTime       int64    `json:"blocktime,omitempty"`
-	TxID            string   `json:"txid"`
-	WalletConflicts []string `json:"walletconflicts"`
-	Time            int64    `json:"time"`
-	TimeReceived    int64    `json:"timereceived"`
-	Comment         string   `json:"comment,omitempty"`
-	OtherAccount    string   `json:"otheraccount"`
+	Account           string   `json:"account"`
+	Address           string   `json:"address,omitempty"`
+	Amount            float64  `json:"amount"`
+	BlockHash         string   `json:"blockhash,omitempty"`
+	BlockIndex        *int64   `json:"blockindex,omitempty"`
+	BlockTime         int64    `json:"blocktime,omitempty"`
+	Category          string   `json:"category"`
+	Confirmations     int64    `json:"confirmations"`
+	Fee               *float64 `json:"fee,omitempty"`
+	Generated         bool     `json:"generated,omitempty"`
+	InvolvesWatchOnly bool     `json:"involveswatchonly,omitempty"`
+	Time              int64    `json:"time"`
+	TimeReceived      int64    `json:"timereceived"`
+	TxID              string   `json:"txid"`
+	Vout              uint32   `json:"vout"`
+	WalletConflicts   []string `json:"walletconflicts"`
+	Comment           string   `json:"comment,omitempty"`
+	OtherAccount      string   `json:"otheraccount,omitempty"`
 }
 
 // ListReceivedByAccountResult models the data from the listreceivedbyaccount

--- a/btcjson/walletsvrwsntfns_test.go
+++ b/btcjson/walletsvrwsntfns_test.go
@@ -72,7 +72,7 @@ func TestWalletSvrWsNtfns(t *testing.T) {
 		{
 			name: "newtx",
 			newNtfn: func() (interface{}, error) {
-				return btcjson.NewCmd("newtx", "acct", `{"account":"acct","address":"1Address","category":"send","amount":1.5,"fee":0.0001,"confirmations":1,"txid":"456","walletconflicts":[],"time":12345678,"timereceived":12345876,"otheraccount":"otheracct"}`)
+				return btcjson.NewCmd("newtx", "acct", `{"account":"acct","address":"1Address","category":"send","amount":1.5,"fee":0.0001,"confirmations":1,"txid":"456","walletconflicts":[],"time":12345678,"timereceived":12345876,"vout":789,"otheraccount":"otheracct"}`)
 			},
 			staticNtfn: func() interface{} {
 				result := btcjson.ListTransactionsResult{
@@ -80,17 +80,18 @@ func TestWalletSvrWsNtfns(t *testing.T) {
 					Address:         "1Address",
 					Category:        "send",
 					Amount:          1.5,
-					Fee:             0.0001,
+					Fee:             btcjson.Float64(0.0001),
 					Confirmations:   1,
 					TxID:            "456",
 					WalletConflicts: []string{},
 					Time:            12345678,
 					TimeReceived:    12345876,
+					Vout:            789,
 					OtherAccount:    "otheracct",
 				}
 				return btcjson.NewNewTxNtfn("acct", result)
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"newtx","params":["acct",{"account":"acct","address":"1Address","category":"send","amount":1.5,"fee":0.0001,"confirmations":1,"txid":"456","walletconflicts":[],"time":12345678,"timereceived":12345876,"otheraccount":"otheracct"}],"id":null}`,
+			marshalled: `{"jsonrpc":"1.0","method":"newtx","params":["acct",{"account":"acct","address":"1Address","amount":1.5,"category":"send","confirmations":1,"fee":0.0001,"time":12345678,"timereceived":12345876,"txid":"456","vout":789,"walletconflicts":[],"otheraccount":"otheracct"}],"id":null}`,
 			unmarshalled: &btcjson.NewTxNtfn{
 				Account: "acct",
 				Details: btcjson.ListTransactionsResult{
@@ -98,12 +99,13 @@ func TestWalletSvrWsNtfns(t *testing.T) {
 					Address:         "1Address",
 					Category:        "send",
 					Amount:          1.5,
-					Fee:             0.0001,
+					Fee:             btcjson.Float64(0.0001),
 					Confirmations:   1,
 					TxID:            "456",
 					WalletConflicts: []string{},
 					Time:            12345678,
 					TimeReceived:    12345876,
+					Vout:            789,
 					OtherAccount:    "otheracct",
 				},
 			},


### PR DESCRIPTION
The following changes were made to ListTransactionsResult (which
models the long result format used by listtransactions,
listsinceblock, etc.):

  - Fee made optional (float64 -> *float64 + omitempty)
  - BlockIndex made optional (int64 + omitempty -> *int64 + omitempty)
  - InvolvesWatchOnly added (bool + omitempty)
  - Vout added (uint32)

The following changes were made to GetTransactionDetailsResult (which
models the short result format of listtransactions):

  - InvolvesWatchOnly added (bool + omitempty)
  - Fee added (*float64 + omitempty)
  - Vout added (uint32)

The combination of pointer types and the omitempty struct tag allow
excluding the field from the JSON object, or including it with the
zero value.  This is useful in particular for the fee fields, which
should be included whenever the category is "send" even if the fee is
zero.  Other optional fields which are only added to the result object
with non-zero values (such as includeswatchonly) can be reduced to
simply an omitempty tag without the pointer type.