### PR TITLE
Implement BIP0065 changeover logic for v4 blocks.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -24,7 +24,7 @@ const (
 	// will require changes to the generated block.  Using the wire constant
 	// for generated block version could allow creation of invalid blocks
 	// for the updated version.
-	generatedBlockVersion = 3
+	generatedBlockVersion = 4
 
 	// minHighPriority is the minimum priority value that allows a
 	// transaction to be considered high priority.

--- a/wire/blockheader.go
+++ b/wire/blockheader.go
@@ -11,7 +11,7 @@ import (
 )
 
 // BlockVersion is the current latest supported block version.
-const BlockVersion = 3
+const BlockVersion = 4
 
 // MaxBlockHeaderPayload is the maximum number of bytes a block header can be.
 // Version 4 bytes + Timestamp 4 bytes + Bits 4 bytes + Nonce 4 bytes +


### PR DESCRIPTION
This commit implements the changeover logic for version 4 blocks as
described by BIP0065.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/535)
<!-- Reviewable:end -->
