### PR TITLE
txscript: Move lockTimeThreshold to txscript

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -23,13 +23,6 @@ const (
 	// allowed for a block.  It is a fraction of the max block payload size.
 	MaxSigOpsPerBlock = wire.MaxBlockPayload / 50
 
-	// lockTimeThreshold is the number below which a lock time is
-	// interpreted to be a block number.  Since an average of one block
-	// is generated per 10 minutes, this allows blocks for about 9,512
-	// years.  However, if the field is interpreted as a timestamp, given
-	// the lock time is a uint32, the max is sometime around 2106.
-	lockTimeThreshold uint32 = 5e8 // Tue Nov 5 00:53:20 1985 UTC
-
 	// MaxTimeOffsetSeconds is the maximum number of seconds a block time
 	// is allowed to be ahead of the current time.  This is currently 2
 	// hours.
@@ -146,10 +139,10 @@ func IsFinalizedTransaction(tx *btcutil.Tx, blockHeight int64, blockTime time.Ti
 
 	// The lock time field of a transaction is either a block height at
 	// which the transaction is finalized or a timestamp depending on if the
-	// value is before the lockTimeThreshold.  When it is under the
+	// value is before the txscript.LockTimeThreshold.  When it is under the
 	// threshold it is a block height.
 	blockTimeOrHeight := int64(0)
-	if lockTime < lockTimeThreshold {
+	if lockTime < txscript.LockTimeThreshold {
 		blockTimeOrHeight = blockHeight
 	} else {
 		blockTimeOrHeight = blockTime.Unix()

--- a/log.go
+++ b/log.go
@@ -21,13 +21,6 @@ import (
 )
 
 const (
-	// lockTimeThreshold is the number below which a lock time is
-	// interpreted to be a block number.  Since an average of one block
-	// is generated per 10 minutes, this allows blocks for about 9,512
-	// years.  However, if the field is interpreted as a timestamp, given
-	// the lock time is a uint32, the max is sometime around 2106.
-	lockTimeThreshold uint32 = 5e8 // Tue Nov 5 00:53:20 1985 UTC
-
 	// maxRejectReasonLen is the maximum length of a sanitized reject reason
 	// that will be logged.
 	maxRejectReasonLen = 250
@@ -214,9 +207,9 @@ func directionString(inbound bool) string {
 func formatLockTime(lockTime uint32) string {
 	// The lock time field of a transaction is either a block height at
 	// which the transaction is finalized or a timestamp depending on if the
-	// value is before the lockTimeThreshold.  When it is under the
+	// value is before the txscript.LockTimeThreshold.  When it is under the
 	// threshold it is a block height.
-	if lockTime < lockTimeThreshold {
+	if lockTime < txscript.LockTimeThreshold {
 		return fmt.Sprintf("height %d", lockTime)
 	}
 

--- a/txscript/consensus.go
+++ b/txscript/consensus.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2015 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package txscript
+
+const (
+	// LockTimeThreshold is the number below which a lock time is
+	// interpreted to be a block number.  Since an average of one block
+	// is generated per 10 minutes, this allows blocks for about 9,512
+	// years.  However, if the field is interpreted as a timestamp, given
+	// the lock time is a uint32, the max is sometime around 2106.
+	LockTimeThreshold uint32 = 5e8 // Tue Nov 5 00:53:20 1985 UTC
+)


### PR DESCRIPTION
Move lockTimeThreshold to txscript and export it.  This is a
consensus value which txscript will need in an upcoming diff.