### PR TITLE
Use NewMsgInvSizeHint when we know the size.

### DIFF
--- a/peer.go
+++ b/peer.go
@@ -1670,7 +1670,7 @@ out:
 
 			// Create and send as many inv messages as needed to
 			// drain the inventory send queue.
-			invMsg := wire.NewMsgInv()
+			invMsg := wire.NewMsgInvSizeHint(uint(invSendQueue.Len()))
 			for e := invSendQueue.Front(); e != nil; e = invSendQueue.Front() {
 				iv := invSendQueue.Remove(e).(*wire.InvVect)
 
@@ -1685,7 +1685,7 @@ out:
 					waiting = queuePacket(
 						outMsg{msg: invMsg},
 						pendingMsgs, waiting)
-					invMsg = wire.NewMsgInv()
+					invMsg = wire.NewMsgInvSizeHint(uint(invSendQueue.Len()))
 				}
 
 				// Add the inventory that is being relayed to


### PR DESCRIPTION
When trickling inv's to peers, allocate for the number of inv's
in the queue instead of the default 1000.  This should save on
memory.