### PR TITLE
Introduce timer to disconnect peers stalling block download

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1076,9 +1076,8 @@ func (b *blockManager) handleInvMsg(imsg *invMsg) {
 				imsg.peer.requestedBlocks[iv.Hash] = struct{}{}
 				gdmsg.AddInvVect(iv)
 				numRequested++
+				blocksRequested = true
 			}
-
-			blocksRequested = true
 
 		case wire.InvTypeTx:
 			// Request the transaction if there is not already a

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -302,7 +302,7 @@ func (b *blockManager) startSync(peers *list.List) {
 
 		// Remove sync candidate peers that are no longer candidates due
 		// to passing their latest known block.  NOTE: The < is
-		// intentional as opposed to <=.  While techcnically the peer
+		// intentional as opposed to <=.  While technically the peer
 		// doesn't have a later block when it's equal, it will likely
 		// have one soon so it is a reasonable choice.  It also allows
 		// the case where both are at 0 such as during regression test.
@@ -348,12 +348,23 @@ func (b *blockManager) startSync(peers *list.List) {
 		if b.nextCheckpoint != nil && height < b.nextCheckpoint.Height &&
 			!cfg.RegressionTest && !cfg.DisableCheckpoints {
 
+			// Initialize a timer which will start ticking once the
+			// getheaders message is written out to the peer. The
+			// timer will disconnect the peer after blockStallTimeout
+			// seconds, unless we receive a headers response message
+			// before then.
+			bestPeer.SetBlockStallTimer(blockStallTimeout)
 			bestPeer.PushGetHeadersMsg(locator, b.nextCheckpoint.Hash)
 			b.headersFirstMode = true
 			bmgrLog.Infof("Downloading headers for blocks %d to "+
 				"%d from peer %s", height+1,
 				b.nextCheckpoint.Height, bestPeer.addr)
 		} else {
+			// Only set a block stall timer if we expect an inv
+			// response to our getblocks message.
+			if bestPeer.lastBlock > int32(height) {
+				bestPeer.SetBlockStallTimer(blockStallTimeout)
+			}
 			bestPeer.PushGetBlocksMsg(locator, &zeroHash)
 		}
 		b.syncPeer = bestPeer
@@ -648,6 +659,7 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 			bmgrLog.Warnf("Failed to get block locator for the "+
 				"latest block: %v", err)
 		} else {
+			bmsg.peer.SetBlockStallTimer(blockStallTimeout)
 			bmsg.peer.PushGetBlocksMsg(locator, orphanRoot)
 		}
 	} else {
@@ -713,6 +725,7 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 	b.nextCheckpoint = b.findNextHeaderCheckpoint(prevHeight)
 	if b.nextCheckpoint != nil {
 		locator := blockchain.BlockLocator([]*wire.ShaHash{prevHash})
+		bmsg.peer.SetBlockStallTimer(blockStallTimeout)
 		err := bmsg.peer.PushGetHeadersMsg(locator, b.nextCheckpoint.Hash)
 		if err != nil {
 			bmgrLog.Warnf("Failed to send getheaders message to "+
@@ -732,6 +745,7 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 	b.headerList.Init()
 	bmgrLog.Infof("Reached the final checkpoint -- switching to normal mode")
 	locator := blockchain.BlockLocator([]*wire.ShaHash{blockSha})
+	bmsg.peer.SetBlockStallTimer(blockStallTimeout)
 	err = bmsg.peer.PushGetBlocksMsg(locator, &zeroHash)
 	if err != nil {
 		bmgrLog.Warnf("Failed to send getblocks message to peer %s: %v",
@@ -880,8 +894,10 @@ func (b *blockManager) handleHeadersMsg(hmsg *headersMsg) {
 
 	// This header is not a checkpoint, so request the next batch of
 	// headers starting from the latest known header and ending with the
-	// next checkpoint.
+	// next checkpoint. Additionally, start a stall timer which we be
+	// cancelled once we receive the next headers message.
 	locator := blockchain.BlockLocator([]*wire.ShaHash{finalHash})
+	hmsg.peer.SetBlockStallTimer(blockStallTimeout)
 	err := hmsg.peer.PushGetHeadersMsg(locator, b.nextCheckpoint.Hash)
 	if err != nil {
 		bmgrLog.Warnf("Failed to send getheaders message to "+
@@ -1020,6 +1036,7 @@ func (b *blockManager) handleInvMsg(imsg *invMsg) {
 						"%v", err)
 					continue
 				}
+				imsg.peer.SetBlockStallTimer(blockStallTimeout)
 				imsg.peer.PushGetBlocksMsg(locator, orphanRoot)
 				continue
 			}
@@ -1033,6 +1050,7 @@ func (b *blockManager) handleInvMsg(imsg *invMsg) {
 				// final one the remote peer knows about (zero
 				// stop hash).
 				locator := chain.BlockLocatorFromHash(&iv.Hash)
+				imsg.peer.SetBlockStallTimer(blockStallTimeout)
 				imsg.peer.PushGetBlocksMsg(locator, &zeroHash)
 			}
 		}

--- a/peer.go
+++ b/peer.go
@@ -139,6 +139,14 @@ type outMsg struct {
 	doneChan chan struct{}
 }
 
+// blockStallMsg is used to to house a message requesting the activation of the
+// blockStallTimer. Additionally it also contains a channel so the handler
+// can signal to the requester when the timer has been activated.
+type blockStallMsg struct {
+	timeout  time.Duration
+	doneChan chan struct{}
+}
+
 // peer provides a bitcoin peer for handling bitcoin communications.  The
 // overall data flow is split into 3 goroutines and a separate block manager.
 // Inbound messages are read via the inHandler goroutine and generally
@@ -188,7 +196,7 @@ type peer struct {
 	sendDoneQueue      chan struct{}
 	queueWg            sync.WaitGroup // TODO(oga) wg -> single use channel?
 	outputInvChan      chan *wire.InvVect
-	blockStallActivate chan time.Duration
+	blockStallActivate chan blockStallMsg
 	blockStallTimer    <-chan time.Time
 	blockStallMtx      sync.Mutex // protects access to blockStallCancel
 	blockStallCancel   chan struct{}
@@ -240,7 +248,11 @@ func (p *peer) isKnownInventory(invVect *wire.InvVect) bool {
 // passes before the peer receives a "block" response, then the peer will
 // disconnect itself.
 func (p *peer) SetBlockStallTimer(timeout time.Duration) {
-	p.blockStallActivate <- timeout
+	done := make(chan struct{}, 1)
+	bsmsg := blockStallMsg{timeout: timeout, doneChan: done}
+
+	p.blockStallActivate <- bsmsg
+	<-done
 }
 
 // UpdateLastBlockHeight updates the last known block for the peer. It is safe
@@ -1461,6 +1473,13 @@ func (p *peer) inHandler() {
 		}
 		p.Disconnect()
 	})
+	cancelBlockStall := func() {
+		p.blockStallMtx.Lock()
+		if p.blockStallCancel != nil {
+			close(p.blockStallCancel)
+		}
+		p.blockStallMtx.Unlock()
+	}
 out:
 	for atomic.LoadInt32(&p.disconnect) == 0 {
 		rmsg, buf, err := p.readMessage()
@@ -1575,17 +1594,17 @@ out:
 			p.handleTxMsg(msg)
 
 		case *wire.MsgBlock:
-			p.blockStallMtx.Lock()
-			if p.blockStallCancel != nil {
-				close(p.blockStallCancel)
-			}
-			p.blockStallMtx.Unlock()
+			cancelBlockStall()
 			p.handleBlockMsg(msg, buf)
 
 		case *wire.MsgInv:
+			if invContainsBlock(msg.InvList) {
+				cancelBlockStall()
+			}
 			p.handleInvMsg(msg)
 
 		case *wire.MsgHeaders:
+			cancelBlockStall()
 			p.handleHeadersMsg(msg)
 
 		case *wire.MsgNotFound:
@@ -1790,6 +1809,21 @@ func (p *peer) outHandler() {
 	})
 	var blockStallActive bool
 	var stallTimeout time.Duration
+	// Starts a blockStallTimer if one is not currently active started, then
+	// initialize the timer to fire off a read in blockStallTimeout seconds.
+	// Additionally, create a cancellation channel so the inHandler can
+	// signal us if a MsgBlock comes in time.
+	startBlockStallTimer := func() bool {
+		if blockStallActive && p.blockStallTimer == nil {
+			p.blockStallTimer = time.After(stallTimeout)
+
+			p.blockStallMtx.Lock()
+			p.blockStallCancel = make(chan struct{})
+			p.blockStallMtx.Unlock()
+			return true
+		}
+		return false
+	}
 out:
 	for {
 		select {
@@ -1826,23 +1860,33 @@ out:
 			case *wire.MsgGetData:
 				// Should get us block, tx, or not found.
 
-				// If the blockStallTimer has not already been
-				// started, then initialize the timer to fire
-				// off a read in blockStallTimeout seconds.
-				// Additionally, create a cancellation channel
-				// so the inHandler can signal us if a MsgBlock
-				// comes in time.
+				// If we're requesting any blocks in this
+				// MsgGetData, then we activate a block stall
+				// timer to be cancelled if we get a block
+				// message in time.
 				gdmsg := msg.msg.(*wire.MsgGetData)
-				if blockStallActive && p.blockStallTimer == nil &&
-					invContainsBlock(gdmsg.InvList) {
-					peerLog.Debugf("Starting block stall timer for: %v", p)
-					p.blockStallTimer = time.After(stallTimeout)
-					p.blockStallMtx.Lock()
-					p.blockStallCancel = make(chan struct{})
-					p.blockStallMtx.Unlock()
+				if invContainsBlock(gdmsg.InvList) {
+					if startBlockStallTimer() {
+						peerLog.Debugf("Starting block stall timer (getdata) for: %v", p)
+					}
 				}
 			case *wire.MsgGetHeaders:
-				// Should get us headers back.
+				// Should get us headers back. We'll activate a
+				// block stall timer (if one isn't already active)
+				// to disconnect this peer if we don't get a
+				// headers message back in time.
+				if startBlockStallTimer() {
+					peerLog.Debugf("Starting block stall timer (getheaders) for: %v", p)
+				}
+			case *wire.MsgGetBlocks:
+				// If a blockStallTimer isn't already active for
+				// this peer, then we start a timer which will
+				// disconnect this peer after `blockStallTimeout`
+				// seconds unless we receive an INV containing block
+				// hashes before the timeout interval has passed.
+				if startBlockStallTimer() {
+					peerLog.Debugf("Starting block stall timer (get blocks) for: %v", p)
+				}
 			default:
 				// Not one of the above, no sure reply.
 				// We want to ping if nothing else
@@ -1863,11 +1907,16 @@ out:
 			p.sendDoneQueue <- struct{}{}
 			peerLog.Tracef("%s: acked queuehandler", p)
 
-		case timeout := <-p.blockStallActivate:
+		case blockStallMsg := <-p.blockStallActivate:
 			peerLog.Debugf("Activating block stall timer (%v) "+
-				"for: %v", timeout, p)
+				"for: %v", blockStallMsg.timeout, p)
+
 			blockStallActive = true
-			stallTimeout = timeout
+			stallTimeout = blockStallMsg.timeout
+
+			if blockStallMsg.doneChan != nil {
+				blockStallMsg.doneChan <- struct{}{}
+			}
 		case <-p.blockStallCancel:
 			// The inHandler received a MsgBlock before
 			// blockStallTimeout seconds had elapsed. So we set the
@@ -1875,17 +1924,18 @@ out:
 			// select loop won't block on those cases in the future.
 			peerLog.Debugf("Stopping block stall timer for: %v", p)
 			p.blockStallTimer = nil
+
 			p.blockStallMtx.Lock()
 			p.blockStallCancel = nil
 			p.blockStallMtx.Unlock()
+
 			blockStallActive = false
 		case <-p.blockStallTimer:
 			// The inHandler didn't receive a MsgBlock before
 			// blockStallTimeout seconds had elapsed. So we
 			// disconnect the peer for stalling block download.
-			peerLog.Warnf("Peer %s is stalling initial "+
-				"block download, no block response for %v "+
-				"disconnecting", p, blockStallTimeout)
+			peerLog.Warnf("Peer %s is stalling block download, no "+
+				"block response for %v  disconnecting", p, blockStallTimeout)
 			p.Disconnect()
 		case <-p.quit:
 			break out
@@ -2040,7 +2090,7 @@ func newPeerBase(s *server, inbound bool) *peer {
 		sendQueue:          make(chan outMsg, 1),   // nonblocking sync
 		sendDoneQueue:      make(chan struct{}, 1), // nonblocking sync
 		outputInvChan:      make(chan *wire.InvVect, outputBufferSize),
-		blockStallActivate: make(chan time.Duration),
+		blockStallActivate: make(chan blockStallMsg, 1),
 		txProcessed:        make(chan struct{}, 1),
 		blockProcessed:     make(chan struct{}, 1),
 		quit:               make(chan struct{}),

--- a/peer.go
+++ b/peer.go
@@ -188,6 +188,10 @@ type peer struct {
 	sendDoneQueue      chan struct{}
 	queueWg            sync.WaitGroup // TODO(oga) wg -> single use channel?
 	outputInvChan      chan *wire.InvVect
+	blockStallActivate chan time.Duration
+	blockStallTimer    <-chan time.Time
+	blockStallMtx      sync.Mutex // protects access to blockStallCancel
+	blockStallCancel   chan struct{}
 	txProcessed        chan struct{}
 	blockProcessed     chan struct{}
 	quit               chan struct{}
@@ -228,6 +232,15 @@ func (p *peer) isKnownInventory(invVect *wire.InvVect) bool {
 		return true
 	}
 	return false
+}
+
+// SetBlockStallTimer activates the block stall timer for this peer. After the
+// block stall timeout mode has been activated, the next outgoing "getdata"
+// message which requests a block will start the timer. If 'timeout' seconds
+// passes before the peer receives a "block" response, then the peer will
+// disconnect itself.
+func (p *peer) SetBlockStallTimer(timeout time.Duration) {
+	p.blockStallActivate <- timeout
 }
 
 // UpdateLastBlockHeight updates the last known block for the peer. It is safe
@@ -1562,6 +1575,11 @@ out:
 			p.handleTxMsg(msg)
 
 		case *wire.MsgBlock:
+			p.blockStallMtx.Lock()
+			if p.blockStallCancel != nil {
+				close(p.blockStallCancel)
+			}
+			p.blockStallMtx.Unlock()
 			p.handleBlockMsg(msg, buf)
 
 		case *wire.MsgInv:
@@ -1770,6 +1788,8 @@ func (p *peer) outHandler() {
 		}
 		p.QueueMessage(wire.NewMsgPing(nonce), nil)
 	})
+	var blockStallActive bool
+	var stallTimeout time.Duration
 out:
 	for {
 		select {
@@ -1805,6 +1825,22 @@ out:
 				// Should return an inv.
 			case *wire.MsgGetData:
 				// Should get us block, tx, or not found.
+
+				// If the blockStallTimer has not already been
+				// started, then initialize the timer to fire
+				// off a read in blockStallTimeout seconds.
+				// Additionally, create a cancellation channel
+				// so the inHandler can signal us if a MsgBlock
+				// comes in time.
+				gdmsg := msg.msg.(*wire.MsgGetData)
+				if blockStallActive && p.blockStallTimer == nil &&
+					invContainsBlock(gdmsg.InvList) {
+					peerLog.Debugf("Starting block stall timer for: %v", p)
+					p.blockStallTimer = time.After(stallTimeout)
+					p.blockStallMtx.Lock()
+					p.blockStallCancel = make(chan struct{})
+					p.blockStallMtx.Unlock()
+				}
 			case *wire.MsgGetHeaders:
 				// Should get us headers back.
 			default:
@@ -1827,6 +1863,30 @@ out:
 			p.sendDoneQueue <- struct{}{}
 			peerLog.Tracef("%s: acked queuehandler", p)
 
+		case timeout := <-p.blockStallActivate:
+			peerLog.Debugf("Activating block stall timer (%v) "+
+				"for: %v", timeout, p)
+			blockStallActive = true
+			stallTimeout = timeout
+		case <-p.blockStallCancel:
+			// The inHandler received a MsgBlock before
+			// blockStallTimeout seconds had elapsed. So we set the
+			// blockStallTimer and blockStallCancel to nil so the
+			// select loop won't block on those cases in the future.
+			peerLog.Debugf("Stopping block stall timer for: %v", p)
+			p.blockStallTimer = nil
+			p.blockStallMtx.Lock()
+			p.blockStallCancel = nil
+			p.blockStallMtx.Unlock()
+			blockStallActive = false
+		case <-p.blockStallTimer:
+			// The inHandler didn't receive a MsgBlock before
+			// blockStallTimeout seconds had elapsed. So we
+			// disconnect the peer for stalling block download.
+			peerLog.Warnf("Peer %s is stalling initial "+
+				"block download, no block response for %v "+
+				"disconnecting", p, blockStallTimeout)
+			p.Disconnect()
 		case <-p.quit:
 			break out
 		}
@@ -1966,23 +2026,24 @@ func (p *peer) Shutdown() {
 // functions to perform base setup needed by both types of peers.
 func newPeerBase(s *server, inbound bool) *peer {
 	p := peer{
-		server:          s,
-		protocolVersion: maxProtocolVersion,
-		btcnet:          s.chainParams.Net,
-		services:        wire.SFNodeNetwork,
-		inbound:         inbound,
-		knownAddresses:  make(map[string]struct{}),
-		knownInventory:  NewMruInventoryMap(maxKnownInventory),
-		requestedTxns:   make(map[wire.ShaHash]struct{}),
-		requestedBlocks: make(map[wire.ShaHash]struct{}),
-		filter:          bloom.LoadFilter(nil),
-		outputQueue:     make(chan outMsg, outputBufferSize),
-		sendQueue:       make(chan outMsg, 1),   // nonblocking sync
-		sendDoneQueue:   make(chan struct{}, 1), // nonblocking sync
-		outputInvChan:   make(chan *wire.InvVect, outputBufferSize),
-		txProcessed:     make(chan struct{}, 1),
-		blockProcessed:  make(chan struct{}, 1),
-		quit:            make(chan struct{}),
+		server:             s,
+		protocolVersion:    maxProtocolVersion,
+		btcnet:             s.chainParams.Net,
+		services:           wire.SFNodeNetwork,
+		inbound:            inbound,
+		knownAddresses:     make(map[string]struct{}),
+		knownInventory:     NewMruInventoryMap(maxKnownInventory),
+		requestedTxns:      make(map[wire.ShaHash]struct{}),
+		requestedBlocks:    make(map[wire.ShaHash]struct{}),
+		filter:             bloom.LoadFilter(nil),
+		outputQueue:        make(chan outMsg, outputBufferSize),
+		sendQueue:          make(chan outMsg, 1),   // nonblocking sync
+		sendDoneQueue:      make(chan struct{}, 1), // nonblocking sync
+		outputInvChan:      make(chan *wire.InvVect, outputBufferSize),
+		blockStallActivate: make(chan time.Duration),
+		txProcessed:        make(chan struct{}, 1),
+		blockProcessed:     make(chan struct{}, 1),
+		quit:               make(chan struct{}),
 	}
 	return &p
 }
@@ -2080,4 +2141,15 @@ func (p *peer) logError(fmt string, args ...interface{}) {
 	} else {
 		peerLog.Debugf(fmt, args...)
 	}
+}
+
+// invContainsBlock returns true if the passed InvList contains an Inv of type
+// InvTypeBlock. Otherwise, it returns false.
+func invContainsBlock(invList []*wire.InvVect) bool {
+	for _, inv := range invList {
+		if inv.Type == wire.InvTypeBlock {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
This commit fixes a long standing bug (#486) which previously, would cause a
syncing node to get "stuck", halting all forward progress with respect
to keeping up with the main chain.

There are many nodes on the network which claim to be a fully
functioning full-node, but don't actually properly implement the entire
p2p protocol. For this particular case, after receiving a "getdata" requesting
blocks, these nodes fail to respond with a "block" message.
This would cause btcd to stall block download indefinitely, waiting for
a response which never arrives. Since btcd currently syncs new blocks
via a single syncPeer, it would never attempt to seek to new, active
peers to download the next block from. To fix this issue, we now
disconnect peers whom we deem are stalling forward progress after a
specified timeout.

