### PR TITLE
mining: Create skeleton package.

### DIFF
--- a/cpuminer.go
+++ b/cpuminer.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/mining"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 )
@@ -52,8 +53,8 @@ var (
 // system which is typically sufficient.
 type CPUMiner struct {
 	sync.Mutex
-	policy            *miningPolicy
-	txSource          TxSource
+	policy            *mining.Policy
+	txSource          mining.TxSource
 	server            *server
 	numWorkers        uint32
 	started           bool
@@ -601,7 +602,7 @@ func (m *CPUMiner) GenerateNBlocks(n uint32) ([]*wire.ShaHash, error) {
 // newCPUMiner returns a new instance of a CPU miner for the provided server.
 // Use Start to begin the mining process.  See the documentation for CPUMiner
 // type for more details.
-func newCPUMiner(policy *miningPolicy, s *server) *CPUMiner {
+func newCPUMiner(policy *mining.Policy, s *server) *CPUMiner {
 	return &CPUMiner{
 		policy:            policy,
 		txSource:          s.txMemPool,

--- a/mempool.go
+++ b/mempool.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/database"
+	"github.com/btcsuite/btcd/mining"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
@@ -43,7 +44,7 @@ const (
 // mempoolTxDesc is a descriptor containing a transaction in the mempool along
 // with additional metadata.
 type mempoolTxDesc struct {
-	miningTxDesc
+	mining.TxDesc
 
 	// StartingPriority is the priority of the transaction when it was added
 	// to the pool.
@@ -106,7 +107,7 @@ type txMemPool struct {
 }
 
 // Ensure the txMemPool type implements the mining.TxSource interface.
-var _ TxSource = (*txMemPool)(nil)
+var _ mining.TxSource = (*txMemPool)(nil)
 
 // removeOrphan is the internal function which implements the public
 // RemoveOrphan.  See the comment for RemoveOrphan for more details.
@@ -420,7 +421,7 @@ func (mp *txMemPool) addTransaction(txStore blockchain.TxStore, tx *btcutil.Tx, 
 	// Add the transaction to the pool and mark the referenced outpoints
 	// as spent by the pool.
 	mp.pool[*tx.Sha()] = &mempoolTxDesc{
-		miningTxDesc: miningTxDesc{
+		TxDesc: mining.TxDesc{
 			Tx:     tx,
 			Added:  time.Now(),
 			Height: height,
@@ -1073,16 +1074,16 @@ func (mp *txMemPool) TxDescs() []*mempoolTxDesc {
 // MiningDescs returns a slice of mining descriptors for all the transactions
 // in the pool.
 //
-// This is part of the TxSource interface implementation and is safe for
+// This is part of the mining.TxSource interface implementation and is safe for
 // concurrent access as required by the interface contract.
-func (mp *txMemPool) MiningDescs() []*miningTxDesc {
+func (mp *txMemPool) MiningDescs() []*mining.TxDesc {
 	mp.RLock()
 	defer mp.RUnlock()
 
-	descs := make([]*miningTxDesc, len(mp.pool))
+	descs := make([]*mining.TxDesc, len(mp.pool))
 	i := 0
 	for _, desc := range mp.pool {
-		descs[i] = &desc.miningTxDesc
+		descs[i] = &desc.TxDesc
 		i++
 	}
 

--- a/mining/README.md
+++ b/mining/README.md
@@ -1,0 +1,23 @@
+mining
+======
+
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
+(https://travis-ci.org/btcsuite/btcd) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcd/mining)
+
+## Overview
+
+This package is currently a work in progress.
+
+## Installation and Updating
+
+```bash
+$ go get -u github.com/btcsuite/btcd/mining
+```
+
+## License
+
+Package mining is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/mining/mining.go
+++ b/mining/mining.go
@@ -1,0 +1,48 @@
+// Copyright (c) 2014-2015 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package mining
+
+import (
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+)
+
+// TxDesc is a descriptor about a transaction in a transaction source along with
+// additional metadata.
+type TxDesc struct {
+	// Tx is the transaction associated with the entry.
+	Tx *btcutil.Tx
+
+	// Added is the time when the entry was added to the source pool.
+	Added time.Time
+
+	// Height is the block height when the entry was added to the the source
+	// pool.
+	Height int32
+
+	// Fee is the total fee the transaction associated with the entry pays.
+	Fee int64
+}
+
+// TxSource represents a source of transactions to consider for inclusion in
+// new blocks.
+//
+// The interface contract requires that all of these methods are safe for
+// concurrent access with respect to the source.
+type TxSource interface {
+	// LastUpdated returns the last time a transaction was added to or
+	// removed from the source pool.
+	LastUpdated() time.Time
+
+	// MiningDescs returns a slice of mining descriptors for all the
+	// transactions in the source pool.
+	MiningDescs() []*TxDesc
+
+	// HaveTransaction returns whether or not the passed transaction hash
+	// exists in the source pool.
+	HaveTransaction(hash *wire.ShaHash) bool
+}

--- a/mining/policy.go
+++ b/mining/policy.go
@@ -1,0 +1,29 @@
+// Copyright (c) 2014-2015 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package mining
+
+import "github.com/btcsuite/btcutil"
+
+// Policy houses the policy (configuration parameters) which is used to control
+// the generation of block templates.  See the documentation for
+// NewBlockTemplate for more details on each of these parameters are used.
+type Policy struct {
+	// BlockMinSize is the minimum block size in bytes to be used when
+	// generating a block template.
+	BlockMinSize uint32
+
+	// BlockMaxSize is the maximum block size in bytes to be used when
+	// generating a block template.
+	BlockMaxSize uint32
+
+	// BlockPrioritySize is the size in bytes for high-priority / low-fee
+	// transactions to be used when generating a block template.
+	BlockPrioritySize uint32
+
+	// TxMinFreeFee is the minimum fee in Satoshi/1000 bytes that is
+	// required for a transaction to be treated as free for mining purposes
+	// (block template generation).
+	TxMinFreeFee btcutil.Amount
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -32,6 +32,7 @@ import (
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/database"
+	"github.com/btcsuite/btcd/mining"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
@@ -3517,7 +3518,7 @@ func handleVerifyMessage(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 type rpcServer struct {
 	started      int32
 	shutdown     int32
-	policy       *miningPolicy
+	policy       *mining.Policy
 	server       *server
 	authsha      [fastsha256.Size]byte
 	limitauthsha [fastsha256.Size]byte
@@ -3995,7 +3996,7 @@ func genCertPair(certFile, keyFile string) error {
 }
 
 // newRPCServer returns a new instance of the rpcServer struct.
-func newRPCServer(listenAddrs []string, policy *miningPolicy, s *server) (*rpcServer, error) {
+func newRPCServer(listenAddrs []string, policy *mining.Policy, s *server) (*rpcServer, error) {
 	rpc := rpcServer{
 		policy:       policy,
 		server:       s,

--- a/server.go
+++ b/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/database"
+	"github.com/btcsuite/btcd/mining"
 	"github.com/btcsuite/btcd/peer"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -2353,7 +2354,7 @@ func newServer(listenAddrs []string, db database.Db, chainParams *chaincfg.Param
 	s.blockManager = bm
 
 	// Create the mining policy based on the configuration options.
-	policy := miningPolicy{
+	policy := mining.Policy{
 		BlockMinSize:      cfg.BlockMinSize,
 		BlockMaxSize:      cfg.BlockMaxSize,
 		BlockPrioritySize: cfg.BlockPrioritySize,


### PR DESCRIPTION
**This pull request requires #563.**

This creates a skeleton mining package that simply contains a few of the definitions used by the mining and mempool code.

This is a step towards decoupling the mining code from the internals of btcd and ultimately will house all of the code related to creating block templates and CPU mining.

The main reason a skeleton package is being created before the full blown package is ready is to avoid blocking mempool separation which relies on these type definitions.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/567)
<!-- Reviewable:end -->
