### PR TITLE
txscript: Fix docs to match function.

### DIFF
--- a/txscript/sigcache_test.go
+++ b/txscript/sigcache_test.go
@@ -12,8 +12,8 @@ import (
 	"github.com/btcsuite/btcd/wire"
 )
 
-// genRandomSig returns a random message, public key, and a signature of the
-// message under the public key. This function is used to generate randomized
+// genRandomSig returns a random message, a signature of the message under the
+// public key and the public key. This function is used to generate randomized
 // test data.
 func genRandomSig() (*wire.ShaHash, *btcec.Signature, *btcec.PublicKey, error) {
 	privKey, err := btcec.NewPrivateKey(btcec.S256())


### PR DESCRIPTION
Changed the order of return values described in the docs to be
consistent with the function’s actual return value signature.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/590)
<!-- Reviewable:end -->
