### PR TITLE
Fix longpoll getblocktemplate not getting notified if a block is pushed via submitblock

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1142,6 +1142,14 @@ out:
 				newestSha, newestHeight, _ := b.server.db.NewestSha()
 				b.updateChainState(newestSha, newestHeight)
 
+				// Allow any clients performing long polling via the
+				// getblocktemplate RPC to be notified when the new block causes
+				// their old block template to become stale.
+				rpcServer := b.server.rpcServer
+				if rpcServer != nil {
+					rpcServer.gbtWorkState.NotifyBlockConnected(msg.block.Sha())
+				}
+
 				msg.reply <- processBlockResponse{
 					isOrphan: isOrphan,
 					err:      nil,


### PR DESCRIPTION
btcd currently does not notify miners waiting for new block templates via longpolling when a block is pushed via submitblock RPC. It does when a block is received via the P2P protocol.

This is due to the code paths for connecting the block being different. The fix adds a call to NotifyBlockConnected in the submitblock code path, as in handleBlockMsg. 

This bug is hard to see in regular conditions: mainnet difficulty is too high, and regtest/simnet is way too low. Maybe it'd be possible to reproduce it in testnet. In the logs below I'm solo mining on a test blockchain with a target of 0000000ffff000.., 16x easier than the Bitcoin difficulty.

Logs before the fix:
btcd:
````
dirbaio@saturn:~$ btcd -u test -P test
16:51:51 2015-08-21 [WRN] BTCD: open /home/dirbaio/.btcd/btcd.conf: no such file or directory
16:51:51 2015-08-21 [INF] BTCD: Version 0.11.1-beta
16:51:51 2015-08-21 [INF] BTCD: Loading block database from '/home/dirbaio/.btcd/data/mainnet/blocks_leveldb'
16:51:51 2015-08-21 [INF] BTCD: Inserted genesis block 0000000e770cd09e3edd8fda4173339c7a1d80436494f94feb9d0c8c9f095ec5
16:51:51 2015-08-21 [INF] BTCD: Block database loaded with block height 0
16:51:51 2015-08-21 [INF] BMGR: Generating initial block node index.  This may take a while...
16:51:51 2015-08-21 [INF] BMGR: Block index generation complete
16:51:51 2015-08-21 [INF] RPCS: Generating TLS certificates...
16:51:51 2015-08-21 [INF] RPCS: Done generating TLS certificates
16:51:51 2015-08-21 [INF] RPCS: RPC server listening on 127.0.0.1:8445
16:51:51 2015-08-21 [INF] SRVR: Server listening on 0.0.0.0:8444
16:51:51 2015-08-21 [INF] RPCS: RPC server listening on [::1]:8445
16:51:51 2015-08-21 [INF] SRVR: Server listening on [::]:8444
16:51:51 2015-08-21 [INF] AMGR: Loaded 0 addresses from file '/home/dirbaio/.btcd/data/mainnet/peers.json'
16:52:02 2015-08-21 [INF] RPCS: Accepted block 00000004fec85b0ee87b3a229795289dacca9e6e1117f4404dbd261a627ec196 via submitblock
16:52:04 2015-08-21 [INF] CHAN: FORK: Block 000000002ffde4f7814a7eb81a95a3deb504187004af58b4e3b912e934d58c11 forks the chain at height 0/block 0000000e770cd09e3edd8fda4173339c7a1d80436494f94feb9d0c8c9f095ec5, but does not cause a reorganize
16:52:04 2015-08-21 [INF] RPCS: Accepted block 000000002ffde4f7814a7eb81a95a3deb504187004af58b4e3b912e934d58c11 via submitblock
16:52:04 2015-08-21 [INF] CHAN: FORK: Block 0000000b18d27eca5623d0937cb49d48dc5c820daa02c7e98b3dd5d70a5f42dd forks the chain at height 0/block 0000000e770cd09e3edd8fda4173339c7a1d80436494f94feb9d0c8c9f095ec5, but does not cause a reorganize
16:52:04 2015-08-21 [INF] RPCS: Accepted block 0000000b18d27eca5623d0937cb49d48dc5c820daa02c7e98b3dd5d70a5f42dd via submitblock
16:52:08 2015-08-21 [INF] CHAN: FORK: Block 0000000e09ee3d255dedf0e7895892a8b295666d4ec148477cd636e290ae0ca3 forks the chain at height 0/block 0000000e770cd09e3edd8fda4173339c7a1d80436494f94feb9d0c8c9f095ec5, but does not cause a reorganize
16:52:08 2015-08-21 [INF] RPCS: Accepted block 0000000e09ee3d255dedf0e7895892a8b295666d4ec148477cd636e290ae0ca3 via submitblock
````
minerd:
````
dirbaio@saturn:~$ minerd -u test -p test -ohttps://localhost:8445 --coinbase-addr 14XsS3AnJFd8W4K9tSiyeZsMuR5dBym3dR -a sha256d -t 4 --cert /home/dirbaio/.btcd/rpc.cert 
[2015-08-21 16:51:54] 4 miner threads started, using 'sha256d' algorithm.
[2015-08-21 16:51:54] Long-polling activated for https://localhost:8445
[2015-08-21 16:51:54] thread 1: 2097152 hashes, 10277 khash/s
[2015-08-21 16:51:54] thread 0: 2097152 hashes, 10166 khash/s
[2015-08-21 16:51:54] thread 3: 2097152 hashes, 5565 khash/s
[2015-08-21 16:51:54] thread 2: 2097152 hashes, 5498 khash/s
[2015-08-21 16:52:02] thread 1: 80330952 hashes, 9901 khash/s
[2015-08-21 16:52:02] accepted: 1/1 (100.00%), 31131 khash/s (yay!!!)
[2015-08-21 16:52:04] thread 1: 14241680 hashes, 10251 khash/s
[2015-08-21 16:52:04] accepted: 2/2 (100.00%), 31481 khash/s (yay!!!)
[2015-08-21 16:52:04] thread 1: 3334472 hashes, 10232 khash/s
[2015-08-21 16:52:04] accepted: 3/3 (100.00%), 31462 khash/s (yay!!!)
[2015-08-21 16:52:08] thread 2: 135155904 hashes, 9904 khash/s
[2015-08-21 16:52:08] accepted: 4/4 (100.00%), 35868 khash/s (yay!!!)
````

Logs after the fix

btcd:
````
dirbaio@saturn:~$ btcd -u test -P test
16:50:17 2015-08-21 [WRN] BTCD: open /home/dirbaio/.btcd/btcd.conf: no such file or directory
16:50:17 2015-08-21 [INF] BTCD: Version 0.11.1-beta
16:50:17 2015-08-21 [INF] BTCD: Loading block database from '/home/dirbaio/.btcd/data/mainnet/blocks_leveldb'
16:50:17 2015-08-21 [INF] BTCD: Inserted genesis block 0000000e770cd09e3edd8fda4173339c7a1d80436494f94feb9d0c8c9f095ec5
16:50:17 2015-08-21 [INF] BTCD: Block database loaded with block height 0
16:50:17 2015-08-21 [INF] BMGR: Generating initial block node index.  This may take a while...
16:50:17 2015-08-21 [INF] BMGR: Block index generation complete
16:50:17 2015-08-21 [INF] RPCS: Generating TLS certificates...
16:50:17 2015-08-21 [INF] RPCS: Done generating TLS certificates
16:50:17 2015-08-21 [INF] RPCS: RPC server listening on 127.0.0.1:8445
16:50:17 2015-08-21 [INF] SRVR: Server listening on 0.0.0.0:8444
16:50:17 2015-08-21 [INF] AMGR: Loaded 0 addresses from file '/home/dirbaio/.btcd/data/mainnet/peers.json'
16:50:17 2015-08-21 [INF] RPCS: RPC server listening on [::1]:8445
16:50:17 2015-08-21 [INF] SRVR: Server listening on [::]:8444
16:50:51 2015-08-21 [INF] RPCS: Accepted block 00000003a19659771655883b98b2b92dfdf3a409bf14df222c2757d9037022a0 via submitblock
16:50:59 2015-08-21 [INF] RPCS: Accepted block 000000053fb1c969ea9d0badaf09247b0e7e25afc9668061123dbf5d2f520e55 via submitblock
16:51:11 2015-08-21 [INF] RPCS: Accepted block 0000000502ba8d3c2c4599ff822d4dbbfb60b19f7fcaba11f9227666ba038757 via submitblock
````

minerd:
````
dirbaio@saturn:~$ minerd -u test -p test -ohttps://localhost:8445 --coinbase-addr 14XsS3AnJFd8W4K9tSiyeZsMuR5dBym3dR -a sha256d -t 4 --cert /home/dirbaio/.btcd/rpc.cert 
[2015-08-21 16:50:46] 4 miner threads started, using 'sha256d' algorithm.
[2015-08-21 16:50:46] Long-polling activated for https://localhost:8445
[2015-08-21 16:50:46] thread 1: 2097152 hashes, 10216 khash/s
[2015-08-21 16:50:46] thread 3: 2097152 hashes, 10201 khash/s
[2015-08-21 16:50:46] thread 0: 2097152 hashes, 10096 khash/s
[2015-08-21 16:50:46] thread 2: 2097152 hashes, 9957 khash/s
[2015-08-21 16:50:51] thread 0: 46271160 hashes, 10314 khash/s
[2015-08-21 16:50:51] accepted: 1/1 (100.00%), 40688 khash/s (yay!!!)
[2015-08-21 16:50:51] LONGPOLL pushed new work
[2015-08-21 16:50:51] thread 2: 43828552 hashes, 9701 khash/s
[2015-08-21 16:50:51] thread 1: 46725304 hashes, 10330 khash/s
[2015-08-21 16:50:51] thread 0: 333120 hashes, 9636 khash/s
[2015-08-21 16:50:51] thread 3: 43949672 hashes, 9718 khash/s
[2015-08-21 16:50:59] thread 0: 85842584 hashes, 10031 khash/s
[2015-08-21 16:50:59] accepted: 2/2 (100.00%), 39781 khash/s (yay!!!)
[2015-08-21 16:50:59] LONGPOLL pushed new work
[2015-08-21 16:50:59] thread 3: 81766016 hashes, 9526 khash/s
[2015-08-21 16:50:59] thread 0: 186904 hashes, 7311 khash/s
[2015-08-21 16:50:59] thread 1: 87841768 hashes, 10234 khash/s
[2015-08-21 16:50:59] thread 2: 84500960 hashes, 9845 khash/s
[2015-08-21 16:51:11] thread 0: 85909904 hashes, 7184 khash/s
[2015-08-21 16:51:11] accepted: 3/3 (100.00%), 36789 khash/s (yay!!!)
[2015-08-21 16:51:11] LONGPOLL pushed new work
[2015-08-21 16:51:11] thread 0: 151920 hashes, 5016 khash/s
[2015-08-21 16:51:11] thread 1: 119900840 hashes, 10001 khash/s
[2015-08-21 16:51:11] thread 2: 108695256 hashes, 9066 khash/s
[2015-08-21 16:51:11] thread 3: 105914320 hashes, 8834 khash/s
[2015-08-21 16:51:13] thread 3: 8492416 hashes, 5535 khash/s
````