### PR TITLE
mempool/mining: Decouple and optimize priority calcs.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -540,7 +540,7 @@ mempoolLoop:
 		// Calculate the final transaction priority using the input
 		// value age sum as well as the adjusted transaction size.  The
 		// formula is: sum(inputValue * inputAge) / adjustedTxSize
-		prioItem.priority = txDesc.CurrentPriority(txStore, nextBlockHeight)
+		prioItem.priority = calcPriority(tx.MsgTx(), txStore, nextBlockHeight)
 
 		// Calculate the fee in Satoshi/kB.
 		txSize := tx.MsgTx().SerializeSize()

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2404,15 +2404,15 @@ func handleGetRawMempool(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 		mp.RLock()
 		defer mp.RUnlock()
 		for _, desc := range descs {
-			// Calculate the starting and current priority from the
-			// the tx's inputs.  Use zeros if one or more of the
-			// input transactions can't be found for some reason.
-			var startingPriority, currentPriority float64
-			inputTxs, err := mp.fetchInputTransactions(desc.Tx, false)
+			// Calculate the current priority from the the tx's
+			// inputs.  Use zero if one or more of the input
+			// transactions can't be found for some reason.
+			tx := desc.Tx
+			var currentPriority float64
+			inputTxs, err := mp.fetchInputTransactions(tx, false)
 			if err == nil {
-				startingPriority = desc.StartingPriority(inputTxs)
-				currentPriority = desc.CurrentPriority(inputTxs,
-					newestHeight+1)
+				currentPriority = calcPriority(tx.MsgTx(),
+					inputTxs, newestHeight+1)
 			}
 
 			mpd := &btcjson.GetRawMempoolVerboseResult{
@@ -2420,7 +2420,7 @@ func handleGetRawMempool(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 				Fee:              btcutil.Amount(desc.Fee).ToBTC(),
 				Time:             desc.Added.Unix(),
 				Height:           int64(desc.Height),
-				StartingPriority: startingPriority,
+				StartingPriority: desc.StartingPriority,
 				CurrentPriority:  currentPriority,
 				Depends:          make([]string, 0),
 			}


### PR DESCRIPTION
This does three things:

- Splits the priority calculation logic from the `TxDesc` type
- Modifies the `calcPriority` function to perform the value age calculation instead of accepting it as a parameter
- Changes the starting priority to be calculated when the transaction is added to the pool

The first is useful as it is a step towards decoupling the mining code from the internals of the memory pool.  Also, the concept of priority is related to mining policy, so it makes more sense to have the calculations separate than being defined on the memory pool tx descriptor.

The second change has been made because everywhere that uses the `calcPriority` function first has to calculate the value age anyways and by making it part of the function it can be avoided altogether in
certain circumstances thereby provided a bit of optimization.

The third change ensures the starting priority is safe for reentrancy which will be important once the mempool is split into a separate package.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/566)
<!-- Reviewable:end -->
