### PR TITLE
btcjson: Add errors to InfoChainResult

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -364,6 +364,7 @@ type InfoChainResult struct {
 	Difficulty      float64 `json:"difficulty"`
 	TestNet         bool    `json:"testnet"`
 	RelayFee        float64 `json:"relayfee"`
+	Errors          string  `json:"errors"`
 }
 
 // LocalAddressesResult models the localaddresses data from the getnetworkinfo


### PR DESCRIPTION
The getinfo RPC will now include the errors attribute in the
result.