### PR TITLE
peer: Implement sendheaders support (BIP0130).

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	// MaxProtocolVersion is the max protocol version the peer supports.
-	MaxProtocolVersion = 70011
+	MaxProtocolVersion = wire.SendHeadersVersion
 
 	// outputBufferSize is the number of elements the output channels use.
 	outputBufferSize = 50
@@ -174,6 +174,10 @@ type MessageListeners struct {
 
 	// OnReject is invoked when a peer receives a reject bitcoin message.
 	OnReject func(p *Peer, msg *wire.MsgReject)
+
+	// OnSendHeaders is invoked when a peer receives a sendheaders bitcoin
+	// message.
+	OnSendHeaders func(p *Peer, msg *wire.MsgSendHeaders)
 
 	// OnRead is invoked when a peer receives a bitcoin message.  It
 	// consists of the number of bytes read, the message, and whether or not
@@ -402,15 +406,16 @@ type Peer struct {
 	cfg     Config
 	inbound bool
 
-	flagsMtx        sync.Mutex // protects the peer flags below
-	na              *wire.NetAddress
-	id              int32
-	userAgent       string
-	services        wire.ServiceFlag
-	versionKnown    bool
-	protocolVersion uint32
-	versionSent     bool
-	verAckReceived  bool
+	flagsMtx             sync.Mutex // protects the peer flags below
+	na                   *wire.NetAddress
+	id                   int32
+	userAgent            string
+	services             wire.ServiceFlag
+	versionKnown         bool
+	protocolVersion      uint32
+	sendHeadersPreferred bool // peer sent a sendheaders message
+	versionSent          bool
+	verAckReceived       bool
 
 	knownInventory     *mruInventoryMap
 	prevGetBlocksMtx   sync.Mutex
@@ -724,6 +729,17 @@ func (p *Peer) StartingHeight() int32 {
 	defer p.statsMtx.RUnlock()
 
 	return p.startingHeight
+}
+
+// WantsHeaders returns if the peer wants header messages instead of
+// inventory vectors for blocks.
+//
+// This function is safe for concurrent access.
+func (p *Peer) WantsHeaders() bool {
+	p.flagsMtx.Lock()
+	defer p.flagsMtx.Unlock()
+
+	return p.sendHeadersPreferred
 }
 
 // pushVersionMsg sends a version message to the connected peer using the
@@ -1633,6 +1649,15 @@ out:
 		case *wire.MsgReject:
 			if p.cfg.Listeners.OnReject != nil {
 				p.cfg.Listeners.OnReject(p, msg)
+			}
+
+		case *wire.MsgSendHeaders:
+			p.flagsMtx.Lock()
+			p.sendHeadersPreferred = true
+			p.flagsMtx.Unlock()
+
+			if p.cfg.Listeners.OnSendHeaders != nil {
+				p.cfg.Listeners.OnSendHeaders(p, msg)
 			}
 
 		default:

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -380,6 +380,9 @@ func TestPeerListeners(t *testing.T) {
 			OnReject: func(p *peer.Peer, msg *wire.MsgReject) {
 				ok <- msg
 			},
+			OnSendHeaders: func(p *peer.Peer, msg *wire.MsgSendHeaders) {
+				ok <- msg
+			},
 		},
 		UserAgentName:    "peer",
 		UserAgentVersion: "1.0",
@@ -498,8 +501,12 @@ func TestPeerListeners(t *testing.T) {
 		// only one version message is allowed
 		// only one verack message is allowed
 		{
-			"OnMsgReject",
+			"OnReject",
 			wire.NewMsgReject("block", wire.RejectDuplicate, "dupe block"),
+		},
+		{
+			"OnSendHeaders",
+			wire.NewMsgSendHeaders(),
 		},
 	}
 	t.Logf("Running %d tests", len(tests))

--- a/server.go
+++ b/server.go
@@ -1403,6 +1403,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 		ChainParams:      sp.server.chainParams,
 		Services:         sp.server.services,
 		DisableRelayTx:   false,
+		ProtocolVersion:  70011,
 	}
 }
 


### PR DESCRIPTION
This modifies the `peer` package to add support for the `sendheaders` protocol message introduced by `BIP0030`.

NOTE: This does not add support to btcd itself. That requires the server and sync code to make use of the new functionality exposed by these changes.  As a result, btcd will still be using protocol version 70011.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/618)
<!-- Reviewable:end -->
