### PR TITLE
server: remove peer from peerState even when doing a retry. Fixes #577

### DIFF
--- a/server.go
+++ b/server.go
@@ -1124,12 +1124,10 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 		// persistent outbound connection.
 		if !sp.Inbound() && sp.persistent && atomic.LoadInt32(&s.shutdown) == 0 {
 			// Retry peer
-			sp = s.newOutboundPeer(sp.Addr(), sp.persistent)
-			if sp != nil {
-				go s.retryConn(sp, false)
+			sp2 := s.newOutboundPeer(sp.Addr(), sp.persistent)
+			if sp2 != nil {
+				go s.retryConn(sp2, false)
 			}
-			list[sp.ID()] = sp
-			return
 		}
 		if !sp.Inbound() && sp.VersionKnown() {
 			state.outboundGroups[addrmgr.GroupKey(sp.NA())]--


### PR DESCRIPTION
The issue is that when the new connection is established, handleAddPeerMsg will be called later when the connection is established, the same way as regular (non-retry) connections. So the old peer needs to be deleted anyway, and the new one doesn't need to be added now. Otherwise entries from dead peers in the peerState stack up and hit the maxPeers limit.

I'm not sure if this is the best way to fix the issue since I'm not very familiar with the peer/server code. I'm open to alternate suggestions.

I'm able to reliably reproduce #577 in my setup, and I have tested this PR reliably fixes the issue: setting maxPeers to 1, using --connect, and causing the connection to fail and retry does not trigger the bug anymore, btcd will keep happily retrying forever.

Fixes #577.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/587)
<!-- Reviewable:end -->
