### PR TITLE
peer: Add DisableRelayTx to config.

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -235,6 +235,10 @@ type Config struct {
 	// peer.MaxProtocolVersion will be used.
 	ProtocolVersion uint32
 
+	// DisableRelayTx specifies if the remote peer should be informed to
+	// not send inv messages for transactions.
+	DisableRelayTx bool
+
 	// Listeners houses callback functions to be invoked on receiving peer
 	// messages.
 	Listeners MessageListeners
@@ -797,6 +801,9 @@ func (p *Peer) pushVersionMsg() error {
 
 	// Advertise our max supported protocol version.
 	msg.ProtocolVersion = int32(p.ProtocolVersion())
+
+	// Advertise if inv messages for transactions are desired.
+	msg.DisableRelayTx = p.cfg.DisableRelayTx
 
 	p.QueueMessage(msg, nil)
 	return nil

--- a/server.go
+++ b/server.go
@@ -1403,6 +1403,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 		UserAgentVersion: userAgentVersion,
 		ChainParams:      sp.server.chainParams,
 		Services:         sp.server.services,
+		DisableRelayTx:   false,
 	}
 }
 


### PR DESCRIPTION
DisableRelayTx sets the DisableRelayTx value in the version
message which informs the remote peer on whether to send
inv messages for transactions.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/574)
<!-- Reviewable:end -->
