### PR TITLE
rpcserver: Allow tx result creation without block.

### DIFF
--- a/rpcwebsocket.go
+++ b/rpcwebsocket.go
@@ -487,8 +487,8 @@ func (m *wsNotificationManager) notifyForNewTx(clients map[chan struct{}]*wsClie
 			}
 
 			net := m.server.server.chainParams
-			rawTx, err := createTxRawResult(net, txShaStr, mtx, nil,
-				0, nil)
+			rawTx, err := createTxRawResult(net, mtx, txShaStr, nil,
+				"", 0, 0)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
This pull request modifies the `createTxRawResult` code path along with callers to work with block headers as opposed to `btcutil.Block`s.  This in turn allows the code in `handleGetRawTransaction` and `handleSearchRawTransactions` to perform a much cheaper block header load as opposed to a full block load.

While here, also very slightly optimize the `createVinList` function to avoid creating a `util.Tx` wrapper and to take advantage of the `btcutil.Amount` type added after the function was originally written