### PR TITLE
Add new option --maxoutboundpeers.

### DIFF
--- a/server.go
+++ b/server.go
@@ -659,7 +659,7 @@ func (s *server) peerHandler() {
 		persistentPeers:  make(map[*peer]struct{}),
 		outboundPeers:    make(map[*peer]struct{}),
 		banned:           make(map[string]time.Time),
-		maxOutboundPeers: defaultMaxOutbound,
+		maxOutboundPeers: cfg.MaxOutboundPeers,
 		outboundGroups:   make(map[string]int),
 	}
 	if cfg.MaxPeers < state.maxOutboundPeers {


### PR DESCRIPTION
The --maxoutboundpeers option allows the user to set the maximum
number of outbound peers to connect to.

Closes #434