### PR TITLE
server: Make consistent use of server peer stringer.

### DIFF
--- a/server.go
+++ b/server.go
@@ -1645,7 +1645,7 @@ out:
 		case <-s.quit:
 			// Disconnect all peers on server shutdown.
 			state.forAllPeers(func(sp *serverPeer) {
-				srvrLog.Tracef("Shutdown peer %s", sp.Peer)
+				srvrLog.Tracef("Shutdown peer %s", sp)
 				sp.Disconnect()
 			})
 			break out
@@ -1663,7 +1663,7 @@ out:
 		if !state.NeedMoreOutbound() || len(cfg.ConnectPeers) > 0 ||
 			atomic.LoadInt32(&s.shutdown) != 0 {
 			state.forPendingPeers(func(sp *serverPeer) {
-				srvrLog.Tracef("Shutdown peer %s", sp.Peer)
+				srvrLog.Tracef("Shutdown peer %s", sp)
 				sp.Disconnect()
 			})
 			continue


### PR DESCRIPTION
This updates a couple of logging statements to use the `serverPeer` instance instead of the embedded `peer.Peer` so they are consistent with all of the other log statements.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/622)
<!-- Reviewable:end -->
