### PR TITLE
mempool/mining: Introduce TxSource interface.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2180,15 +2180,15 @@ func handleGetInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (in
 
 // handleGetMempoolInfo implements the getmempoolinfo command.
 func handleGetMempoolInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
-	txD := s.server.txMemPool.TxDescs()
+	mempoolTxns := s.server.txMemPool.TxDescs()
 
 	var numBytes int64
-	for _, desc := range txD {
-		numBytes += int64(desc.Tx.MsgTx().SerializeSize())
+	for _, txD := range mempoolTxns {
+		numBytes += int64(txD.Tx.MsgTx().SerializeSize())
 	}
 
 	ret := &btcjson.GetMempoolInfoResult{
-		Size:  int64(len(txD)),
+		Size:  int64(len(mempoolTxns)),
 		Bytes: numBytes,
 	}
 
@@ -2416,7 +2416,7 @@ func handleGetRawMempool(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 			}
 
 			mpd := &btcjson.GetRawMempoolVerboseResult{
-				Size:             int32(desc.Tx.MsgTx().SerializeSize()),
+				Size:             int32(tx.MsgTx().SerializeSize()),
 				Fee:              btcutil.Amount(desc.Fee).ToBTC(),
 				Time:             desc.Added.Unix(),
 				Height:           int64(desc.Height),
@@ -2424,7 +2424,7 @@ func handleGetRawMempool(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 				CurrentPriority:  currentPriority,
 				Depends:          make([]string, 0),
 			}
-			for _, txIn := range desc.Tx.MsgTx().TxIn {
+			for _, txIn := range tx.MsgTx().TxIn {
 				hash := &txIn.PreviousOutPoint.Hash
 				if s.server.txMemPool.haveTransaction(hash) {
 					mpd.Depends = append(mpd.Depends,
@@ -2432,7 +2432,7 @@ func handleGetRawMempool(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 				}
 			}
 
-			result[desc.Tx.Sha().String()] = mpd
+			result[tx.Sha().String()] = mpd
 		}
 
 		return result, nil


### PR DESCRIPTION
**This pull request requires #559 and #566.**

This introduces the concept of a new interface named `TxSource` which aims to generically provide a concurrent safe source of transactions to be considered for inclusion in a new block.  This is a step towards decoupling the mining code from the internals of btcd.  Ultimately the intent is to create a separate `mining` package.

The new `TxSource` interface relies on a new struct named `miningTxDesc`, which describes each entry in the transaction source.  Once this code is refactored into a separate mining package, the mining prefix can simply be dropped leaving the type exported as `mining.TxDesc`.

To go along with this, the existing `TxDesc` type in the mempool has been renamed to `mempoolTxDesc` and changed to embed the new `miningTxDesc type`.  This allows the mempool to efficiently implement the `MiningTxDescs` method needed to satisfy the `TxSource` interface.

This approach effectively separates the direct reliance of the mining code on the `mempool` and its data structures.  Even though the memory pool will still be the default concrete implementation of the interface,
making it an interface offers much more flexibility in terms of testing and even provides the potential to allow more than one source (perhaps multiple independent relay networks, for example).

Finally, the memory pool and all of the mining code has been updated to implement and use the new interface.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/563)
<!-- Reviewable:end -->
