### PR TITLE
blockchain: Fix serialized coinbase height error message

### DIFF
--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -764,7 +764,7 @@ func ExtractCoinbaseHeight(coinbaseTx *btcutil.Tx) (int32, error) {
 		str := "the coinbase signature script for blocks of " +
 			"version %d or greater must start with the " +
 			"serialized block height"
-		str = fmt.Sprintf(str, serializedLen)
+		str = fmt.Sprintf(str, serializedHeightVersion)
 		return 0, ruleError(ErrMissingCoinbaseHeight, str)
 	}
 


### PR DESCRIPTION
Tiny change: the substitution was wrong, causing a confusing error message.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/585)
<!-- Reviewable:end -->
