### PR TITLE
mempool: Correct cmd field for rejected txns.

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -499,7 +499,7 @@ func (b *blockManager) handleTxMsg(tmsg *txMsg) {
 		// Convert the error into an appropriate reject message and
 		// send it.
 		code, reason := errToRejectErr(err)
-		tmsg.peer.PushRejectMsg(wire.CmdBlock, code, reason, txHash,
+		tmsg.peer.PushRejectMsg(wire.CmdTx, code, reason, txHash,
 			false)
 		return
 	}


### PR DESCRIPTION
This pull request corrects an issue where the reject message sent in response to rejected transactions had the Cmd field set to "block" instead of "tx".

Fixes #436.