### PR TITLE
Implmement BlockHeader BtcEncode/BtcDecode.

### DIFF
--- a/wire/blockheader.go
+++ b/wire/blockheader.go
@@ -56,6 +56,22 @@ func (h *BlockHeader) BlockSha() ShaHash {
 	return DoubleSha256SH(buf.Bytes())
 }
 
+// BtcDecode decodes r using the bitcoin protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+// See Deserialize for decoding block headers stored to disk, such as in a
+// database, as opposed to decoding block headers from the wire.
+func (h *BlockHeader) BtcDecode(r io.Reader, pver uint32) error {
+	return readBlockHeader(r, pver, h)
+}
+
+// BtcEncode encodes the receiver to w using the bitcoin protocol encoding.
+// This is part of the Message interface implementation.
+// See Serialize for encoding block headers to be stored to disk, such as in a
+// database, as opposed to encoding block headers for the wire.
+func (h *BlockHeader) BtcEncode(w io.Writer, pver uint32) error {
+	return writeBlockHeader(w, pver, h)
+}
+
 // Deserialize decodes a block header from r into the receiver using a format
 // that is suitable for long-term storage such as a database while respecting
 // the Version field.

--- a/wire/blockheader_test.go
+++ b/wire/blockheader_test.go
@@ -50,6 +50,7 @@ func TestBlockHeader(t *testing.T) {
 // protocol versions.
 func TestBlockHeaderWire(t *testing.T) {
 	nonce := uint32(123123) // 0x1e0f3
+	pver := uint32(70001)
 
 	// baseBlockHdr is used in the various tests as a baseline BlockHeader.
 	bits := uint32(0x1d00ffff)
@@ -140,6 +141,18 @@ func TestBlockHeaderWire(t *testing.T) {
 			continue
 		}
 
+		buf.Reset()
+		err = test.in.BtcEncode(&buf, pver)
+		if err != nil {
+			t.Errorf("BtcEncode #%d error %v", i, err)
+			continue
+		}
+		if !bytes.Equal(buf.Bytes(), test.buf) {
+			t.Errorf("BtcEncode #%d\n got: %s want: %s", i,
+				spew.Sdump(buf.Bytes()), spew.Sdump(test.buf))
+			continue
+		}
+
 		// Decode the block header from wire format.
 		var bh wire.BlockHeader
 		rbuf := bytes.NewReader(test.buf)
@@ -150,6 +163,18 @@ func TestBlockHeaderWire(t *testing.T) {
 		}
 		if !reflect.DeepEqual(&bh, test.out) {
 			t.Errorf("readBlockHeader #%d\n got: %s want: %s", i,
+				spew.Sdump(&bh), spew.Sdump(test.out))
+			continue
+		}
+
+		rbuf = bytes.NewReader(test.buf)
+		err = bh.BtcDecode(rbuf, pver)
+		if err != nil {
+			t.Errorf("BtcDecode #%d error %v", i, err)
+			continue
+		}
+		if !reflect.DeepEqual(&bh, test.out) {
+			t.Errorf("BtcDecode #%d\n got: %s want: %s", i,
 				spew.Sdump(&bh), spew.Sdump(test.out))
 			continue
 		}


### PR DESCRIPTION
At the current time, there is no difference between the wire encoding
at protocol version 0 and the stable long-term storage format.  These
methods are simply for consistency with the other types.