### PR TITLE
Fix failing test case because of wrong TimeOffset

### DIFF
--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -151,8 +151,11 @@ func testPeer(t *testing.T, p *peer.Peer, s peerStats) {
 		return
 	}
 
-	if p.TimeOffset() != s.wantTimeOffset {
-		t.Errorf("testPeer: wrong TimeOffset - got %v, want %v", p.TimeOffset(), s.wantTimeOffset)
+	// Allow for a deviation of 1s, as the second may tick when the message is
+	// in transit and the protocol doesn't support any further precision.
+	if p.TimeOffset() != s.wantTimeOffset && p.TimeOffset() != s.wantTimeOffset-1 {
+		t.Errorf("testPeer: wrong TimeOffset - got %v, want %v or %v", p.TimeOffset(),
+			s.wantTimeOffset, s.wantTimeOffset-1)
 		return
 	}
 


### PR DESCRIPTION
In rare cases, the build fails with the error:

    --- FAIL: TestPeerConnection (0.01s)
        peer_test.go:296: Running 2 tests
        peer_test.go:155: testPeer: wrong TimeOffset - got -1, want 0

https://travis-ci.org/btcsuite/btcd/jobs/87692240#L542

One reason this might happen is when the current timestamp is `1s` ahead of the message timestamp and the tick happens when the message is in transit.

Since the protocol is limited to one second precision, we do not have enough data to compare the timestamps any further. Therefore, I guess there will be some peer connections which inadvertently have an offset of `1s`. Updated the test case to handle this.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/543)
<!-- Reviewable:end -->
