### PR TITLE
peer: Unexport the mru inventory map.

### DIFF
--- a/peer/mruinvmap.go
+++ b/peer/mruinvmap.go
@@ -13,10 +13,10 @@ import (
 	"github.com/btcsuite/btcd/wire"
 )
 
-// MruInventoryMap provides a concurrency safe map that is limited to a maximum
+// mruInventoryMap provides a concurrency safe map that is limited to a maximum
 // number of items with eviction for the oldest entry when the limit is
 // exceeded.
-type MruInventoryMap struct {
+type mruInventoryMap struct {
 	invMtx  sync.Mutex
 	invMap  map[wire.InvVect]*list.Element // nearly O(1) lookups
 	invList *list.List                     // O(1) insert, update, delete
@@ -26,7 +26,7 @@ type MruInventoryMap struct {
 // String returns the map as a human-readable string.
 //
 // This function is safe for concurrent access.
-func (m *MruInventoryMap) String() string {
+func (m *mruInventoryMap) String() string {
 	m.invMtx.Lock()
 	defer m.invMtx.Unlock()
 
@@ -48,7 +48,7 @@ func (m *MruInventoryMap) String() string {
 // Exists returns whether or not the passed inventory item is in the map.
 //
 // This function is safe for concurrent access.
-func (m *MruInventoryMap) Exists(iv *wire.InvVect) bool {
+func (m *mruInventoryMap) Exists(iv *wire.InvVect) bool {
 	m.invMtx.Lock()
 	defer m.invMtx.Unlock()
 
@@ -63,7 +63,7 @@ func (m *MruInventoryMap) Exists(iv *wire.InvVect) bool {
 // item makes it the most recently used item.
 //
 // This function is safe for concurrent access.
-func (m *MruInventoryMap) Add(iv *wire.InvVect) {
+func (m *mruInventoryMap) Add(iv *wire.InvVect) {
 	m.invMtx.Lock()
 	defer m.invMtx.Unlock()
 
@@ -107,7 +107,7 @@ func (m *MruInventoryMap) Add(iv *wire.InvVect) {
 // Delete deletes the passed inventory item from the map (if it exists).
 //
 // This function is safe for concurrent access.
-func (m *MruInventoryMap) Delete(iv *wire.InvVect) {
+func (m *mruInventoryMap) Delete(iv *wire.InvVect) {
 	m.invMtx.Lock()
 	defer m.invMtx.Unlock()
 
@@ -117,12 +117,12 @@ func (m *MruInventoryMap) Delete(iv *wire.InvVect) {
 	}
 }
 
-// NewMruInventoryMap returns a new inventory map that is limited to the number
+// newMruInventoryMap returns a new inventory map that is limited to the number
 // of entries specified by limit.  When the number of entries exceeds the limit,
 // the oldest (least recently used) entry will be removed to make room for the
 // new entry.
-func NewMruInventoryMap(limit uint) *MruInventoryMap {
-	m := MruInventoryMap{
+func newMruInventoryMap(limit uint) *mruInventoryMap {
+	m := mruInventoryMap{
 		invMap:  make(map[wire.InvVect]*list.Element),
 		invList: list.New(),
 		limit:   limit,

--- a/peer/mruinvmap_test.go
+++ b/peer/mruinvmap_test.go
@@ -44,7 +44,7 @@ testLoop:
 		// limit and add all of the test inventory vectors.  This will
 		// cause evicition since there are more test inventory vectors
 		// than the limits.
-		mruInvMap := NewMruInventoryMap(uint(test.limit))
+		mruInvMap := newMruInventoryMap(uint(test.limit))
 		for j := 0; j < numInvVects; j++ {
 			mruInvMap.Add(invVects[j])
 		}
@@ -127,7 +127,7 @@ func TestMruInventoryMapStringer(t *testing.T) {
 	iv2 := wire.NewInvVect(wire.InvTypeBlock, hash2)
 
 	// Create new mru inventory map and add the inventory vectors.
-	mruInvMap := NewMruInventoryMap(uint(2))
+	mruInvMap := newMruInventoryMap(uint(2))
 	mruInvMap.Add(iv1)
 	mruInvMap.Add(iv2)
 
@@ -162,7 +162,7 @@ func BenchmarkMruInventoryList(b *testing.B) {
 
 	// Benchmark the add plus evicition code.
 	limit := 20000
-	mruInvMap := NewMruInventoryMap(uint(limit))
+	mruInvMap := newMruInventoryMap(uint(limit))
 	for i := 0; i < b.N; i++ {
 		mruInvMap.Add(invVects[i%numInvVects])
 	}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -403,7 +403,7 @@ type Peer struct {
 	versionSent     bool
 	verAckReceived  bool
 
-	knownInventory     *MruInventoryMap
+	knownInventory     *mruInventoryMap
 	prevGetBlocksMtx   sync.Mutex
 	prevGetBlocksBegin *wire.ShaHash
 	prevGetBlocksStop  *wire.ShaHash
@@ -2045,7 +2045,7 @@ func newPeerBase(cfg *Config, inbound bool) *Peer {
 
 	p := Peer{
 		inbound:         inbound,
-		knownInventory:  NewMruInventoryMap(maxKnownInventory),
+		knownInventory:  newMruInventoryMap(maxKnownInventory),
 		stallControl:    make(chan stallControlMsg, 1), // nonblocking sync
 		outputQueue:     make(chan outMsg, outputBufferSize),
 		sendQueue:       make(chan outMsg, 1),   // nonblocking sync


### PR DESCRIPTION
This unexports the `mruInventoryMap` type since it is only needed within the peer package.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/557)
<!-- Reviewable:end -->
