### PR TITLE
adds filteraddrs param to searchrawtransactions API

### DIFF
--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -549,12 +549,13 @@ func NewReconsiderBlockCmd(blockHash string) *ReconsiderBlockCmd {
 
 // SearchRawTransactionsCmd defines the searchrawtransactions JSON-RPC command.
 type SearchRawTransactionsCmd struct {
-	Address  string
-	Verbose  *int  `jsonrpcdefault:"1"`
-	Skip     *int  `jsonrpcdefault:"0"`
-	Count    *int  `jsonrpcdefault:"100"`
-	VinExtra *int  `jsonrpcdefault:"0"`
-	Reverse  *bool `jsonrpcdefault:"false"`
+	Address     string
+	Verbose     *int  `jsonrpcdefault:"1"`
+	Skip        *int  `jsonrpcdefault:"0"`
+	Count       *int  `jsonrpcdefault:"100"`
+	VinExtra    *int  `jsonrpcdefault:"0"`
+	Reverse     *bool `jsonrpcdefault:"false"`
+	FilterAddrs *[]string
 }
 
 // NewSearchRawTransactionsCmd returns a new instance which can be used to issue a
@@ -562,14 +563,15 @@ type SearchRawTransactionsCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewSearchRawTransactionsCmd(address string, verbose, skip, count *int, vinExtra *int, reverse *bool) *SearchRawTransactionsCmd {
+func NewSearchRawTransactionsCmd(address string, verbose, skip, count *int, vinExtra *int, reverse *bool, filterAddrs *[]string) *SearchRawTransactionsCmd {
 	return &SearchRawTransactionsCmd{
-		Address:  address,
-		Verbose:  verbose,
-		Skip:     skip,
-		Count:    count,
-		VinExtra: vinExtra,
-		Reverse:  reverse,
+		Address:     address,
+		Verbose:     verbose,
+		Skip:        skip,
+		Count:       count,
+		VinExtra:    vinExtra,
+		Reverse:     reverse,
+		FilterAddrs: filterAddrs,
 	}
 }
 

--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -700,16 +700,17 @@ func TestChainSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("searchrawtransactions", "1Address")
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewSearchRawTransactionsCmd("1Address", nil, nil, nil, nil, nil)
+				return btcjson.NewSearchRawTransactionsCmd("1Address", nil, nil, nil, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address"],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
-				Address:  "1Address",
-				Verbose:  btcjson.Int(1),
-				Skip:     btcjson.Int(0),
-				Count:    btcjson.Int(100),
-				VinExtra: btcjson.Int(0),
-				Reverse:  btcjson.Bool(false),
+				Address:     "1Address",
+				Verbose:     btcjson.Int(1),
+				Skip:        btcjson.Int(0),
+				Count:       btcjson.Int(100),
+				VinExtra:    btcjson.Int(0),
+				Reverse:     btcjson.Bool(false),
+				FilterAddrs: nil,
 			},
 		},
 		{
@@ -719,16 +720,17 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Int(0), nil, nil, nil, nil)
+					btcjson.Int(0), nil, nil, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
-				Address:  "1Address",
-				Verbose:  btcjson.Int(0),
-				Skip:     btcjson.Int(0),
-				Count:    btcjson.Int(100),
-				VinExtra: btcjson.Int(0),
-				Reverse:  btcjson.Bool(false),
+				Address:     "1Address",
+				Verbose:     btcjson.Int(0),
+				Skip:        btcjson.Int(0),
+				Count:       btcjson.Int(100),
+				VinExtra:    btcjson.Int(0),
+				Reverse:     btcjson.Bool(false),
+				FilterAddrs: nil,
 			},
 		},
 		{
@@ -738,16 +740,17 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Int(0), btcjson.Int(5), nil, nil, nil)
+					btcjson.Int(0), btcjson.Int(5), nil, nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
-				Address:  "1Address",
-				Verbose:  btcjson.Int(0),
-				Skip:     btcjson.Int(5),
-				Count:    btcjson.Int(100),
-				VinExtra: btcjson.Int(0),
-				Reverse:  btcjson.Bool(false),
+				Address:     "1Address",
+				Verbose:     btcjson.Int(0),
+				Skip:        btcjson.Int(5),
+				Count:       btcjson.Int(100),
+				VinExtra:    btcjson.Int(0),
+				Reverse:     btcjson.Bool(false),
+				FilterAddrs: nil,
 			},
 		},
 		{
@@ -757,16 +760,17 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Int(0), btcjson.Int(5), btcjson.Int(10), nil, nil)
+					btcjson.Int(0), btcjson.Int(5), btcjson.Int(10), nil, nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
-				Address:  "1Address",
-				Verbose:  btcjson.Int(0),
-				Skip:     btcjson.Int(5),
-				Count:    btcjson.Int(10),
-				VinExtra: btcjson.Int(0),
-				Reverse:  btcjson.Bool(false),
+				Address:     "1Address",
+				Verbose:     btcjson.Int(0),
+				Skip:        btcjson.Int(5),
+				Count:       btcjson.Int(10),
+				VinExtra:    btcjson.Int(0),
+				Reverse:     btcjson.Bool(false),
+				FilterAddrs: nil,
 			},
 		},
 		{
@@ -776,16 +780,17 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Int(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), nil)
+					btcjson.Int(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
-				Address:  "1Address",
-				Verbose:  btcjson.Int(0),
-				Skip:     btcjson.Int(5),
-				Count:    btcjson.Int(10),
-				VinExtra: btcjson.Int(1),
-				Reverse:  btcjson.Bool(false),
+				Address:     "1Address",
+				Verbose:     btcjson.Int(0),
+				Skip:        btcjson.Int(5),
+				Count:       btcjson.Int(10),
+				VinExtra:    btcjson.Int(1),
+				Reverse:     btcjson.Bool(false),
+				FilterAddrs: nil,
 			},
 		},
 		{
@@ -795,16 +800,37 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 			staticCmd: func() interface{} {
 				return btcjson.NewSearchRawTransactionsCmd("1Address",
-					btcjson.Int(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), btcjson.Bool(true))
+					btcjson.Int(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), btcjson.Bool(true), nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1,true],"id":1}`,
 			unmarshalled: &btcjson.SearchRawTransactionsCmd{
-				Address:  "1Address",
-				Verbose:  btcjson.Int(0),
-				Skip:     btcjson.Int(5),
-				Count:    btcjson.Int(10),
-				VinExtra: btcjson.Int(1),
-				Reverse:  btcjson.Bool(true),
+				Address:     "1Address",
+				Verbose:     btcjson.Int(0),
+				Skip:        btcjson.Int(5),
+				Count:       btcjson.Int(10),
+				VinExtra:    btcjson.Int(1),
+				Reverse:     btcjson.Bool(true),
+				FilterAddrs: nil,
+			},
+		},
+		{
+			name: "searchrawtransactions",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("searchrawtransactions", "1Address", 0, 5, 10, 1, true, []string{"1Address"})
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewSearchRawTransactionsCmd("1Address",
+					btcjson.Int(0), btcjson.Int(5), btcjson.Int(10), btcjson.Int(1), btcjson.Bool(true), &[]string{"1Address"})
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"searchrawtransactions","params":["1Address",0,5,10,1,true,["1Address"]],"id":1}`,
+			unmarshalled: &btcjson.SearchRawTransactionsCmd{
+				Address:     "1Address",
+				Verbose:     btcjson.Int(0),
+				Skip:        btcjson.Int(5),
+				Count:       btcjson.Int(10),
+				VinExtra:    btcjson.Int(1),
+				Reverse:     btcjson.Bool(true),
+				FilterAddrs: &[]string{"1Address"},
 			},
 		},
 		{

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -400,7 +400,7 @@ type TxRawResult struct {
 // SearchRawTransactionsResult models the data from the searchrawtransaction
 // command.
 type SearchRawTransactionsResult struct {
-	Hex           string       `json:"hex"`
+	Hex           string       `json:"hex,omitempty"`
 	Txid          string       `json:"txid"`
 	Version       int32        `json:"version"`
 	LockTime      uint32       `json:"locktime"`

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -472,6 +472,7 @@ var helpDescsEnUS = map[string]string{
 	"searchrawtransactions-count":       "The maximum number of transactions to return",
 	"searchrawtransactions-vinextra":    "Specify that extra data from previous output will be returned in vin",
 	"searchrawtransactions-reverse":     "Specifies that the transactions should be returned in reverse chronological order",
+	"searchrawtransactions-filteraddrs": "Address list.  Only inputs or outputs with matching address will be returned",
 	"searchrawtransactions--result0":    "Hex-encoded serialized transaction",
 
 	// SendRawTransactionCmd help.


### PR DESCRIPTION
# abstract
The new filteraddrs parameter enables the caller to pass a list of addresses to the searchrawtransactions API. Only inputs and outputs that match addresses in the list will be returned.

Additionally, if at least 1 filter address is passed then the (loooong) Hex attribute of the transaction will be empty.  ( though key is still present. )

# motivation
To increase efficiency of the API particularly in terms of bandwidth usage, processing overhead for the caller, and overall roundtrip time.    The API is presently returning datasets that are 20+ MB for some addresses when the application may need only a tiny fraction of that.

# example
My application displays a transaction history for one or more addresses.  To do this, it calls searchrawtransaction once per address.  It only needs to see the vin/vout entries that pay to or from that address.  Below we call this address passed as the first param to searchrawtransactions the "target address".

For bitcoin addresses with many inputs and outputs such as those involved in mining pool payouts, the bulk of the inputs/outputs are NOT related to the target address.  All this extra data is unnecessary and wasteful.

Additionally, my application does not use the Hex attribute of the transaction, but a large amount of unused data is returned with it.

Using the new filteraddrs param, my application simply passes the target address as the only element in the filteraddrs array, and the majority of unused data disappears.

This implementation makes it possible to filter vin/vout by an address other than the target address.  Or by multiple addresses.  But likely the most common use-case will be to filter by target address only.

# how much savings?
Obviously the savings will vary depending on the address.  But the savings can be very significant.  For one address that I know was receiving mining pool payouts for a couple months, the total size of returned JSON is:
  without filteraddrs: 22938656 bytes,  6.911 seconds
  with filteraddrs: 123229 bytes, 2.087 seconds

So 22.9 MB vs 123KB.  That's 186 times smaller.  Also a 3x roundtrip speedup on localhost.  The speedup would of course be larger if making the call over the internet given the size of data being transferred.

Also, many addresses exist with many times more transactions and vin/vout.  I expect there are addresses that would return 100+ MB result sets.

# testing performed

1) Updated test cases for searchrawtransactions and added 1 new test case for the filteraddrs param.
2) passes goclean.sh tests.
3) Verified manually that the API works as expected when called (a) without filteraddrs param, (b) with filteraddrs set to nil, (c) with filteraddrs set to array containing target address only, (d) with filteraddrs set to array with multiple addresses from the result set.
4) Used in my application and verified that the transaction history appears the same with or without the filterAddrs param in use.

