### PR TITLE
Correct reconnect handling for persistent peers.

### DIFF
--- a/server.go
+++ b/server.go
@@ -39,10 +39,6 @@ const (
 	// server.
 	supportedServices = wire.SFNodeNetwork
 
-	// connectionRetryInterval is the amount of time to wait in between
-	// retries when connecting to persistent peers.
-	connectionRetryInterval = time.Second * 10
-
 	// defaultMaxOutbound is the default number of max outbound peers.
 	defaultMaxOutbound = 8
 )
@@ -307,7 +303,9 @@ func (s *server) handleDonePeerMsg(state *peerState, p *peer) {
 			// Issue an asynchronous reconnect if the peer was a
 			// persistent outbound connection.
 			if !p.inbound && p.persistent && atomic.LoadInt32(&s.shutdown) == 0 {
+				delete(list, e)
 				e = newOutboundPeer(s, p.addr, true, p.retryCount+1)
+				list[e] = struct{}{}
 				return
 			}
 			if !p.inbound {


### PR DESCRIPTION
This pull request correctly replaces persistent peers that are being retried in the list of persistent peers so it will continue to be retried as intended.

Also, it limits the maximum retry interval for persistent peers to 5 minutes.

Fixes #463.