### PR TITLE
btcec: Mitigate timing attacks while using btcec.Decrypt

### DIFF
--- a/btcec/ciphering.go
+++ b/btcec/ciphering.go
@@ -178,7 +178,7 @@ func Decrypt(priv *PrivateKey, in []byte) ([]byte, error) {
 	hm := hmac.New(sha256.New, keyM)
 	hm.Write(in[:len(in)-sha256.Size]) // everything is hashed
 	expectedMAC := hm.Sum(nil)
-	if !bytes.Equal(messageMAC, expectedMAC) {
+	if !hmac.Equal(messageMAC, expectedMAC) {
 		return nil, ErrInvalidMAC
 	}
 


### PR DESCRIPTION
A side channel attack vector in btcec.Decrypt has been closed. bytes.Equal returns false as soon as the first byte fails to match. An attacker could guess the correct HMAC using careful timing analysis and then spoof it. Changing it to hmac.Equal, which has a constant run time, ensures that this doesn't happen.