### PR TITLE
chaincfg: Move DNS Seeds to chaincfg.

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -55,6 +55,7 @@ type Params struct {
 	Name        string
 	Net         wire.BitcoinNet
 	DefaultPort string
+	DNSSeeds    []string
 
 	// Chain parameters
 	GenesisBlock           *wire.MsgBlock
@@ -101,6 +102,15 @@ var MainNetParams = Params{
 	Name:        "mainnet",
 	Net:         wire.MainNet,
 	DefaultPort: "8333",
+	DNSSeeds: []string{
+		"seed.bitcoin.sipa.be",
+		"dnsseed.bluematt.me",
+		"dnsseed.bitcoin.dashjr.org",
+		"seed.bitcoinstats.com",
+		"seed.bitnodes.io",
+		"bitseed.xf2.org",
+		"seed.bitcoin.jonasschnelli.ch",
+	},
 
 	// Chain parameters
 	GenesisBlock:           &genesisBlock,
@@ -166,6 +176,7 @@ var RegressionNetParams = Params{
 	Name:        "regtest",
 	Net:         wire.TestNet,
 	DefaultPort: "18444",
+	DNSSeeds:    []string{},
 
 	// Chain parameters
 	GenesisBlock:           &regTestGenesisBlock,
@@ -213,6 +224,12 @@ var TestNet3Params = Params{
 	Name:        "testnet3",
 	Net:         wire.TestNet3,
 	DefaultPort: "18333",
+	DNSSeeds: []string{
+		"testnet-seed.alexykot.me",
+		"testnet-seed.bitcoin.schildbach.de",
+		"testnet-seed.bitcoin.petertodd.org",
+		"testnet-seed.bluematt.me",
+	},
 
 	// Chain parameters
 	GenesisBlock:           &testNet3GenesisBlock,
@@ -266,6 +283,7 @@ var SimNetParams = Params{
 	Name:        "simnet",
 	Net:         wire.SimNet,
 	DefaultPort: "18555",
+	DNSSeeds:    []string{}, // NOTE: There must NOT be any seeds.
 
 	// Chain parameters
 	GenesisBlock:           &simNetGenesisBlock,

--- a/params.go
+++ b/params.go
@@ -17,8 +17,7 @@ var activeNetParams = &mainNetParams
 // network and test networks.
 type params struct {
 	*chaincfg.Params
-	rpcPort  string
-	dnsSeeds []string
+	rpcPort string
 }
 
 // mainNetParams contains parameters specific to the main network
@@ -30,15 +29,6 @@ type params struct {
 var mainNetParams = params{
 	Params:  &chaincfg.MainNetParams,
 	rpcPort: "8334",
-	dnsSeeds: []string{
-		"seed.bitcoin.sipa.be",
-		"dnsseed.bluematt.me",
-		"dnsseed.bitcoin.dashjr.org",
-		"seed.bitcoinstats.com",
-		"seed.bitnodes.io",
-		"bitseed.xf2.org",
-		"seed.bitcoin.jonasschnelli.ch",
-	},
 }
 
 // regressionNetParams contains parameters specific to the regression test
@@ -46,9 +36,8 @@ var mainNetParams = params{
 // than the reference implementation - see the mainNetParams comment for
 // details.
 var regressionNetParams = params{
-	Params:   &chaincfg.RegressionNetParams,
-	rpcPort:  "18334",
-	dnsSeeds: []string{},
+	Params:  &chaincfg.RegressionNetParams,
+	rpcPort: "18334",
 }
 
 // testNet3Params contains parameters specific to the test network (version 3)
@@ -57,20 +46,13 @@ var regressionNetParams = params{
 var testNet3Params = params{
 	Params:  &chaincfg.TestNet3Params,
 	rpcPort: "18334",
-	dnsSeeds: []string{
-		"testnet-seed.alexykot.me",
-		"testnet-seed.bitcoin.schildbach.de",
-		"testnet-seed.bitcoin.petertodd.org",
-		"testnet-seed.bluematt.me",
-	},
 }
 
 // simNetParams contains parameters specific to the simulation test network
 // (wire.SimNet).
 var simNetParams = params{
-	Params:   &chaincfg.SimNetParams,
-	rpcPort:  "18556",
-	dnsSeeds: []string{}, // NOTE: There must NOT be any seeds.
+	Params:  &chaincfg.SimNetParams,
+	rpcPort: "18556",
 }
 
 // netName returns the name used when referring to a bitcoin network.  At the

--- a/server.go
+++ b/server.go
@@ -1429,7 +1429,7 @@ func (s *server) seedFromDNS() {
 		return
 	}
 
-	for _, seeder := range activeNetParams.dnsSeeds {
+	for _, seeder := range activeNetParams.DNSSeeds {
 		go func(seeder string) {
 			randSource := mrand.New(mrand.NewSource(time.Now().UnixNano()))
 


### PR DESCRIPTION
This allows API users access to the DNS Seeds for use with SPV
clients, seeders, etc.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/544)
<!-- Reviewable:end -->
