### PR TITLE
server: Correct mempool/cpu miner initialize order.

### DIFF
--- a/server.go
+++ b/server.go
@@ -2354,15 +2354,6 @@ func newServer(listenAddrs []string, db database.Db, chainParams *chaincfg.Param
 	}
 	s.blockManager = bm
 
-	// Create the mining policy based on the configuration options.
-	policy := mining.Policy{
-		BlockMinSize:      cfg.BlockMinSize,
-		BlockMaxSize:      cfg.BlockMaxSize,
-		BlockPrioritySize: cfg.BlockPrioritySize,
-		TxMinFreeFee:      cfg.minRelayTxFee,
-	}
-	s.cpuMiner = newCPUMiner(&policy, &s)
-
 	txC := mempoolConfig{
 		DisableRelayPriority:  cfg.NoRelayPriority,
 		EnableAddrIndex:       cfg.AddrIndex,
@@ -2376,6 +2367,17 @@ func newServer(listenAddrs []string, db database.Db, chainParams *chaincfg.Param
 		TimeSource:            s.timeSource,
 	}
 	s.txMemPool = newTxMemPool(&txC)
+
+	// Create the mining policy based on the configuration options.
+	// NOTE: The CPU miner relies on the mempool, so the mempool has to be
+	// created before calling the function to create the CPU miner.
+	policy := mining.Policy{
+		BlockMinSize:      cfg.BlockMinSize,
+		BlockMaxSize:      cfg.BlockMaxSize,
+		BlockPrioritySize: cfg.BlockPrioritySize,
+		TxMinFreeFee:      cfg.minRelayTxFee,
+	}
+	s.cpuMiner = newCPUMiner(&policy, &s)
 
 	if cfg.AddrIndex {
 		ai, err := newAddrIndexer(&s)


### PR DESCRIPTION
The CPU miner relies on the mempool, so the mempool has to be created before calling the function to create the CPU miner.  When PR #568 introduced the mempool config struct, it moved the mempool creation
after the miner creation, which leads to the CPU miner crashing due to trying to access a nil mempool.

This move the CPU miner creation after the mempool creation appropriately.

Once the mempool and miner separation is done this won't matter anymore since the miner config will require a `mining.TxSource` which effectively enforces its creation first.


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/578)
<!-- Reviewable:end -->
