### PR TITLE
txscript: Rename SignTxOutput to SignTx and improve comment.

### DIFF
--- a/txscript/error.go
+++ b/txscript/error.go
@@ -28,11 +28,11 @@ var (
 
 	// ErrStackOpDisabled is returned when a disabled opcode is encountered
 	// in the script.
-	ErrStackOpDisabled = errors.New("Disabled Opcode")
+	ErrStackOpDisabled = errors.New("disabled opcode")
 
 	// ErrStackVerifyFailed is returned when one of the OP_VERIFY or
 	// OP_*VERIFY instructions is executed and the conditions fails.
-	ErrStackVerifyFailed = errors.New("Verify failed")
+	ErrStackVerifyFailed = errors.New("verify failed")
 
 	// ErrStackNumberTooBig is returned when the argument for an opcode that
 	// should be an offset is obviously far too large.
@@ -40,15 +40,15 @@ var (
 
 	// ErrStackInvalidOpcode is returned when an opcode marked as invalid or
 	// a completely undefined opcode is encountered.
-	ErrStackInvalidOpcode = errors.New("Invalid Opcode")
+	ErrStackInvalidOpcode = errors.New("invalid opcode")
 
 	// ErrStackReservedOpcode is returned when an opcode marked as reserved
 	// is encountered.
-	ErrStackReservedOpcode = errors.New("Reserved Opcode")
+	ErrStackReservedOpcode = errors.New("reserved opcode")
 
 	// ErrStackEarlyReturn is returned when OP_RETURN is executed in the
 	// script.
-	ErrStackEarlyReturn = errors.New("Script returned early")
+	ErrStackEarlyReturn = errors.New("script returned early")
 
 	// ErrStackNoIf is returned if an OP_ELSE or OP_ENDIF is encountered
 	// without first having an OP_IF or OP_NOTIF in the script.
@@ -60,15 +60,15 @@ var (
 
 	// ErrStackTooManyPubKeys is returned if an OP_CHECKMULTISIG is
 	// encountered with more than MaxPubKeysPerMultiSig pubkeys present.
-	ErrStackTooManyPubKeys = errors.New("Invalid pubkey count in OP_CHECKMULTISIG")
+	ErrStackTooManyPubKeys = errors.New("invalid pubkey count in OP_CHECKMULTISIG")
 
 	// ErrStackTooManyOperations is returned if a script has more than
 	// MaxOpsPerScript opcodes that do not push data.
-	ErrStackTooManyOperations = errors.New("Too many operations in script")
+	ErrStackTooManyOperations = errors.New("too many operations in script")
 
 	// ErrStackElementTooBig is returned if the size of an element to be
 	// pushed to the stack is over MaxScriptElementSize.
-	ErrStackElementTooBig = errors.New("Element in script too large")
+	ErrStackElementTooBig = errors.New("element in script too large")
 
 	// ErrStackUnknownAddress is returned when ScriptToAddrHash does not
 	// recognise the pattern of the script and thus can not find the address
@@ -82,12 +82,12 @@ var (
 
 	// ErrStackScriptUnfinished is returned when CheckErrorCondition is
 	// called on a script that has not finished executing.
-	ErrStackScriptUnfinished = errors.New("Error check when script unfinished")
+	ErrStackScriptUnfinished = errors.New("error check when script unfinished")
 
 	// ErrStackEmptyStack is returned when the stack is empty at the end of
 	// execution. Normal operation requires that a boolean is on top of the
 	// stack when the scripts have finished executing.
-	ErrStackEmptyStack = errors.New("Stack empty at end of execution")
+	ErrStackEmptyStack = errors.New("stack empty at end of execution")
 
 	// ErrStackP2SHNonPushOnly is returned when a Pay-to-Script-Hash
 	// transaction is encountered and the ScriptSig does operations other
@@ -105,7 +105,7 @@ var (
 
 	// ErrStackInvalidIndex is returned when an out-of-bounds index was
 	// passed to a function.
-	ErrStackInvalidIndex = errors.New("Invalid script index")
+	ErrStackInvalidIndex = errors.New("invalid script index")
 
 	// ErrStackNonPushOnly is returned when ScriptInfo is called with a
 	// pkScript that peforms operations other that pushing data to the stack.
@@ -113,7 +113,7 @@ var (
 
 	// ErrStackOverflow is returned when stack and altstack combined depth
 	// is over the limit.
-	ErrStackOverflow = errors.New("Stacks overflowed")
+	ErrStackOverflow = errors.New("stack overflow")
 
 	// ErrStackInvalidLowSSignature is returned when the ScriptVerifyLowS
 	// flag is set and the script contains any signatures whose S values

--- a/txscript/example_test.go
+++ b/txscript/example_test.go
@@ -150,7 +150,7 @@ func ExampleSignTxOutput() {
 	// Notice that the script database parameter is nil here since it isn't
 	// used.  It must be specified when pay-to-script-hash transactions are
 	// being signed.
-	sigScript, err := txscript.SignTxOutput(&chaincfg.MainNetParams,
+	sigScript, err := txscript.SignTx(&chaincfg.MainNetParams,
 		redeemTx, 0, originTx.TxOut[0].PkScript, txscript.SigHashAll,
 		txscript.KeyClosure(lookupKey), nil, nil)
 	if err != nil {

--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -77,7 +77,7 @@ func signAndCheck(msg string, tx *wire.MsgTx, idx int, pkScript []byte,
 	hashType txscript.SigHashType, kdb txscript.KeyDB, sdb txscript.ScriptDB,
 	previousScript []byte) error {
 
-	sigScript, err := txscript.SignTxOutput(&chaincfg.TestNet3Params, tx,
+	sigScript, err := txscript.SignTx(&chaincfg.TestNet3Params, tx,
 		idx, pkScript, hashType, kdb, sdb, nil)
 	if err != nil {
 		return fmt.Errorf("failed to sign output %s: %v", msg, err)
@@ -204,7 +204,7 @@ func TestSignTxOutput(t *testing.T) {
 					"for %s: %v", msg, err)
 			}
 
-			sigScript, err := txscript.SignTxOutput(
+			sigScript, err := txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, pkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, false},
@@ -217,7 +217,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			// by the above loop, this should be valid, now sign
 			// again and merge.
-			sigScript, err = txscript.SignTxOutput(
+			sigScript, err = txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, pkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, false},
@@ -303,7 +303,7 @@ func TestSignTxOutput(t *testing.T) {
 					"for %s: %v", msg, err)
 			}
 
-			sigScript, err := txscript.SignTxOutput(
+			sigScript, err := txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, pkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, true},
@@ -316,7 +316,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			// by the above loop, this should be valid, now sign
 			// again and merge.
-			sigScript, err = txscript.SignTxOutput(
+			sigScript, err = txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, pkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, true},
@@ -402,7 +402,7 @@ func TestSignTxOutput(t *testing.T) {
 					"for %s: %v", msg, err)
 			}
 
-			sigScript, err := txscript.SignTxOutput(
+			sigScript, err := txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, pkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, false},
@@ -415,7 +415,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			// by the above loop, this should be valid, now sign
 			// again and merge.
-			sigScript, err = txscript.SignTxOutput(
+			sigScript, err = txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, pkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, false},
@@ -501,7 +501,7 @@ func TestSignTxOutput(t *testing.T) {
 					"for %s: %v", msg, err)
 			}
 
-			sigScript, err := txscript.SignTxOutput(
+			sigScript, err := txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, pkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, true},
@@ -514,7 +514,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			// by the above loop, this should be valid, now sign
 			// again and merge.
-			sigScript, err = txscript.SignTxOutput(
+			sigScript, err = txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, pkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, true},
@@ -636,7 +636,7 @@ func TestSignTxOutput(t *testing.T) {
 				break
 			}
 
-			sigScript, err := txscript.SignTxOutput(
+			sigScript, err := txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, scriptPkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, false},
@@ -651,7 +651,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			// by the above loop, this should be valid, now sign
 			// again and merge.
-			sigScript, err = txscript.SignTxOutput(
+			sigScript, err = txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, scriptPkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, false},
@@ -774,7 +774,7 @@ func TestSignTxOutput(t *testing.T) {
 				break
 			}
 
-			sigScript, err := txscript.SignTxOutput(
+			sigScript, err := txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, scriptPkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, true},
@@ -789,7 +789,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			// by the above loop, this should be valid, now sign
 			// again and merge.
-			sigScript, err = txscript.SignTxOutput(
+			sigScript, err = txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, scriptPkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, true},
@@ -912,7 +912,7 @@ func TestSignTxOutput(t *testing.T) {
 				break
 			}
 
-			sigScript, err := txscript.SignTxOutput(
+			sigScript, err := txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, scriptPkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, false},
@@ -927,7 +927,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			// by the above loop, this should be valid, now sign
 			// again and merge.
-			sigScript, err = txscript.SignTxOutput(
+			sigScript, err = txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, scriptPkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, false},
@@ -1050,7 +1050,7 @@ func TestSignTxOutput(t *testing.T) {
 				break
 			}
 
-			sigScript, err := txscript.SignTxOutput(
+			sigScript, err := txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, scriptPkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, true},
@@ -1065,7 +1065,7 @@ func TestSignTxOutput(t *testing.T) {
 
 			// by the above loop, this should be valid, now sign
 			// again and merge.
-			sigScript, err = txscript.SignTxOutput(
+			sigScript, err = txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, scriptPkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address.EncodeAddress(): {key, true},
@@ -1227,7 +1227,7 @@ func TestSignTxOutput(t *testing.T) {
 				break
 			}
 
-			sigScript, err := txscript.SignTxOutput(
+			sigScript, err := txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, scriptPkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address1.EncodeAddress(): {key1, true},
@@ -1248,7 +1248,7 @@ func TestSignTxOutput(t *testing.T) {
 			}
 
 			// Sign with the other key and merge
-			sigScript, err = txscript.SignTxOutput(
+			sigScript, err = txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, scriptPkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address2.EncodeAddress(): {key2, true},
@@ -1334,7 +1334,7 @@ func TestSignTxOutput(t *testing.T) {
 				break
 			}
 
-			sigScript, err := txscript.SignTxOutput(
+			sigScript, err := txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, scriptPkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address1.EncodeAddress(): {key1, true},
@@ -1355,7 +1355,7 @@ func TestSignTxOutput(t *testing.T) {
 			}
 
 			// Sign with the other key and merge
-			sigScript, err = txscript.SignTxOutput(
+			sigScript, err = txscript.SignTx(
 				&chaincfg.TestNet3Params, tx, i, scriptPkScript,
 				hashType, mkGetKey(map[string]addressToKey{
 					address1.EncodeAddress(): {key1, true},


### PR DESCRIPTION
Note that this is an API breaking change and will make the `btcwallet` build fail so it will need to be coordinated with an appropriate `btcwallet` change.

Along with this commit I would like to make `txscript.RawTxInSignature` and `txscript.SignatureScript` private functions because in my opinion they complicate the API and as far as I can see add nothing that `txscript.SignTxOutput` (now `txscript.SignTx`) don't already do.

There is probably a reason why `RawTxInSignature` and `SignatureScript` are public but I can't see one. So I though I would raise the issue here before I add a couple of commits to this pull request making them private.

In any case, you might not want to change the API at this point, in which case I will revert back to just the `txscript: Make error strings idiomatic.` commit 27f7f8235518af9c7f1bdc99db0cf81d2a9a1a3d.