### PR TITLE
peer: Consolidate Connect, Disconnect, Start, Shutdown public methods.

### DIFF
--- a/peer/doc.go
+++ b/peer/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2015-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -66,15 +66,12 @@ This provides high flexibility for things such as connecting via proxies, acting
 as a proxy, creating bridge peers, choosing whether to listen for inbound peers,
 etc.
 
-For outgoing peers, the NewOutboundPeer function must be used to specify the
-configuration followed by invoking Connect with the net.Conn instance.  This
- will start all async I/O goroutines and initiate the initial negotiation
-process.  Once that has been completed, the peer is fully functional.
-
-For inbound peers, the NewInboundPeer function must be used to specify the
-configuration and net.Conn instance followed by invoking Start.  This will start
-all async I/O goroutines and listen for the initial negotiation process.  Once
-that has been completed, the peer is fully functional.
+NewOutboundPeer and NewInboundPeer functions must be followed by calling Connect
+with a net.Conn instance to the peer.  This will start all async I/O goroutines
+and initiate the protocol negotiation process.  Once finished with the peer call
+Disconnect to disconnect from the peer and clean up all resources.
+WaitForDisconnect can be used to block until peer disconnection and resource
+cleanup has completed.
 
 Callbacks
 

--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2015-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -38,9 +38,9 @@ func mockRemotePeer() error {
 		}
 
 		// Create and start the inbound peer.
-		p := peer.NewInboundPeer(peerCfg, conn)
-		if err := p.Start(); err != nil {
-			fmt.Printf("Start: error %v\n", err)
+		p := peer.NewInboundPeer(peerCfg)
+		if err := p.Connect(conn); err != nil {
+			fmt.Printf("Connect: error %v\n", err)
 			return
 		}
 	}()
@@ -105,8 +105,9 @@ func Example_newOutboundPeer() {
 		fmt.Printf("Example_peerConnection: verack timeout")
 	}
 
-	// Shutdown the peer.
-	p.Shutdown()
+	// Disconnect the peer.
+	p.Disconnect()
+	p.WaitForDisconnect()
 
 	// Output:
 	// outbound: received version


### PR DESCRIPTION
This commit does not change functionality. It makes the creation of inbound and outbound peers more homogeneous. As a result the Start method of peer was removed as it was found not to be necessary. This is the first of several pull requests/commits designed to make the peer public API and internals less complex.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/617)
<!-- Reviewable:end -->
