### PR TITLE
Update TravisCI to test against golang 1.5.1.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.3.3
   - 1.4.2
+  - 1.5.1
 sudo: false
 before_install:
   - gotools=golang.org/x/tools

--- a/goclean.sh
+++ b/goclean.sh
@@ -10,10 +10,10 @@
 set -ex
 
 # Automatic checks
-test -z $(gofmt -l -w . | tee /dev/stderr)
-test -z $(goimports -l -w . | tee /dev/stderr)
-test -z $(golint ./... | grep -v "ALL_CAPS\|OP_\|NewFieldVal\|Id\|RpcCommand\|RpcRawCommand\|RpcSend\|Dns" | tee /dev/stderr)
-go tool vet -structtags=false .
+test -z "$(gofmt -l -w . | tee /dev/stderr)"
+test -z "$(goimports -l -w . | tee /dev/stderr)"
+test -z "$(golint ./... | grep -v 'ALL_CAPS\|OP_\|NewFieldVal\|Id\|RpcCommand\|RpcRawCommand\|RpcSend\|Dns' | tee /dev/stderr)"
+test -z "$(go tool vet . 2>&1 | grep -v 'Example\|newestSha' | tee /dev/stderr)"
 env GORACE="halt_on_error=1" go test -v -race ./...
 
 # Run test coverage on each subdirectories and merge the coverage profile.


### PR DESCRIPTION
This pull request updates TravisCI to use the most recent versions of Go and also modifies the `goclean.sh` script to quote the test command arguments and update the vet test to exclude recent false positives.