### PR TITLE
config: New option --minrelaytxfee

### DIFF
--- a/config.go
+++ b/config.go
@@ -106,6 +106,7 @@ type config struct {
 	CPUProfile         string        `long:"cpuprofile" description:"Write CPU profile to the specified file"`
 	DebugLevel         string        `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
 	Upnp               bool          `long:"upnp" description:"Use UPnP to map our listening port outside of NAT"`
+	MinRelayTxFee      float64       `long:"minrelaytxfee" description:"The minimum transaction fee in BTC/kB to be considered a non-zero fee."`
 	FreeTxRelayLimit   float64       `long:"limitfreerelay" description:"Limit relay of transactions with no transaction fee to the given amount in thousands of bytes per minute"`
 	NoRelayPriority    bool          `long:"norelaypriority" description:"Do not require free or low-fee transactions to have high priority for relaying"`
 	MaxOrphanTxs       int           `long:"maxorphantx" description:"Max number of orphan transactions to keep in memory"`
@@ -124,6 +125,7 @@ type config struct {
 	oniondial          func(string, string) (net.Conn, error)
 	dial               func(string, string) (net.Conn, error)
 	miningAddrs        []btcutil.Address
+	minRelayTxFee      btcutil.Amount
 }
 
 // serviceOptions defines the configuration options for btcd as a service on
@@ -320,6 +322,7 @@ func loadConfig() (*config, []string, error) {
 		DbType:            defaultDbType,
 		RPCKey:            defaultRPCKeyFile,
 		RPCCert:           defaultRPCCertFile,
+		MinRelayTxFee:     defaultMinRelayTxFee.ToBTC(),
 		FreeTxRelayLimit:  defaultFreeTxRelayLimit,
 		BlockMinSize:      defaultBlockMinSize,
 		BlockMaxSize:      defaultBlockMaxSize,
@@ -592,6 +595,16 @@ func loadConfig() (*config, []string, error) {
 			addr = net.JoinHostPort(addr, activeNetParams.rpcPort)
 			cfg.RPCListeners = append(cfg.RPCListeners, addr)
 		}
+	}
+
+	// Validate the the minrelaytxfee.
+	cfg.minRelayTxFee, err = btcutil.NewAmount(cfg.MinRelayTxFee)
+	if err != nil {
+		str := "%s: invalid minrelaytxfee: %v"
+		err := fmt.Errorf(str, funcName, err)
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, usageMessage)
+		return nil, nil, err
 	}
 
 	// Limit the max block size to a sane value.

--- a/doc.go
+++ b/doc.go
@@ -81,6 +81,8 @@ Application Options:
                             the log level for individual subsystems -- Use show
                             to list available subsystems (info)
       --upnp                Use UPnP to map our listening port outside of NAT
+      --minrelaytxfee=      The minimum transaction fee in BTC/kB to be
+                            considered a non-zero fee.
       --limitfreerelay=     Limit relay of transactions with no transaction fee
                             to the given amount in thousands of bytes per
                             minute (15)

--- a/mining.go
+++ b/mining.go
@@ -604,13 +604,14 @@ mempoolLoop:
 
 		// Skip free transactions once the block is larger than the
 		// minimum block size.
-		if sortedByFee && prioItem.feePerKB < minTxRelayFee &&
+		if sortedByFee &&
+			prioItem.feePerKB < float64(cfg.minRelayTxFee) &&
 			blockPlusTxSize >= cfg.BlockMinSize {
 
 			minrLog.Tracef("Skipping tx %s with feePerKB %.2f "+
 				"< minTxRelayFee %d and block size %d >= "+
 				"minBlockSize %d", tx.Sha(), prioItem.feePerKB,
-				minTxRelayFee, blockPlusTxSize,
+				cfg.minRelayTxFee, blockPlusTxSize,
 				cfg.BlockMinSize)
 			logSkippedDeps(tx, deps)
 			continue

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2103,7 +2103,7 @@ func handleGetInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (in
 		Proxy:           cfg.Proxy,
 		Difficulty:      getDifficultyRatio(blkHeader.Bits),
 		TestNet:         cfg.TestNet3,
-		RelayFee:        float64(minTxRelayFee) / btcutil.SatoshiPerBitcoin,
+		RelayFee:        cfg.minRelayTxFee.ToBTC(),
 	}
 
 	return ret, nil

--- a/sample-btcd.conf
+++ b/sample-btcd.conf
@@ -214,6 +214,9 @@
 ; Mempool Settings - The following options
 ; ------------------------------------------------------------------------------
 
+; Set the minimum transaction fee to be considered a non-zero fee,
+; minrelaytxfee=0.00001
+
 ; Rate-limit free transactions to the value 15 * 1000 bytes per
 ; minute.
 ; limitfreerelay=15


### PR DESCRIPTION
--minrelaytxfee allows the user to specify the minimum transaction
fee in BTC/kB in which the fee is considered a non-zero fee.