### PR TITLE
Fix mempool transactions disappearing if a parent tx is confirmed.

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1215,11 +1215,11 @@ func (b *blockManager) handleNotifyMsg(notification *blockchain.Notification) {
 		// connected block from the transaction pool.  Secondly, remove any
 		// transactions which are now double spends as a result of these
 		// new transactions.  Finally, remove any transaction that is
-		// no longer an orphan.  Note that removing a transaction from
-		// pool also removes any transactions which depend on it,
-		// recursively.
+		// no longer an orphan. Transactions which depend on a confirmed
+		// transaction are NOT removed recursively because they are still
+		// valid.
 		for _, tx := range block.Transactions()[1:] {
-			b.server.txMemPool.RemoveTransaction(tx)
+			b.server.txMemPool.RemoveTransaction(tx, false)
 			b.server.txMemPool.RemoveDoubleSpends(tx)
 			b.server.txMemPool.RemoveOrphan(tx.Sha())
 			b.server.txMemPool.ProcessOrphans(tx.Sha())
@@ -1261,7 +1261,7 @@ func (b *blockManager) handleNotifyMsg(notification *blockchain.Notification) {
 				// Remove the transaction and all transactions
 				// that depend on it if it wasn't accepted into
 				// the transaction pool.
-				b.server.txMemPool.RemoveTransaction(tx)
+				b.server.txMemPool.RemoveTransaction(tx, true)
 			}
 		}
 

--- a/mempool.go
+++ b/mempool.go
@@ -398,13 +398,15 @@ func (mp *txMemPool) HaveTransaction(hash *wire.ShaHash) bool {
 // RemoveTransaction.  See the comment for RemoveTransaction for more details.
 //
 // This function MUST be called with the mempool lock held (for writes).
-func (mp *txMemPool) removeTransaction(tx *btcutil.Tx) {
-	// Remove any transactions which rely on this one.
+func (mp *txMemPool) removeTransaction(tx *btcutil.Tx, removeRedeemers bool) {
 	txHash := tx.Sha()
-	for i := uint32(0); i < uint32(len(tx.MsgTx().TxOut)); i++ {
-		outpoint := wire.NewOutPoint(txHash, i)
-		if txRedeemer, exists := mp.outpoints[*outpoint]; exists {
-			mp.removeTransaction(txRedeemer)
+	if removeRedeemers {
+		// Remove any transactions which rely on this one.
+		for i := uint32(0); i < uint32(len(tx.MsgTx().TxOut)); i++ {
+			outpoint := wire.NewOutPoint(txHash, i)
+			if txRedeemer, exists := mp.outpoints[*outpoint]; exists {
+				mp.removeTransaction(txRedeemer, true)
+			}
 		}
 	}
 
@@ -466,16 +468,18 @@ func (mp *txMemPool) removeScriptFromAddrIndex(pkScript []byte, tx *btcutil.Tx) 
 	return nil
 }
 
-// RemoveTransaction removes the passed transaction and any transactions which
-// depend on it from the memory pool.
+// RemoveTransaction removes the passed transaction from the mempool. If
+// removeRedeemers flag is set, any transactions that redeem outputs from the
+// removed transaction will also be removed recursively from the mempool, as
+// they would otherwise become orphan.
 //
 // This function is safe for concurrent access.
-func (mp *txMemPool) RemoveTransaction(tx *btcutil.Tx) {
+func (mp *txMemPool) RemoveTransaction(tx *btcutil.Tx, removeRedeemers bool) {
 	// Protect concurrent access.
 	mp.Lock()
 	defer mp.Unlock()
 
-	mp.removeTransaction(tx)
+	mp.removeTransaction(tx, removeRedeemers)
 }
 
 // RemoveDoubleSpends removes all transactions which spend outputs spent by the
@@ -493,7 +497,7 @@ func (mp *txMemPool) RemoveDoubleSpends(tx *btcutil.Tx) {
 	for _, txIn := range tx.MsgTx().TxIn {
 		if txRedeemer, ok := mp.outpoints[txIn.PreviousOutPoint]; ok {
 			if !txRedeemer.Sha().IsEqual(tx.Sha()) {
-				mp.removeTransaction(txRedeemer)
+				mp.removeTransaction(txRedeemer, true)
 			}
 		}
 	}


### PR DESCRIPTION
There's a bug in the logic that processes new blocks that causes txs to be unnecessarily dropped from mempool.

Basically:

There are two txs A and B in mempool. Tx B uses an output from A.
A new block is received that contains A but not B. 

RemoveTransaction(A) will be called on the mempool, which will recursively remove B. However, B should not be removed because it's not orphan, its parent is now on the blockchain.

This fixes the bug by not recursively removing depending transactions when processing blocks.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/539)
<!-- Reviewable:end -->
