### PR TITLE
peer: drain chans before exiting peerHandler

### DIFF
--- a/server.go
+++ b/server.go
@@ -1494,7 +1494,7 @@ func (s *server) peerConnHandler(sp *serverPeer) {
 	err := s.establishConn(sp)
 	if err != nil {
 		srvrLog.Debugf("Failed to connect to %s: %v", sp.Addr(), err)
-		s.donePeers <- sp
+		sp.Disconnect()
 	}
 }
 
@@ -1730,6 +1730,23 @@ out:
 	}
 	s.blockManager.Stop()
 	s.addrManager.Stop()
+
+	// Drain channels before exiting so nothing is left waiting around
+	// to send.
+cleanup:
+	for {
+		select {
+		case <-s.newPeers:
+		case <-s.donePeers:
+		case <-s.peerHeightsUpdate:
+		case <-s.relayInv:
+		case <-s.broadcast:
+		case <-s.wakeup:
+		case <-s.query:
+		default:
+			break cleanup
+		}
+	}
 	s.wg.Done()
 	srvrLog.Tracef("Peer handler done")
 }


### PR DESCRIPTION
Updated `peerHandler` to drain `newPeers` before exiting so that any pending peers don't cause a hang on shutdown.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/584)
<!-- Reviewable:end -->
