### PR TITLE
wire: Reject non-canonically encoded varints.

### DIFF
--- a/wire/msgversion.go
+++ b/wire/msgversion.go
@@ -18,7 +18,7 @@ import (
 const MaxUserAgentLen = 2000
 
 // DefaultUserAgent for wire in the stack
-const DefaultUserAgent = "/btcwire:0.2.0/"
+const DefaultUserAgent = "/btcwire:0.2.1/"
 
 // MsgVersion implements the Message interface and represents a bitcoin version
 // message.  It is used for a peer to advertise itself as soon as an outbound


### PR DESCRIPTION
The Bitcoin wire protocol includes several fields with their lengths encoded according to a variable length integer encoding scheme that does not enforce a unique encoding for all numbers.

This can lead to a situation where deserializing and re-serializing the same data can result in different bytes.  There are no currently known issues due to this, but it is safer to reject such subtle differences as
they could potentially lead to exploits.

Consequently, this pull request modifies the varint decoding function to error when the value is not canonically encoded which effectively means that all messages with varints that are not canonically encoded will now be rejected.  This will not cause issues with old client versions in regards to blocks and transactions since the data is deserialized into memory and then reserialized before being relayed thereby effectively erasing any non-canonical encodings.

Also, new tests have been added to ensure non-canonical encodings are properly rejected and exercise the new code, and the default user agent version for wire has been bumped to version 0.2.1 to differentiate the new behavior.

The equivalent logic was implemented in Bitcoin Core by PR 2884.