### PR TITLE
Fix incorrect ip connection attempt logic.

### DIFF
--- a/server.go
+++ b/server.go
@@ -769,8 +769,7 @@ out:
 
 			// only allow recent nodes (10mins) after we failed 30
 			// times
-			if time.Now().After(addr.LastAttempt().Add(10*time.Minute)) &&
-				tries < 30 {
+			if tries < 30 && time.Now().Sub(addr.LastAttempt()) < 10*time.Minute {
 				continue
 			}
 


### PR DESCRIPTION
The comment says "only allow recent nodes (10mins) after we failed 30 times", but the server actually did the opposite and allowed only recent nodes before 30 failed connection attempts. This corrects the server's behavior.

https://golang.org/pkg/time/#Time.After 
"(t Time) After(u Time) After reports whether the time instant t is after u. "

So, previously, if now is AFTER the last connect attempt + ten minutes, in other words, if the last connect attempt was greater than ten minutes ago, don't bother trying to connect! 