# further thoughts / notes

## bool flag vs array/list
If we assume that the target address is going to be the desired filter 99.99% of the time then it is simpler just to use a boolean "filterAddr=true" than a list.  In fact, my initial implementation did this.  However, for public use I imagine there will likely be other use cases, and the performance is about the same, so I decided to expose a filterlist to the caller.

## empty filter list behavior
In this implementation the behavior is the same if filteraddrs arg is omitted or if an empty array is passed.  In either case, all vin/vout and also the tx.Hex attribute are returned as per legacy behavior.

It is possible that a caller might wish to omit ALL vin/vout and might try passing an empty array to achieve this.  But that won't work.   A workaround for this person would be to pass a single impossible address.  That will never match anything, so all will be filtered out.

Alternatively, it would be possible to change the behavior so that an empty array filters out all, but nil/null filters nothing.

## Tx.Hex attribute

This patch presently includes the hex attribute but with an empty value when filterAddrs contains 1 or more values.  We could hide/remove it entirely via the json omitempty flag.   Alternatively, this change could be de-bundled from the patch and be part of a more comprehensive "user chooses fields" feature.  see below.

## further size savings
Additional savings are possible.  I tried to make this patch conservative by removing only the worst offenders and thereby getting the most bang for the buck.  A possible future approach could be to allow the caller to specify which fields to receive/omit for the tx, vins, vouts via a separate parameter.  This would be similar to a SQL select list.  I'm not proposing to work on this, as the present patch is good enough for my needs.  Just throwing it out there as food for thought.

## parameter creep
searchrawtransactions is such a useful function it would not surprise me if future parameters get added, and each one changes the signature and adds new default.  So an idea for the dev team to consider would be creating a new param called "options" which is a struct.  So adding new params is as simple as adding a new key to this struct, and callers do not have to specify all the defaults for previous params.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/516)
<!-- Reviewable:end -->
