### PR TITLE
Correct a few style related issues found by golint.

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -12,7 +12,7 @@ set -ex
 # Automatic checks
 test -z "$(gofmt -l -w . | tee /dev/stderr)"
 test -z "$(goimports -l -w . | tee /dev/stderr)"
-test -z "$(golint ./... | grep -v 'ALL_CAPS\|OP_\|NewFieldVal\|Id\|RpcCommand\|RpcRawCommand\|RpcSend\|Dns' | tee /dev/stderr)"
+test -z "$(golint ./... | grep -v 'ALL_CAPS\|OP_\|NewFieldVal\|RpcCommand\|RpcRawCommand\|RpcSend\|Dns' | tee /dev/stderr)"
 test -z "$(go tool vet . 2>&1 | grep -v 'Example\|newestSha' | tee /dev/stderr)"
 env GORACE="halt_on_error=1" go test -v -race ./...
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -395,15 +395,15 @@ func handleNode(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (inter
 	c := cmd.(*btcjson.NodeCmd)
 
 	var addr string
-	var nodeId uint64
+	var nodeID uint64
 	var errN, err error
 	switch c.SubCmd {
 	case "disconnect":
 		// If we have a valid uint disconnect by node id. Otherwise,
 		// attempt to disconnect by address, returning an error if a
 		// valid IP address is not supplied.
-		if nodeId, errN = strconv.ParseUint(c.Target, 10, 32); errN == nil {
-			err = s.server.DisconnectNodeById(int32(nodeId))
+		if nodeID, errN = strconv.ParseUint(c.Target, 10, 32); errN == nil {
+			err = s.server.DisconnectNodeByID(int32(nodeID))
 		} else {
 			if _, _, errP := net.SplitHostPort(c.Target); errP == nil || net.ParseIP(c.Target) != nil {
 				addr = normalizeAddress(c.Target, activeNetParams.DefaultPort)
@@ -415,7 +415,7 @@ func handleNode(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (inter
 				}
 			}
 		}
-		if err != nil && peerExists(s.server.PeerInfo(), addr, int32(nodeId)) {
+		if err != nil && peerExists(s.server.PeerInfo(), addr, int32(nodeID)) {
 			return nil, &btcjson.RPCError{
 				Code:    btcjson.ErrRPCMisc,
 				Message: "can't disconnect a permanent peer, use remove",
@@ -425,8 +425,8 @@ func handleNode(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (inter
 		// If we have a valid uint disconnect by node id. Otherwise,
 		// attempt to disconnect by address, returning an error if a
 		// valid IP address is not supplied.
-		if nodeId, errN = strconv.ParseUint(c.Target, 10, 32); errN == nil {
-			err = s.server.RemoveNodeById(int32(nodeId))
+		if nodeID, errN = strconv.ParseUint(c.Target, 10, 32); errN == nil {
+			err = s.server.RemoveNodeByID(int32(nodeID))
 		} else {
 			if _, _, errP := net.SplitHostPort(c.Target); errP == nil || net.ParseIP(c.Target) != nil {
 				addr = normalizeAddress(c.Target, activeNetParams.DefaultPort)
@@ -438,7 +438,7 @@ func handleNode(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (inter
 				}
 			}
 		}
-		if err != nil && peerExists(s.server.PeerInfo(), addr, int32(nodeId)) {
+		if err != nil && peerExists(s.server.PeerInfo(), addr, int32(nodeID)) {
 			return nil, &btcjson.RPCError{
 				Code:    btcjson.ErrRPCMisc,
 				Message: "can't remove a temporary peer, use disconnect",
@@ -483,9 +483,9 @@ func handleNode(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (inter
 // peerExists determines if a certain peer is currently connected given
 // information about all currently connected peers. Peer existence is
 // determined using either a target address or node id.
-func peerExists(peerInfos []*btcjson.GetPeerInfoResult, addr string, nodeId int32) bool {
+func peerExists(peerInfos []*btcjson.GetPeerInfoResult, addr string, nodeID int32) bool {
 	for _, peerInfo := range peerInfos {
-		if peerInfo.ID == nodeId || peerInfo.Addr == addr {
+		if peerInfo.ID == nodeID || peerInfo.Addr == addr {
 			return true
 		}
 	}

--- a/server.go
+++ b/server.go
@@ -878,7 +878,7 @@ func (s *server) DisconnectNodeByAddr(addr string) error {
 // DisconnectNodeByID disconnects a peer by target node id. Both outbound and
 // inbound nodes will be searched for the target node. An error message will be
 // returned if the peer was not found.
-func (s *server) DisconnectNodeById(id int32) error {
+func (s *server) DisconnectNodeByID(id int32) error {
 	replyChan := make(chan error)
 
 	s.query <- disconnectNodeMsg{
@@ -902,9 +902,9 @@ func (s *server) RemoveNodeByAddr(addr string) error {
 	return <-replyChan
 }
 
-// RemoveNodeById removes a peer by node ID from the list of persistent peers
+// RemoveNodeByID removes a peer by node ID from the list of persistent peers
 // if present. An error will be returned if the peer was not found.
-func (s *server) RemoveNodeById(id int32) error {
+func (s *server) RemoveNodeByID(id int32) error {
 	replyChan := make(chan error)
 
 	s.query <- removeNodeMsg{

--- a/wire/blockheader.go
+++ b/wire/blockheader.go
@@ -13,6 +13,7 @@ import (
 // BlockVersion is the current latest supported block version.
 const BlockVersion = 3
 
+// MaxBlockHeaderPayload is the maximum number of bytes a block header can be.
 // Version 4 bytes + Timestamp 4 bytes + Bits 4 bytes + Nonce 4 bytes +
 // PrevBlock and MerkleRoot hashes.
 const MaxBlockHeaderPayload = 16 + (HashSize * 2)

--- a/wire/common.go
+++ b/wire/common.go
@@ -14,7 +14,7 @@ import (
 	"github.com/btcsuite/fastsha256"
 )
 
-// Maximum payload size for a variable length integer.
+// MaxVarIntPayload is the maximum payload size for a variable length integer.
 const MaxVarIntPayload = 9
 
 // errNonCanonicalVarInt is the common format string used for non-canonically

--- a/wire/shahash.go
+++ b/wire/shahash.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 )
 
-// Size of array used to store sha hashes.  See ShaHash.
+// HashSize is the array size used to store sha hashes.  See ShaHash.
 const HashSize = 32
 
 // MaxHashStringSize is the maximum length of a ShaHash hash string.


### PR DESCRIPTION
Also, update TravisCI goclean script to remove the special casing which ignored `Id` from the lint output since that exception is no longer needed.  It was previously required due to the old version of `btcjson`,
but that is no longer in the repo.