### PR TITLE
Add new option --torisolation

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -63,7 +63,8 @@ Application Options:
       --onionuser=         Username for onion proxy server
       --onionpass=         Password for onion proxy server
       --noonion=           Disable connecting to tor hidden services
-      --tor=               Specifies the proxy server used is a Tor node
+      --torisolation       Enable Tor stream isolation by randomizing user
+                           credentials for each connection.
       --testnet=           Use the test network
       --regtest=           Use the regression test network
       --nocheckpoints=     Disable built-in checkpoints.  Don't do this unless

--- a/docs/configuring_tor.md
+++ b/docs/configuring_tor.md
@@ -12,16 +12,21 @@
 4.1 [Description](#BridgeDescription)<br />
 4.2 [Command Line Example](#BridgeCLIExample)<br />
 4.3 [Config File Example](#BridgeConfigFileExample)<br />
+5. [Tor Stream Isolation](#TorStreamIsolation)<br />
+5.1 [Description](#TorStreamIsolationDescription)<br />
+5.2 [Command Line Example](#TorStreamIsolationCLIExample)<br />
+5.3 [Config File Example](#TorStreamIsolationFileExample)<br />
 
 <a name="Overview" />
 ### 1. Overview
 
 btcd provides full support for anonymous networking via the
 [Tor Project](https://www.torproject.org/), including [client-only](#Client)
-and [hidden service](#HiddenService) configurations.  In addition, btcd supports
-a hybrid, [bridge mode](#Bridge) which is not anonymous, but allows it to
-operate as a bridge between regular nodes and hidden service nodes without
-routing the regular connections through Tor.
+and [hidden service](#HiddenService) configurations along with
+[stream isolation](#TorStreamIsolation).  In addition, btcd supports a hybrid,
+[bridge mode](#Bridge) which is not anonymous, but allows it to operate as a
+bridge between regular nodes and hidden service nodes without routing the
+regular connections through Tor.
 
 While it is easier to only run as a client, it is more beneficial to the Bitcoin
 network to run as both a client and a server so others may connect to you to as
@@ -153,4 +158,33 @@ $ ./btcd --onion=127.0.0.1:9050 --externalip=fooanon.onion
 
 onion=127.0.0.1:9050
 externalip=fooanon.onion
+```
+
+<a name="TorStreamIsolation" />
+### 5. Tor Stream Isolation
+
+<a name="TorStreamIsolationDescription" />
+**5.1 Description**<br />
+
+Tor stream isolation forces Tor to build a new circuit for each connection
+making it harder to correlate connections.
+
+btcd provides support for Tor stream isolation by using the `--torisolation`
+flag.  This option requires --proxy or --onionproxy to be set.
+
+<a name="TorStreamIsolationCLIExample" />
+**5.2 Command Line Example**<br />
+
+```bash
+$ ./btcd --proxy=127.0.0.1:9050 --torisolation
+```
+
+<a name="TorStreamIsolationFileExample" />
+**5.3 Config File Example**<br />
+
+```text
+[Application Options]
+
+proxy=127.0.0.1:9050
+torisolation=1
 ```

--- a/sample-btcd.conf
+++ b/sample-btcd.conf
@@ -41,6 +41,11 @@
 ; onionuser=
 ; onionpass=
 
+; Enable Tor stream isolation by randomizing proxy user credentials resulting in
+; Tor creating a new circuit for each connection.  This makes it more difficult
+; to correlate connections.
+; torisolation=1
+
 ; Use Universal Plug and Play (UPnP) to automatically open the listen port
 ; and obtain the external IP address from supported devices.  NOTE: This option
 ; will have no effect if exernal IP addresses are specified.


### PR DESCRIPTION
Tor stream isolation randomizes proxy user credentials resulting in
Tor creating a new circuit for each connection.  This makes it more
difficult to correlate connections.

Idea from Wladimir J. van der Laan via Bitcoin Core.