### PR TITLE
txscript:  Add ScriptVerifyLowS to the standard flags

### DIFF
--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -30,7 +30,8 @@ const (
 		ScriptVerifyMinimalData |
 		ScriptStrictMultiSig |
 		ScriptDiscourageUpgradableNops |
-		ScriptVerifyCleanStack
+		ScriptVerifyCleanStack |
+		ScriptVerifyLowS
 )
 
 // ScriptClass is an enumeration for the list of standard types of script.


### PR DESCRIPTION
We've already been generating lowS sigs for quite a while.  This removes
the malleability vector.

This mimics Bitcoin Core commit 49dd5c629df0a08cf3b1ea8085c03312d1a81696