### PR TITLE
server: Allow IPv6 addresses with zone id.

### DIFF
--- a/server.go
+++ b/server.go
@@ -14,6 +14,7 @@ import (
 	"net"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -2073,6 +2074,13 @@ func parseListeners(addrs []string) ([]string, []string, bool, error) {
 			ipv6ListenAddrs = append(ipv6ListenAddrs, addr)
 			haveWildcard = true
 			continue
+		}
+
+		// Strip IPv6 zone id if present since net.ParseIP does not
+		// handle it.
+		zoneIndex := strings.LastIndex(host, "%")
+		if zoneIndex > 0 {
+			host = host[:zoneIndex]
 		}
 
 		// Parse the IP.


### PR DESCRIPTION
This modifies the IP parsing code to work with IPv6 zone ids.  This is needed since the `net.ParseIP` function does not allow zone ids even though `net.Listen` does.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/538)
<!-- Reviewable:end -->
