### PR TITLE
Update btcjson and txscript tests to work properly on ARM

### DIFF
--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -63,7 +63,7 @@ func TestChainSvrCmds(t *testing.T) {
 			name: "createrawtransaction optional",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("createrawtransaction", `[{"txid":"123","vout":1}]`,
-					`{"456":0.0123}`, 12312333333)
+					`{"456":0.0123}`, int64(12312333333))
 			},
 			staticCmd: func() interface{} {
 				txInputs := []btcjson.TransactionInput{


### PR DESCRIPTION
For `btcjson`, it modifies the test for `createrawtransaction` to specify the constant size passed as an `int64`.  This is necessary because the `NewCmd` function accepts the parameters as interfaces in order to support varargs and a raw numeric constant is treated as an integer.  Since the constant value is larger than an `int32`, this causes certain platforms like ARM which treat a raw integer as a 32-bit integer to fail to compile.

For `txscript`, it modifies the conversion of the output index from the JSON-based test data for valid and invalid transactions to first convert to a signed int and then to an unsigned int.  This is necessary because the result of a direct conversion of a float to an unsigned int is implementation dependent and doesn't result in the expected value on all platforms.

Also, while here it changes the function names in the error prints of the modified functions to match the actual names.

Fixes #600.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/601)
<!-- Reviewable:end -->
