### PR TITLE
txscript: fix isMultiSig bug.

### DIFF
--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -108,6 +108,13 @@ func isMultiSig(pops []parsedOpcode) bool {
 	if pops[l-1].opcode.value != OP_CHECKMULTISIG {
 		return false
 	}
+
+	// Verify the number of pubkeys specified matches the actual number
+	// of pubkeys provided.
+	if l-2-1 != asSmallInt(pops[l-2].opcode) {
+		return false
+	}
+
 	for _, pop := range pops[1 : l-2] {
 		// Valid pubkeys are either 33 or 65 bytes.
 		if len(pop.data) != 33 && len(pop.data) != 65 {

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -928,6 +928,18 @@ var scriptClassTests = []scriptClassTest{
 		script: "DATA_5 0x01020304",
 		class:  txscript.NonStandardTy,
 	},
+	{
+		name: "multisig script with wrong number of pubkeys",
+		script: "2 " +
+			"DATA_33 " +
+			"0x027adf5df7c965a2d46203c781bd4dd8" +
+			"21f11844136f6673af7cc5a4a05cd29380 " +
+			"DATA_33 " +
+			"0x02c08f3de8ee2de9be7bd770f4c10eb0" +
+			"d6ff1dd81ee96eedd3a9d4aeaf86695e80 " +
+			"3 CHECKMULTISIG",
+		class: txscript.NonStandardTy,
+	},
 }
 
 // TestScriptClass ensures all the scripts in scriptClassTests have the expected


### PR DESCRIPTION
isMultiSig was not verifying the number of pubkeys specified matched
the number of pubkeys provided.  This caused certain non-standard
scripts to be considered multisig scripts.

However, the script still would have failed during execution.

NOTE: This only affects whether or not the script is considered
standard and does NOT affect consensus.