### PR TITLE
Altered min fee calculation function to match current Core behavior.

### DIFF
--- a/policy.go
+++ b/policy.go
@@ -26,11 +26,14 @@ const (
 func calcMinRequiredTxRelayFee(serializedSize int64, minRelayTxFee btcutil.Amount) int64 {
 	// Calculate the minimum fee for a transaction to be allowed into the
 	// mempool and relayed by scaling the base fee (which is the minimum
-	// free transaction relay fee).  minRelayTxFee is in Satoshi/KB, so
-	// divide the transaction size by 1000 to convert to kilobytes.  Also,
-	// integer division is used so fees only increase on full kilobyte
-	// boundaries.
-	minFee := (1 + serializedSize/1000) * int64(minRelayTxFee)
+	// free transaction relay fee). minTxRelayFee is in Satoshi/kB so
+	// multiply by serializedSize (which is in bytes) and divide by 1000 to get
+	// minimum Satoshis.
+	minFee := (serializedSize * int64(minRelayTxFee)) / 1000
+
+	if minFee == 0 && minRelayTxFee > 0 {
+		minFee = int64(minRelayTxFee)
+	}
 
 	// Set the minimum fee to the maximum possible value if the calculated
 	// fee is not in the valid range for monetary amounts.

--- a/policy_test.go
+++ b/policy_test.go
@@ -22,28 +22,60 @@ func TestCalcMinRequiredTxRelayFee(t *testing.T) {
 		want     int64          // Expected fee.
 	}{
 		{
-			"zero value with default minimum relay fee",
-			0,
-			defaultMinRelayTxFee,
-			int64(defaultMinRelayTxFee),
+			// Ensure combination of size and fee that are less than 1000
+			// produce a non-zero fee.
+			"250 bytes with relay fee of 3",
+			250,
+			3,
+			3,
 		},
 		{
 			"100 bytes with default minimum relay fee",
 			100,
 			defaultMinRelayTxFee,
-			int64(defaultMinRelayTxFee),
+			100,
 		},
 		{
 			"max standard tx size with default minimum relay fee",
 			maxStandardTxSize,
 			defaultMinRelayTxFee,
-			101000,
+			100000,
 		},
 		{
 			"max standard tx size with max satoshi relay fee",
 			maxStandardTxSize,
 			btcutil.MaxSatoshi,
 			btcutil.MaxSatoshi,
+		},
+		{
+			"1500 bytes with 5000 relay fee",
+			1500,
+			5000,
+			7500,
+		},
+		{
+			"1500 bytes with 3000 relay fee",
+			1500,
+			3000,
+			4500,
+		},
+		{
+			"782 bytes with 5000 relay fee",
+			782,
+			5000,
+			3910,
+		},
+		{
+			"782 bytes with 3000 relay fee",
+			782,
+			3000,
+			2346,
+		},
+		{
+			"782 bytes with 2550 relay fee",
+			782,
+			2550,
+			1994,
 		},
 	}
 


### PR DESCRIPTION
Specifically the number of KB is no longer rounded down to next integer.

Since this changes slightly the meaning of the 'minRelayTxFee' variable it has been renamed to 'relayTxFeeRate' and have deprecated the old config value associated with it and have added a new one.

See issue: https://github.com/btcsuite/btcd/issues/521

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/537)
<!-- Reviewable:end -->
