### PR TITLE
Convert block heights to int32.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -30,7 +30,7 @@ func (b *BlockChain) maybeAcceptBlock(block *btcutil.Block, flags BehaviorFlags)
 
 	// The height of this block is one more than the referenced previous
 	// block.
-	blockHeight := int64(0)
+	blockHeight := int32(0)
 	if prevNode != nil {
 		blockHeight = prevNode.height + 1
 	}

--- a/blockchain/blocklocator.go
+++ b/blockchain/blocklocator.go
@@ -48,8 +48,8 @@ func (b *BlockChain) BlockLocatorFromHash(hash *wire.ShaHash) BlockLocator {
 	// Attempt to find the height of the block that corresponds to the
 	// passed hash, and if it's on a side chain, also find the height at
 	// which it forks from the main chain.
-	blockHeight := int64(-1)
-	forkHeight := int64(-1)
+	blockHeight := int32(-1)
+	forkHeight := int32(-1)
 	node, exists := b.index[*hash]
 	if !exists {
 		// Try to look up the height for passed block hash.  Assume an
@@ -80,7 +80,7 @@ func (b *BlockChain) BlockLocatorFromHash(hash *wire.ShaHash) BlockLocator {
 	// in the BlockLocator comment and make sure to leave room for the
 	// final genesis hash.
 	iterNode := node
-	increment := int64(1)
+	increment := int32(1)
 	for len(locator) < wire.MaxBlockLocatorsPerMsg-1 {
 		// Once there are 10 locators, exponentially increase the
 		// distance between each block locator.

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -58,7 +58,7 @@ type blockNode struct {
 	parentHash *wire.ShaHash
 
 	// height is the position in the block chain.
-	height int64
+	height int32
 
 	// workSum is the total amount of work in the chain up to and including
 	// this node.
@@ -79,7 +79,7 @@ type blockNode struct {
 // completely disconnected from the chain and the workSum value is just the work
 // for the passed block.  The work sum is updated accordingly when the node is
 // inserted into a chain.
-func newBlockNode(blockHeader *wire.BlockHeader, blockSha *wire.ShaHash, height int64) *blockNode {
+func newBlockNode(blockHeader *wire.BlockHeader, blockSha *wire.ShaHash, height int32) *blockNode {
 	// Make a copy of the hash so the node doesn't keep a reference to part
 	// of the full block/block header preventing it from being garbage
 	// collected.
@@ -144,7 +144,7 @@ func removeChildNode(children []*blockNode, node *blockNode) []*blockNode {
 type BlockChain struct {
 	db                  database.Db
 	chainParams         *chaincfg.Params
-	checkpointsByHeight map[int64]*chaincfg.Checkpoint
+	checkpointsByHeight map[int32]*chaincfg.Checkpoint
 	notifications       NotificationCallback
 	root                *blockNode
 	bestChain           *blockNode
@@ -384,7 +384,7 @@ func (b *BlockChain) GenerateInitialIndex() error {
 
 		// Start at the next block after the latest one on the next loop
 		// iteration.
-		start += int64(len(hashList))
+		start += int32(len(hashList))
 	}
 
 	return nil
@@ -567,7 +567,7 @@ func (b *BlockChain) pruneBlockNodes() error {
 	// the latter loads the node and the goal is to find nodes still in
 	// memory that can be pruned.
 	newRootNode := b.bestChain
-	for i := int64(0); i < minMemoryNodes-1 && newRootNode != nil; i++ {
+	for i := int32(0); i < minMemoryNodes-1 && newRootNode != nil; i++ {
 		newRootNode = newRootNode.parent
 	}
 
@@ -1069,9 +1069,9 @@ func (b *BlockChain) IsCurrent(timeSource MedianTimeSource) bool {
 // interested in receiving notifications.
 func New(db database.Db, params *chaincfg.Params, c NotificationCallback) *BlockChain {
 	// Generate a checkpoint by height map from the provided checkpoints.
-	var checkpointsByHeight map[int64]*chaincfg.Checkpoint
+	var checkpointsByHeight map[int32]*chaincfg.Checkpoint
 	if len(params.Checkpoints) > 0 {
-		checkpointsByHeight = make(map[int64]*chaincfg.Checkpoint)
+		checkpointsByHeight = make(map[int32]*chaincfg.Checkpoint)
 		for i := range params.Checkpoints {
 			checkpoint := &params.Checkpoints[i]
 			checkpointsByHeight[checkpoint.Height] = checkpoint

--- a/blockchain/checkpoints.go
+++ b/blockchain/checkpoints.go
@@ -59,7 +59,7 @@ func (b *BlockChain) LatestCheckpoint() *chaincfg.Checkpoint {
 // verifyCheckpoint returns whether the passed block height and hash combination
 // match the hard-coded checkpoint data.  It also returns true if there is no
 // checkpoint data for the passed block height.
-func (b *BlockChain) verifyCheckpoint(height int64, hash *wire.ShaHash) bool {
+func (b *BlockChain) verifyCheckpoint(height int32, hash *wire.ShaHash) bool {
 	if b.noCheckpoints || len(b.chainParams.Checkpoints) == 0 {
 		return true
 	}

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -184,7 +184,7 @@ func loadTxStore(filename string) (blockchain.TxStore, error) {
 		if err != nil {
 			return nil, err
 		}
-		txD.BlockHeight = int64(uintBuf)
+		txD.BlockHeight = int32(uintBuf)
 
 		// Num spent bits.
 		err = binary.Read(r, binary.LittleEndian, &uintBuf)

--- a/blockchain/difficulty.go
+++ b/blockchain/difficulty.go
@@ -25,7 +25,7 @@ const (
 	// BlocksPerRetarget is the number of blocks between each difficulty
 	// retarget.  It is calculated based on the desired block generation
 	// rate.
-	BlocksPerRetarget = int64(targetTimespan / targetSpacing)
+	BlocksPerRetarget = int32(targetTimespan / targetSpacing)
 
 	// retargetAdjustmentFactor is the adjustment factor used to limit
 	// the minimum and maximum amount of adjustment that can occur between
@@ -295,7 +295,7 @@ func (b *BlockChain) calcNextRequiredDifficulty(lastNode *blockNode, newBlockTim
 	// Get the block node at the previous retarget (targetTimespan days
 	// worth of blocks).
 	firstNode := lastNode
-	for i := int64(0); i < BlocksPerRetarget-1 && firstNode != nil; i++ {
+	for i := int32(0); i < BlocksPerRetarget-1 && firstNode != nil; i++ {
 		// Get the previous block node.  This function is used over
 		// simply accessing firstNode.parent directly as it will
 		// dynamically create previous block nodes as needed.  This

--- a/blockchain/internal_test.go
+++ b/blockchain/internal_test.go
@@ -19,7 +19,7 @@ import (
 
 // TstSetCoinbaseMaturity makes the ability to set the coinbase maturity
 // available to the test package.
-func TstSetCoinbaseMaturity(maturity int64) {
+func TstSetCoinbaseMaturity(maturity int32) {
 	coinbaseMaturity = maturity
 }
 

--- a/blockchain/txlookup.go
+++ b/blockchain/txlookup.go
@@ -17,7 +17,7 @@ import (
 type TxData struct {
 	Tx          *btcutil.Tx
 	Hash        *wire.ShaHash
-	BlockHeight int64
+	BlockHeight int32
 	Spent       []bool
 	Err         error
 }

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -82,7 +82,7 @@ func TestCheckSerializedHeight(t *testing.T) {
 
 	tests := []struct {
 		sigScript  []byte // Serialized data
-		wantHeight int64  // Expected height
+		wantHeight int32  // Expected height
 		err        error  // Expected error type
 	}{
 		// No serialized height length.

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -150,7 +150,7 @@ type pauseMsg struct {
 // headerNode is used as a node in a list of headers that are linked together
 // between checkpoints.
 type headerNode struct {
-	height int64
+	height int32
 	sha    *wire.ShaHash
 }
 
@@ -163,7 +163,7 @@ type headerNode struct {
 type chainState struct {
 	sync.Mutex
 	newestHash        *wire.ShaHash
-	newestHeight      int64
+	newestHeight      int32
 	pastMedianTime    time.Time
 	pastMedianTimeErr error
 }
@@ -172,7 +172,7 @@ type chainState struct {
 // chain.
 //
 // This function is safe for concurrent access.
-func (c *chainState) Best() (*wire.ShaHash, int64) {
+func (c *chainState) Best() (*wire.ShaHash, int32) {
 	c.Lock()
 	defer c.Unlock()
 
@@ -207,7 +207,7 @@ type blockManager struct {
 
 // resetHeaderState sets the headers-first mode state to values appropriate for
 // syncing from a new peer.
-func (b *blockManager) resetHeaderState(newestHash *wire.ShaHash, newestHeight int64) {
+func (b *blockManager) resetHeaderState(newestHash *wire.ShaHash, newestHeight int32) {
 	b.headersFirstMode = false
 	b.headerList.Init()
 	b.startHeader = nil
@@ -225,7 +225,7 @@ func (b *blockManager) resetHeaderState(newestHash *wire.ShaHash, newestHeight i
 // This allows fast access to chain information since btcchain is currently not
 // safe for concurrent access and the block manager is typically quite busy
 // processing block and inventory.
-func (b *blockManager) updateChainState(newestHash *wire.ShaHash, newestHeight int64) {
+func (b *blockManager) updateChainState(newestHash *wire.ShaHash, newestHeight int32) {
 	b.chainState.Lock()
 	defer b.chainState.Unlock()
 
@@ -243,7 +243,7 @@ func (b *blockManager) updateChainState(newestHash *wire.ShaHash, newestHeight i
 // It returns nil when there is not one either because the height is already
 // later than the final checkpoint or some other reason such as disabled
 // checkpoints.
-func (b *blockManager) findNextHeaderCheckpoint(height int64) *chaincfg.Checkpoint {
+func (b *blockManager) findNextHeaderCheckpoint(height int32) *chaincfg.Checkpoint {
 	// There is no next checkpoint if checkpoints are disabled or there are
 	// none for this current network.
 	if cfg.DisableCheckpoints {
@@ -524,7 +524,7 @@ func (b *blockManager) current() bool {
 	// TODO(oga) we can get chain to return the height of each block when we
 	// parse an orphan, which would allow us to update the height of peers
 	// from what it was at initial handshake.
-	if err != nil || height < int64(b.syncPeer.lastBlock) {
+	if err != nil || height < b.syncPeer.lastBlock {
 		return false
 	}
 	return true

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -44,7 +44,7 @@ var (
 // documentation for blockchain.IsCheckpointCandidate for details on the
 // selection criteria.
 type Checkpoint struct {
-	Height int64
+	Height int32
 	Hash   *wire.ShaHash
 }
 

--- a/chainindexer.go
+++ b/chainindexer.go
@@ -69,8 +69,8 @@ type addrIndexer struct {
 	addrIndexJobs   chan *indexBlockMsg
 	writeRequests   chan *writeIndexReq
 	progressLogger  *blockProgressLogger
-	currentIndexTip int64
-	chainTip        int64
+	currentIndexTip int32
+	chainTip        int32
 	sync.Mutex
 }
 

--- a/cmd/dropafter/dropafter.go
+++ b/cmd/dropafter/dropafter.go
@@ -167,7 +167,7 @@ var errBadShaPrefix = errors.New("invalid prefix")
 var errBadShaLen = errors.New("invalid len")
 var errBadShaChar = errors.New("invalid character")
 
-func parsesha(argstr string) (argtype int, height int64, psha *wire.ShaHash, err error) {
+func parsesha(argstr string) (argtype int, height int32, psha *wire.ShaHash, err error) {
 	var sha wire.ShaHash
 
 	var hashbuf string
@@ -189,7 +189,7 @@ func parsesha(argstr string) (argtype int, height int64, psha *wire.ShaHash, err
 			var h int
 			h, err = strconv.Atoi(argstr)
 			if err == nil {
-				height = int64(h)
+				height = int32(h)
 				return
 			}
 			log.Infof("Unable to parse height %v, err %v", height, err)

--- a/cmd/findcheckpoint/findcheckpoint.go
+++ b/cmd/findcheckpoint/findcheckpoint.go
@@ -61,7 +61,7 @@ func findCandidates(db database.Db, latestHash *wire.ShaHash) ([]*chaincfg.Check
 
 	// The latest known block must be at least the last known checkpoint
 	// plus required checkpoint confirmations.
-	checkpointConfirmations := int64(blockchain.CheckpointConfirmations)
+	checkpointConfirmations := int32(blockchain.CheckpointConfirmations)
 	requiredHeight := latestCheckpoint.Height + checkpointConfirmations
 	if block.Height() < requiredHeight {
 		return nil, fmt.Errorf("the block database is only at height "+
@@ -79,7 +79,7 @@ func findCandidates(db database.Db, latestHash *wire.ShaHash) ([]*chaincfg.Check
 
 	// Loop backwards through the chain to find checkpoint candidates.
 	candidates := make([]*chaincfg.Checkpoint, 0, cfg.NumCandidates)
-	numTested := int64(0)
+	numTested := int32(0)
 	for len(candidates) < cfg.NumCandidates && block.Height() > requiredHeight {
 		// Display progress.
 		if numTested%progressInterval == 0 {

--- a/cpuminer.go
+++ b/cpuminer.go
@@ -165,7 +165,7 @@ func (m *CPUMiner) submitBlock(block *btcutil.Block) bool {
 // This function will return early with false when conditions that trigger a
 // stale block such as a new block showing up or periodically when there are
 // new transactions and enough time has elapsed without finding a solution.
-func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, blockHeight int64,
+func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, blockHeight int32,
 	ticker *time.Ticker, quit chan struct{}) bool {
 
 	// Choose a random extra nonce offset for this block template and

--- a/database/db.go
+++ b/database/db.go
@@ -28,7 +28,7 @@ var (
 
 // AllShas is a special value that can be used as the final sha when requesting
 // a range of shas by height to request them all.
-const AllShas = int64(^uint64(0) >> 1)
+const AllShas = int32(^uint32(0) >> 1)
 
 // Db defines a generic interface that is used to request and insert data into
 // the bitcoin block chain.  This interface is intended to be agnostic to actual
@@ -53,7 +53,7 @@ type Db interface {
 	FetchBlockBySha(sha *wire.ShaHash) (blk *btcutil.Block, err error)
 
 	// FetchBlockHeightBySha returns the block height for the given hash.
-	FetchBlockHeightBySha(sha *wire.ShaHash) (height int64, err error)
+	FetchBlockHeightBySha(sha *wire.ShaHash) (height int32, err error)
 
 	// FetchBlockHeaderBySha returns a wire.BlockHeader for the given
 	// sha.  The implementation may cache the underlying data if desired.
@@ -61,13 +61,13 @@ type Db interface {
 
 	// FetchBlockShaByHeight returns a block hash based on its height in the
 	// block chain.
-	FetchBlockShaByHeight(height int64) (sha *wire.ShaHash, err error)
+	FetchBlockShaByHeight(height int32) (sha *wire.ShaHash, err error)
 
 	// FetchHeightRange looks up a range of blocks by the start and ending
 	// heights.  Fetch is inclusive of the start height and exclusive of the
 	// ending height. To fetch all hashes from the start height until no
 	// more are present, use the special id `AllShas'.
-	FetchHeightRange(startHeight, endHeight int64) (rshalist []wire.ShaHash, err error)
+	FetchHeightRange(startHeight, endHeight int32) (rshalist []wire.ShaHash, err error)
 
 	// ExistsTxSha returns whether or not the given tx hash is present in
 	// the database
@@ -103,19 +103,19 @@ type Db interface {
 	// into the database.  The first block inserted into the database
 	// will be treated as the genesis block.  Every subsequent block insert
 	// requires the referenced parent block to already exist.
-	InsertBlock(block *btcutil.Block) (height int64, err error)
+	InsertBlock(block *btcutil.Block) (height int32, err error)
 
 	// NewestSha returns the hash and block height of the most recent (end)
 	// block of the block chain.  It will return the zero hash, -1 for
 	// the block height, and no error (nil) if there are not any blocks in
 	// the database yet.
-	NewestSha() (sha *wire.ShaHash, height int64, err error)
+	NewestSha() (sha *wire.ShaHash, height int32, err error)
 
 	// FetchAddrIndexTip returns the hash and block height of the most recent
 	// block which has had its address index populated. It will return
 	// ErrAddrIndexDoesNotExist along with a zero hash, and -1 if the
 	// addrindex hasn't yet been built up.
-	FetchAddrIndexTip() (sha *wire.ShaHash, height int64, err error)
+	FetchAddrIndexTip() (sha *wire.ShaHash, height int32, err error)
 
 	// UpdateAddrIndexForBlock updates the stored addrindex with passed
 	// index information for a particular block height. Additionally, it
@@ -124,7 +124,7 @@ type Db interface {
 	// transaction which is commited before the function returns.
 	// Addresses are indexed by the raw bytes of their base58 decoded
 	// hash160.
-	UpdateAddrIndexForBlock(blkSha *wire.ShaHash, height int64,
+	UpdateAddrIndexForBlock(blkSha *wire.ShaHash, height int32,
 		addrIndex BlockAddrIndex) error
 
 	// FetchTxsForAddr looks up and returns all transactions which either
@@ -162,7 +162,7 @@ type TxListReply struct {
 	Sha     *wire.ShaHash
 	Tx      *wire.MsgTx
 	BlkSha  *wire.ShaHash
-	Height  int64
+	Height  int32
 	TxSpent []bool
 	Err     error
 }

--- a/database/interface_test.go
+++ b/database/interface_test.go
@@ -26,7 +26,7 @@ type testContext struct {
 	t           *testing.T
 	dbType      string
 	db          database.Db
-	blockHeight int64
+	blockHeight int32
 	blockHash   *wire.ShaHash
 	block       *btcutil.Block
 	useSpends   bool
@@ -213,7 +213,7 @@ func testFetchBlockShaByHeight(tc *testContext) bool {
 
 func testFetchBlockShaByHeightErrors(tc *testContext) bool {
 	// Invalid heights must error and return a nil hash.
-	tests := []int64{-1, tc.blockHeight + 1, tc.blockHeight + 2}
+	tests := []int32{-1, tc.blockHeight + 1, tc.blockHeight + 2}
 	for i, wantHeight := range tests {
 		hashFromDb, err := tc.db.FetchBlockShaByHeight(wantHeight)
 		if err == nil {
@@ -545,7 +545,7 @@ func testInterface(t *testing.T, dbType string) {
 	context := testContext{t: t, dbType: dbType, db: db}
 
 	t.Logf("Loaded %d blocks for testing %s", len(blocks), dbType)
-	for height := int64(1); height < int64(len(blocks)); height++ {
+	for height := int32(1); height < int32(len(blocks)); height++ {
 		// Get the appropriate block and hash and update the test
 		// context accordingly.
 		block := blocks[height]
@@ -581,7 +581,7 @@ func testInterface(t *testing.T, dbType string) {
 	// Run the data integrity tests again after all blocks have been
 	// inserted to ensure the spend tracking  is working properly.
 	context.useSpends = true
-	for height := int64(0); height < int64(len(blocks)); height++ {
+	for height := int32(0); height < int32(len(blocks)); height++ {
 		// Get the appropriate block and hash and update the
 		// test context accordingly.
 		block := blocks[height]
@@ -613,14 +613,14 @@ func testInterface(t *testing.T, dbType string) {
 	   - DropAfterBlockBySha(*wire.ShaHash) (err error)
 	   x ExistsSha(sha *wire.ShaHash) (exists bool)
 	   x FetchBlockBySha(sha *wire.ShaHash) (blk *btcutil.Block, err error)
-	   x FetchBlockShaByHeight(height int64) (sha *wire.ShaHash, err error)
-	   - FetchHeightRange(startHeight, endHeight int64) (rshalist []wire.ShaHash, err error)
+	   x FetchBlockShaByHeight(height int32) (sha *wire.ShaHash, err error)
+	   - FetchHeightRange(startHeight, endHeight int32) (rshalist []wire.ShaHash, err error)
 	   x ExistsTxSha(sha *wire.ShaHash) (exists bool)
 	   x FetchTxBySha(txsha *wire.ShaHash) ([]*TxListReply, error)
 	   x FetchTxByShaList(txShaList []*wire.ShaHash) []*TxListReply
 	   x FetchUnSpentTxByShaList(txShaList []*wire.ShaHash) []*TxListReply
-	   x InsertBlock(block *btcutil.Block) (height int64, err error)
-	   x NewestSha() (sha *wire.ShaHash, height int64, err error)
+	   x InsertBlock(block *btcutil.Block) (height int32, err error)
+	   x NewestSha() (sha *wire.ShaHash, height int32, err error)
 	   - RollbackClose()
 	   - Sync()
 	*/

--- a/database/ldb/dup_test.go
+++ b/database/ldb/dup_test.go
@@ -48,7 +48,7 @@ func Test_dupTx(t *testing.T) {
 	// Populate with the fisrt 256 blocks, so we have blocks to 'mess with'
 	err = nil
 out:
-	for height := int64(0); height < int64(len(blocks)); height++ {
+	for height := int32(0); height < int32(len(blocks)); height++ {
 		block := blocks[height]
 
 		// except for NoVerify which does not allow lookups check inputs

--- a/database/ldb/insertremove_test.go
+++ b/database/ldb/insertremove_test.go
@@ -63,7 +63,7 @@ func testUnspentInsert(t *testing.T) {
 
 	blocks := loadblocks(t)
 endtest:
-	for height := int64(0); height < int64(len(blocks)); height++ {
+	for height := int32(0); height < int32(len(blocks)); height++ {
 
 		block := blocks[height]
 		// look up inputs to this tx

--- a/database/ldb/leveldb.go
+++ b/database/ldb/leveldb.go
@@ -29,7 +29,7 @@ var log = btclog.Disabled
 
 type tTxInsertData struct {
 	txsha   *wire.ShaHash
-	blockid int64
+	blockid int32
 	txoff   int
 	txlen   int
 	usedbuf []byte
@@ -47,14 +47,14 @@ type LevelDb struct {
 
 	lbatch *leveldb.Batch
 
-	nextBlock int64
+	nextBlock int32
 
 	lastBlkShaCached bool
 	lastBlkSha       wire.ShaHash
-	lastBlkIdx       int64
+	lastBlkIdx       int32
 
 	lastAddrIndexBlkSha wire.ShaHash
-	lastAddrIndexBlkIdx int64
+	lastAddrIndexBlkIdx int32
 
 	txUpdateMap      map[wire.ShaHash]*txUpdateObj
 	txSpentUpdateMap map[wire.ShaHash]*spentTxUpdate
@@ -98,9 +98,9 @@ func OpenDB(args ...interface{}) (database.Db, error) {
 	}
 
 	// Need to find last block and tx
-	var lastknownblock, nextunknownblock, testblock int64
+	var lastknownblock, nextunknownblock, testblock int32
 
-	increment := int64(100000)
+	increment := int32(100000)
 	ldb := db.(*LevelDb)
 
 	var lastSha *wire.ShaHash
@@ -345,7 +345,7 @@ func (db *LevelDb) DropAfterBlockBySha(sha *wire.ShaHash) (rerr error) {
 			db.txUpdateMap[*tx.Sha()] = &txUo
 		}
 		db.lBatch().Delete(shaBlkToKey(blksha))
-		db.lBatch().Delete(int64ToKey(height))
+		db.lBatch().Delete(int64ToKey(int64(height)))
 	}
 
 	// update the last block cache
@@ -361,7 +361,7 @@ func (db *LevelDb) DropAfterBlockBySha(sha *wire.ShaHash) (rerr error) {
 // database.  The first block inserted into the database will be treated as the
 // genesis block.  Every subsequent block insert requires the referenced parent
 // block to already exist.
-func (db *LevelDb) InsertBlock(block *btcutil.Block) (height int64, rerr error) {
+func (db *LevelDb) InsertBlock(block *btcutil.Block) (height int32, rerr error) {
 	db.dbLock.Lock()
 	defer db.dbLock.Unlock()
 	defer func() {

--- a/database/ldb/operational_test.go
+++ b/database/ldb/operational_test.go
@@ -72,7 +72,7 @@ func TestOperational(t *testing.T) {
 
 // testAddrIndexOperations ensures that all normal operations concerning
 // the optional address index function correctly.
-func testAddrIndexOperations(t *testing.T, db database.Db, newestBlock *btcutil.Block, newestSha *wire.ShaHash, newestBlockIdx int64) {
+func testAddrIndexOperations(t *testing.T, db database.Db, newestBlock *btcutil.Block, newestSha *wire.ShaHash, newestBlockIdx int32) {
 	// Metadata about the current addr index state should be unset.
 	sha, height, err := db.FetchAddrIndexTip()
 	if err != database.ErrAddrIndexDoesNotExist {
@@ -188,7 +188,7 @@ func testAddrIndexOperations(t *testing.T, db database.Db, newestBlock *btcutil.
 
 }
 
-func assertAddrIndexTipIsUpdated(db database.Db, t *testing.T, newestSha *wire.ShaHash, newestBlockIdx int64) {
+func assertAddrIndexTipIsUpdated(db database.Db, t *testing.T, newestSha *wire.ShaHash, newestBlockIdx int32) {
 	// Safe to ignore error, since height will be < 0 in "error" case.
 	sha, height, _ := db.FetchAddrIndexTip()
 	if newestBlockIdx != height {
@@ -215,7 +215,7 @@ func testOperationalMode(t *testing.T) {
 	defer testDb.cleanUpFunc()
 	err = nil
 out:
-	for height := int64(0); height < int64(len(testDb.blocks)); height++ {
+	for height := int32(0); height < int32(len(testDb.blocks)); height++ {
 		block := testDb.blocks[height]
 		mblock := block.MsgBlock()
 		var txneededList []*wire.ShaHash
@@ -306,7 +306,7 @@ func testBackout(t *testing.T) {
 	}
 
 	err = nil
-	for height := int64(0); height < int64(len(testDb.blocks)); height++ {
+	for height := int32(0); height < int32(len(testDb.blocks)); height++ {
 		if height == 100 {
 			t.Logf("Syncing at block height 100")
 			testDb.db.Sync()
@@ -417,7 +417,7 @@ func loadBlocks(t *testing.T, file string) (blocks []*btcutil.Block, err error) 
 
 	var block *btcutil.Block
 	err = nil
-	for height := int64(1); err == nil; height++ {
+	for height := int32(1); err == nil; height++ {
 		var rintbuf uint32
 		err = binary.Read(dr, binary.LittleEndian, &rintbuf)
 		if err == io.EOF {
@@ -456,18 +456,18 @@ func loadBlocks(t *testing.T, file string) (blocks []*btcutil.Block, err error) 
 
 func testFetchHeightRange(t *testing.T, db database.Db, blocks []*btcutil.Block) {
 
-	var testincrement int64 = 50
-	var testcnt int64 = 100
+	var testincrement int32 = 50
+	var testcnt int32 = 100
 
 	shanames := make([]*wire.ShaHash, len(blocks))
 
-	nBlocks := int64(len(blocks))
+	nBlocks := int32(len(blocks))
 
 	for i := range blocks {
 		shanames[i] = blocks[i].Sha()
 	}
 
-	for startheight := int64(0); startheight < nBlocks; startheight += testincrement {
+	for startheight := int32(0); startheight < nBlocks; startheight += testincrement {
 		endheight := startheight + testcnt
 
 		if endheight > nBlocks {
@@ -480,20 +480,20 @@ func testFetchHeightRange(t *testing.T, db database.Db, blocks []*btcutil.Block)
 		}
 
 		if endheight == database.AllShas {
-			if int64(len(shalist)) != nBlocks-startheight {
+			if int32(len(shalist)) != nBlocks-startheight {
 				t.Errorf("FetchHeightRange: expected A %v shas, got %v", nBlocks-startheight, len(shalist))
 			}
 		} else {
-			if int64(len(shalist)) != testcnt {
+			if int32(len(shalist)) != testcnt {
 				t.Errorf("FetchHeightRange: expected %v shas, got %v", testcnt, len(shalist))
 			}
 		}
 
 		for i := range shalist {
-			sha0 := *shanames[int64(i)+startheight]
+			sha0 := *shanames[int32(i)+startheight]
 			sha1 := shalist[i]
 			if sha0 != sha1 {
-				t.Errorf("FetchHeightRange: mismatch sha at %v requested range %v %v: %v %v ", int64(i)+startheight, startheight, endheight, sha0, sha1)
+				t.Errorf("FetchHeightRange: mismatch sha at %v requested range %v %v: %v %v ", int32(i)+startheight, startheight, endheight, sha0, sha1)
 			}
 		}
 	}

--- a/database/reorg_test.go
+++ b/database/reorg_test.go
@@ -33,7 +33,7 @@ func testReorganization(t *testing.T, dbType string) {
 		t.Fatalf("Error loading file: %v", err)
 	}
 
-	for i := int64(0); i <= 2; i++ {
+	for i := int32(0); i <= 2; i++ {
 		_, err = db.InsertBlock(blocks[i])
 		if err != nil {
 			t.Fatalf("Error inserting block %d (%v): %v", i,
@@ -45,7 +45,7 @@ func testReorganization(t *testing.T, dbType string) {
 		}
 	}
 
-	for i := int64(1); i >= 0; i-- {
+	for i := int32(1); i >= 0; i-- {
 		blkHash := blocks[i].Sha()
 		err = db.DropAfterBlockBySha(blkHash)
 		if err != nil {
@@ -63,7 +63,7 @@ func testReorganization(t *testing.T, dbType string) {
 		}
 	}
 
-	for i := int64(3); i < int64(len(blocks)); i++ {
+	for i := int32(3); i < int32(len(blocks)); i++ {
 		blkHash := blocks[i].Sha()
 		if err != nil {
 			t.Fatalf("Error getting SHA for block %dA: %v", i-2, err)
@@ -79,7 +79,7 @@ func testReorganization(t *testing.T, dbType string) {
 		t.Fatalf("Error getting newest block info")
 	}
 
-	for i := int64(0); i <= maxHeight; i++ {
+	for i := int32(0); i <= maxHeight; i++ {
 		blkHash, err := db.FetchBlockShaByHeight(i)
 		if err != nil {
 			t.Fatalf("Error fetching SHA for block %d: %v", i, err)
@@ -126,7 +126,7 @@ func loadReorgBlocks(filename string) ([]*btcutil.Block, error) {
 	var block *btcutil.Block
 
 	err = nil
-	for height := int64(1); err == nil; height++ {
+	for height := int32(1); err == nil; height++ {
 		var rintbuf uint32
 		err = binary.Read(dr, binary.LittleEndian, &rintbuf)
 		if err == io.EOF {

--- a/mining.go
+++ b/mining.go
@@ -158,7 +158,7 @@ type BlockTemplate struct {
 	block           *wire.MsgBlock
 	fees            []int64
 	sigOpCounts     []int64
-	height          int64
+	height          int32
 	validPayAddress bool
 }
 
@@ -180,8 +180,8 @@ func mergeTxStore(txStoreA blockchain.TxStore, txStoreB blockchain.TxStore) {
 // signature script of the coinbase transaction of a new block.  In particular,
 // it starts with the block height that is required by version 2 blocks and adds
 // the extra nonce as well as additional coinbase flags.
-func standardCoinbaseScript(nextBlockHeight int64, extraNonce uint64) ([]byte, error) {
-	return txscript.NewScriptBuilder().AddInt64(nextBlockHeight).
+func standardCoinbaseScript(nextBlockHeight int32, extraNonce uint64) ([]byte, error) {
+	return txscript.NewScriptBuilder().AddInt64(int64(nextBlockHeight)).
 		AddInt64(int64(extraNonce)).AddData([]byte(coinbaseFlags)).
 		Script()
 }
@@ -192,7 +192,7 @@ func standardCoinbaseScript(nextBlockHeight int64, extraNonce uint64) ([]byte, e
 //
 // See the comment for NewBlockTemplate for more information about why the nil
 // address handling is useful.
-func createCoinbaseTx(coinbaseScript []byte, nextBlockHeight int64, addr btcutil.Address) (*btcutil.Tx, error) {
+func createCoinbaseTx(coinbaseScript []byte, nextBlockHeight int32, addr btcutil.Address) (*btcutil.Tx, error) {
 	// Create the script to pay to the provided payment address if one was
 	// specified.  Otherwise create a script that allows the coinbase to be
 	// redeemable by anyone.
@@ -232,7 +232,7 @@ func createCoinbaseTx(coinbaseScript []byte, nextBlockHeight int64, addr btcutil
 // spendTransaction updates the passed transaction store by marking the inputs
 // to the passed transaction as spent.  It also adds the passed transaction to
 // the store at the provided height.
-func spendTransaction(txStore blockchain.TxStore, tx *btcutil.Tx, height int64) error {
+func spendTransaction(txStore blockchain.TxStore, tx *btcutil.Tx, height int32) error {
 	for _, txIn := range tx.MsgTx().TxIn {
 		originHash := &txIn.PreviousOutPoint.Hash
 		originIndex := txIn.PreviousOutPoint.Index
@@ -793,7 +793,7 @@ func UpdateBlockTime(msgBlock *wire.MsgBlock, bManager *blockManager) error {
 // block by regenerating the coinbase script with the passed value and block
 // height.  It also recalculates and updates the new merkle root that results
 // from changing the coinbase script.
-func UpdateExtraNonce(msgBlock *wire.MsgBlock, blockHeight int64, extraNonce uint64) error {
+func UpdateExtraNonce(msgBlock *wire.MsgBlock, blockHeight int32, extraNonce uint64) error {
 	coinbaseScript, err := standardCoinbaseScript(blockHeight, extraNonce)
 	if err != nil {
 		return err

--- a/peer.go
+++ b/peer.go
@@ -928,7 +928,7 @@ func (p *peer) handleGetBlocksMsg(msg *wire.MsgGetBlocks) {
 	// provided locator are known.  This does mean the client will start
 	// over with the genesis block if unknown block locators are provided.
 	// This mirrors the behavior in the reference implementation.
-	startIdx := int64(1)
+	startIdx := int32(1)
 	for _, hash := range msg.BlockLocatorHashes {
 		height, err := p.server.db.FetchBlockHeightBySha(hash)
 		if err == nil {
@@ -972,7 +972,7 @@ func (p *peer) handleGetBlocksMsg(msg *wire.MsgGetBlocks) {
 			iv := wire.NewInvVect(wire.InvTypeBlock, &hashCopy)
 			invMsg.AddInvVect(iv)
 		}
-		start += int64(len(hashList))
+		start += int32(len(hashList))
 	}
 
 	// Send the inventory message if there is anything to send.
@@ -1034,7 +1034,7 @@ func (p *peer) handleGetHeadersMsg(msg *wire.MsgGetHeaders) {
 	// provided locator are known.  This does mean the client will start
 	// over with the genesis block if unknown block locators are provided.
 	// This mirrors the behavior in the reference implementation.
-	startIdx := int64(1)
+	startIdx := int32(1)
 	for _, hash := range msg.BlockLocatorHashes {
 		height, err := p.server.db.FetchBlockHeightBySha(hash)
 		if err == nil {
@@ -1083,7 +1083,7 @@ func (p *peer) handleGetHeadersMsg(msg *wire.MsgGetHeaders) {
 
 		// Start at the next block header after the latest one on the
 		// next loop iteration.
-		start += int64(len(hashList))
+		start += int32(len(hashList))
 	}
 	p.QueueMessage(headersMsg, nil)
 }

--- a/rpcwebsocket.go
+++ b/rpcwebsocket.go
@@ -1759,7 +1759,7 @@ func rescanBlock(wsc *wsClient, lookups *rescanKeys, blk *btcutil.Block) {
 // verifies that the new range of blocks is on the same fork as a previous
 // range of blocks.  If this condition does not hold true, the JSON-RPC error
 // for an unrecoverable reorganize is returned.
-func recoverFromReorg(db database.Db, minBlock, maxBlock int64,
+func recoverFromReorg(db database.Db, minBlock, maxBlock int32,
 	lastBlock *wire.ShaHash) ([]wire.ShaHash, error) {
 
 	hashList, err := db.FetchHeightRange(minBlock, maxBlock)
@@ -2023,7 +2023,7 @@ fetchRange:
 				// A goto is used to branch executation back to
 				// before the range was evaluated, as it must be
 				// reevaluated for the new hashList.
-				minBlock += int64(i)
+				minBlock += int32(i)
 				hashList, err = recoverFromReorg(db, minBlock,
 					maxBlock, lastBlockHash)
 				if err != nil {
@@ -2083,7 +2083,7 @@ fetchRange:
 			}
 		}
 
-		minBlock += int64(len(hashList))
+		minBlock += int32(len(hashList))
 	}
 
 	// Notify websocket client of the finished rescan.  Due to how btcd


### PR DESCRIPTION
This pull request depends on btcsuite/btcutil#56.

This pull request converts all block height references to int32 instead of int64.  The current target block production rate is 10 mins per block which means it will take roughly 40,800 years to reach the maximum
height an int32 affords.  Even if the target rate were lowered to one block per minute, it would still take roughly another 4,080 years to reach the maximum.

In the mean time, there is no reason to use a larger type which results in higher memory and disk space usage.  However, for now, in order to avoid having to reserialize a bunch of database information, the heights are still serialized to the database as 8-byte uint64s.

This is being mainly being done in preparation for further upcoming infrastructure changes which will use the smaller and more efficient 4-byte serialization in the database as well.