### PR TITLE
blockchain: Finish TODO by improving error message.

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -240,13 +240,14 @@ func CheckTransactionSanity(tx *btcutil.Tx) error {
 			return ruleError(ErrBadTxOutValue, str)
 		}
 
-		// TODO(davec): No need to check < 0 here as satoshi is
-		// guaranteed to be positive per the above check.  Also need
-		// to add overflow checks.
+		// Two's complement int64 overflow guarantees that any overflow
+		// is detected and reported.  This is impossible for Bitcoin, but
+		// perhaps possible if an alt increases the total money supply.
 		totalSatoshi += satoshi
 		if totalSatoshi < 0 {
 			str := fmt.Sprintf("total value of all transaction "+
-				"outputs has negative value of %v", totalSatoshi)
+				"outputs exceeds max allowed value of %v",
+				btcutil.MaxSatoshi)
 			return ruleError(ErrBadTxOutValue, str)
 		}
 		if totalSatoshi > btcutil.MaxSatoshi {


### PR DESCRIPTION
Removes a TODO by improving the error message.

In the presence of overflow, the actual output sum is still not negative and should not be reported as so.

I also realize that for bitcoin the overflow would have never occurred to begin with, but in other cryptocurrencies 2*MaxBaseUnits (whatever they call them) may overflow an int64 and the total in the error message would be negative.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/540)
<!-- Reviewable:end -->
