### PR TITLE
Fix skip not being applied to mempool txns in searchrawtransactions

### DIFF
--- a/database/db.go
+++ b/database/db.go
@@ -134,7 +134,9 @@ type Db interface {
 	// Additionally, if the caller wishes to skip forward in the results
 	// some amount, the 'seek' represents how many results to skip.
 	// NOTE: Values for both `seek` and `limit` MUST be positive.
-	FetchTxsForAddr(addr btcutil.Address, skip int, limit int) ([]*TxListReply, error)
+	// It will return the array of fetched transactions, along with the amount
+	// of transactions that were actually skipped.
+	FetchTxsForAddr(addr btcutil.Address, skip int, limit int) ([]*TxListReply, int, error)
 
 	// DeleteAddrIndex deletes the entire addrindex stored within the DB.
 	DeleteAddrIndex() error

--- a/database/ldb/operational_test.go
+++ b/database/ldb/operational_test.go
@@ -91,12 +91,12 @@ func testAddrIndexOperations(t *testing.T, db database.Db, newestBlock *btcutil.
 
 	// Test enforcement of constraints for "limit" and "skip"
 	var fakeAddr btcutil.Address
-	_, err = db.FetchTxsForAddr(fakeAddr, -1, 0)
+	_, _, err = db.FetchTxsForAddr(fakeAddr, -1, 0)
 	if err == nil {
 		t.Fatalf("Negative value for skip passed, should return an error")
 	}
 
-	_, err = db.FetchTxsForAddr(fakeAddr, 0, -1)
+	_, _, err = db.FetchTxsForAddr(fakeAddr, 0, -1)
 	if err == nil {
 		t.Fatalf("Negative value for limit passed, should return an error")
 	}
@@ -136,7 +136,7 @@ func testAddrIndexOperations(t *testing.T, db database.Db, newestBlock *btcutil.
 	assertAddrIndexTipIsUpdated(db, t, newestSha, newestBlockIdx)
 
 	// Check index retrieval.
-	txReplies, err := db.FetchTxsForAddr(testAddrs[0], 0, 1000)
+	txReplies, _, err := db.FetchTxsForAddr(testAddrs[0], 0, 1000)
 	if err != nil {
 		t.Fatalf("FetchTxsForAddr failed to correctly fetch txs for an "+
 			"address, err %v", err)
@@ -171,7 +171,7 @@ func testAddrIndexOperations(t *testing.T, db database.Db, newestBlock *btcutil.
 	}
 
 	// Former index should no longer exist.
-	txReplies, err = db.FetchTxsForAddr(testAddrs[0], 0, 1000)
+	txReplies, _, err = db.FetchTxsForAddr(testAddrs[0], 0, 1000)
 	if err != nil {
 		t.Fatalf("Unable to fetch transactions for address: %v", err)
 	}
@@ -555,9 +555,13 @@ func TestLimitAndSkipFetchTxsForAddr(t *testing.T) {
 	}
 
 	// Try skipping the first 4 results, should get 6 in return.
-	txReply, err := testDb.db.FetchTxsForAddr(targetAddr, 4, 100000)
+	txReply, txSkipped, err := testDb.db.FetchTxsForAddr(targetAddr, 4, 100000)
 	if err != nil {
 		t.Fatalf("Unable to fetch transactions for address: %v", err)
+	}
+	if txSkipped != 4 {
+		t.Fatalf("Did not correctly return skipped amount"+
+			" got %v txs, expected %v", txSkipped, 4)
 	}
 	if len(txReply) != 6 {
 		t.Fatalf("Did not correctly skip forward in txs for address reply"+
@@ -565,9 +569,13 @@ func TestLimitAndSkipFetchTxsForAddr(t *testing.T) {
 	}
 
 	// Limit the number of results to 3.
-	txReply, err = testDb.db.FetchTxsForAddr(targetAddr, 0, 3)
+	txReply, txSkipped, err = testDb.db.FetchTxsForAddr(targetAddr, 0, 3)
 	if err != nil {
 		t.Fatalf("Unable to fetch transactions for address: %v", err)
+	}
+	if txSkipped != 0 {
+		t.Fatalf("Did not correctly return skipped amount"+
+			" got %v txs, expected %v", txSkipped, 0)
 	}
 	if len(txReply) != 3 {
 		t.Fatalf("Did not correctly limit in txs for address reply"+
@@ -575,9 +583,13 @@ func TestLimitAndSkipFetchTxsForAddr(t *testing.T) {
 	}
 
 	// Skip 1, limit 5.
-	txReply, err = testDb.db.FetchTxsForAddr(targetAddr, 1, 5)
+	txReply, txSkipped, err = testDb.db.FetchTxsForAddr(targetAddr, 1, 5)
 	if err != nil {
 		t.Fatalf("Unable to fetch transactions for address: %v", err)
+	}
+	if txSkipped != 1 {
+		t.Fatalf("Did not correctly return skipped amount"+
+			" got %v txs, expected %v", txSkipped, 1)
 	}
 	if len(txReply) != 5 {
 		t.Fatalf("Did not correctly limit in txs for address reply"+

--- a/database/ldb/tx.go
+++ b/database/ldb/tx.go
@@ -430,16 +430,16 @@ func bytesPrefix(prefix []byte) *util.Range {
 // caller wishes to seek forward in the results some amount, the 'seek'
 // represents how many results to skip.
 func (db *LevelDb) FetchTxsForAddr(addr btcutil.Address, skip int,
-	limit int) ([]*database.TxListReply, error) {
+	limit int) ([]*database.TxListReply, int, error) {
 	db.dbLock.Lock()
 	defer db.dbLock.Unlock()
 
 	// Enforce constraints for skip and limit.
 	if skip < 0 {
-		return nil, errors.New("offset for skip must be positive")
+		return nil, 0, errors.New("offset for skip must be positive")
 	}
 	if limit < 0 {
-		return nil, errors.New("value for limit must be positive")
+		return nil, 0, errors.New("value for limit must be positive")
 	}
 
 	// Parse address type, bailing on an unknown type.
@@ -455,7 +455,7 @@ func (db *LevelDb) FetchTxsForAddr(addr btcutil.Address, skip int,
 		hash160 := addr.AddressPubKeyHash().Hash160()
 		addrKey = hash160[:]
 	default:
-		return nil, database.ErrUnsupportedAddressType
+		return nil, 0, database.ErrUnsupportedAddressType
 	}
 
 	// Create the prefix for our search.
@@ -464,8 +464,10 @@ func (db *LevelDb) FetchTxsForAddr(addr btcutil.Address, skip int,
 	copy(addrPrefix[3:23], addrKey)
 
 	iter := db.lDb.NewIterator(bytesPrefix(addrPrefix), nil)
+	skipped := 0
 	for skip != 0 && iter.Next() {
 		skip--
+		skipped++
 	}
 
 	// Iterate through all address indexes that match the targeted prefix.
@@ -491,10 +493,10 @@ func (db *LevelDb) FetchTxsForAddr(addr btcutil.Address, skip int,
 	}
 	iter.Release()
 	if err := iter.Error(); err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
-	return replies, nil
+	return replies, skipped, nil
 }
 
 // UpdateAddrIndexForBlock updates the stored addrindex with passed

--- a/database/memdb/memdb.go
+++ b/database/memdb/memdb.go
@@ -690,8 +690,8 @@ func (db *MemDb) UpdateAddrIndexForBlock(*wire.ShaHash, int32,
 
 // FetchTxsForAddr isn't currently implemented. This is a part of the database.Db
 // interface implementation.
-func (db *MemDb) FetchTxsForAddr(btcutil.Address, int, int) ([]*database.TxListReply, error) {
-	return nil, database.ErrNotImplemented
+func (db *MemDb) FetchTxsForAddr(btcutil.Address, int, int) ([]*database.TxListReply, int, error) {
+	return nil, 0, database.ErrNotImplemented
 }
 
 // DeleteAddrIndex isn't currently implemented. This is a part of the database.Db


### PR DESCRIPTION
Currently, skip is not being applied properly to mempool transactions in searchrawtransactions. This PR fixes that.

I had to change FetchTxsForAddr to additionally return the number of transactions skipped, to properly calculate how many transactions in mempool to skip. (For example, if FetchTxsForAddr returns an empty array, I need to know whether there was no transactions at all, or there were some but they were all skipped).