### PR TITLE
docs: Make various README.md files consistent.

### DIFF
--- a/blockchain/README.md
+++ b/blockchain/README.md
@@ -4,6 +4,8 @@ blockchain
 [![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
 (https://travis-ci.org/btcsuite/btcd) [![ISC License]
 (http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcd/blockchain)
 
 Package blockchain implements bitcoin block handling and chain selection rules.
 The test coverage is currently only around 60%, but will be increasing over
@@ -18,23 +20,10 @@ This package has intentionally been designed so it can be used as a standalone
 package for any projects needing to handle processing of blocks into the bitcoin
 block chain.
 
-## Documentation
-
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/blockchain)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/btcsuite/btcd/blockchain
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcd/blockchain
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/btcsuite/btcd/blockchain
+$ go get -u github.com/btcsuite/btcd/blockchain
 ```
 
 ## Bitcoin Chain Processing Overview

--- a/btcec/README.md
+++ b/btcec/README.md
@@ -2,7 +2,10 @@ btcec
 =====
 
 [![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)]
-(https://travis-ci.org/btcsuite/btcec)
+(https://travis-ci.org/btcsuite/btcec) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://godoc.org/github.com/btcsuite/btcd/btcec?status.png)]
+(http://godoc.org/github.com/btcsuite/btcd/btcec)
 
 Package btcec implements elliptic curve cryptography needed for working with
 Bitcoin (secp256k1 only for now). It is designed so that it may be used with the
@@ -16,23 +19,10 @@ Although this package was primarily written for btcd, it has intentionally been
 designed so it can be used as a standalone package for any projects needing to
 use secp256k1 elliptic curve cryptography.
 
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/btcsuite/btcd/btcec?status.png)]
-(http://godoc.org/github.com/btcsuite/btcd/btcec)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site
-[here](http://godoc.org/github.com/btcsuite/btcd/btcec).
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcd/btcec
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/btcsuite/btcd/btcec
+$ go get -u github.com/btcsuite/btcd/btcec
 ```
 
 ## Examples

--- a/btcjson/README.md
+++ b/btcjson/README.md
@@ -4,6 +4,8 @@ btcjson
 [![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)]
 (https://travis-ci.org/btcsuite/btcd) [![ISC License]
 (http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcd/btcjson)
 
 Package btcjson implements concrete types for marshalling to and from the
 bitcoin JSON-RPC API.  A comprehensive suite of tests is provided to ensure
@@ -22,23 +24,10 @@ management, websocket support, automatic notification re-registration on
 reconnect, and conversion from the raw underlying RPC types (strings, floats,
 ints, etc) to higher-level types with many nice and useful properties.
 
-## Documentation
-
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/btcjson)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site
-[here](http://godoc.org/github.com/btcsuite/btcd/btcjson).
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcd/btcjson
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/btcsuite/btcd/btcjson
+$ go get -u github.com/btcsuite/btcd/btcjson
 ```
 
 ## Examples

--- a/chaincfg/README.md
+++ b/chaincfg/README.md
@@ -4,6 +4,8 @@ chaincfg
 [![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
 (https://travis-ci.org/btcsuite/btcd) [![ISC License]
 (http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcd/chaincfg)
 
 Package chaincfg defines chain configuration parameters for the three standard
 Bitcoin networks and provides the ability for callers to define their own custom
@@ -53,23 +55,10 @@ func main() {
 }
 ```
 
-## Documentation
-
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/chaincfg)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site
-[here](http://godoc.org/github.com/btcsuite/btcd/chaincfg).
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcd/chaincfg
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/btcsuite/btcd/chaincfg
+$ go get -u github.com/btcsuite/btcd/chaincfg
 ```
 
 ## GPG Verification Key

--- a/database/README.md
+++ b/database/README.md
@@ -4,6 +4,8 @@ database
 [![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
 (https://travis-ci.org/btcsuite/btcd)  [![ISC License]
 (http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcd/database)
 
 Package database provides a database interface for the bitcoin block chain and
 transactions.
@@ -18,23 +20,10 @@ likely want to use the [btcrpcclient](https://github.com/btcsuite/btcrpcclient)
 package which makes use of the [JSON-RPC API]
 (https://github.com/btcsuite/btcd/tree/master/docs/json_rpc_api.md).
 
-## Documentation
-
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/database)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site
-[here](http://godoc.org/github.com/btcsuite/btcd/database).
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcd/database
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/btcsuite/btcd/database
+$ go get -u github.com/btcsuite/btcd/database
 ```
 
 ## Examples

--- a/peer/README.md
+++ b/peer/README.md
@@ -4,6 +4,8 @@ peer
 [![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
 (https://travis-ci.org/btcsuite/btcd) [![ISC License]
 (http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcd/peer)
 
 Package peer provides a common base for creating and managing bitcoin network
 peers.
@@ -54,19 +56,6 @@ A quick overview of the major features peer provides are as follows:
      filtering and address randomization
  - Ability to wait for shutdown/disconnect
  - Comprehensive test coverage
-
-## Documentation
-
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/peer)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/btcsuite/btcd/peer
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcd/peer
 
 ## Installation and Updating
 

--- a/txscript/README.md
+++ b/txscript/README.md
@@ -2,11 +2,13 @@ txscript
 ========
 
 [![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)]
-(https://travis-ci.org/btcsuite/btcd)
+(https://travis-ci.org/btcsuite/btcd) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://godoc.org/github.com/btcsuite/btcd/txscript?status.png)]
+(http://godoc.org/github.com/btcsuite/btcd/txscript)
 
 Package txscript implements the bitcoin transaction script language.  There is
-a comprehensive test suite.  Package txscript is licensed under the liberal ISC
-license.
+a comprehensive test suite.
 
 This package has intentionally been designed so it can be used as a standalone
 package for any projects needing to use or validate bitcoin transaction scripts.
@@ -18,23 +20,10 @@ the bitcoin transactions.  This language is not turing complete
 although it is still fairly powerful.  A description of the language
 can be found at https://en.bitcoin.it/wiki/Script
 
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/btcsuite/btcd/txscript?status.png)]
-(http://godoc.org/github.com/btcsuite/btcd/txscript)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site
-[here](http://godoc.org/github.com/btcsuite/btcd/txscript).
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcd/txscript
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/btcsuite/btcd/txscript
+$ go get -u github.com/btcsuite/btcd/txscript
 ```
 
 ## Examples
@@ -75,4 +64,5 @@ verify the signature perform the following:
 
 ## License
 
-Package txscript is licensed under the liberal ISC License.
+Package txscript is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/wire/README.md
+++ b/wire/README.md
@@ -4,6 +4,8 @@ wire
 [![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
 (https://travis-ci.org/btcsuite/btcd) [![ISC License]
 (http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcd/wire)
 
 Package wire implements the bitcoin wire protocol.  A comprehensive suite of
 tests with 100% test coverage is provided to ensure proper functionality.
@@ -15,23 +17,10 @@ This package has intentionally been designed so it can be used as a standalone
 package for any projects needing to interface with bitcoin peers at the wire
 protocol level.
 
-## Documentation
-
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/wire)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/btcsuite/btcd/wire
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcd/wire
-
-## Installation
+## Installation and Updating
 
 ```bash
-$ go get github.com/btcsuite/btcd/wire
+$ go get -u github.com/btcsuite/btcd/wire
 ```
 
 ## Bitcoin Message Overview


### PR DESCRIPTION
First, it removes the documentation section from all the `README.md` files and instead puts a web-based godoc badge and link at the top with the other badges.  This is being done since the local godoc tool no longer ships with Go by default, so the instructions no longer work without first installing godoc. Due to this, pretty much everyone uses the web-based godoc these days anyways.  Anyone who has manually installed godoc won't need instructions.

Second, it makes sure the ISC license badge is at the top with the other badges and removes the textual reference in the overview section.

Finally, it's modifies the `Installation` section to `Installation and Updating` and adds a `-u` to the `go get` command since it works for both and thus is simpler.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/530)
<!-- Reviewable:end -->
