### PR TITLE
Fix documentation for opcodeInvalid

### DIFF
--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -833,7 +833,7 @@ func opcodeReserved(op *parsedOpcode, vm *Engine) error {
 	return ErrStackReservedOpcode
 }
 
-// opcodeReserved is a common handler for all invalid opcodes.  It returns an
+// opcodeInvalid is a common handler for all invalid opcodes.  It returns an
 // appropriate error indicating the opcode is invalid.
 func opcodeInvalid(op *parsedOpcode, vm *Engine) error {
 	return ErrStackInvalidOpcode


### PR DESCRIPTION
Change 'opcodeReserved' to 'opcodeInvalid'

Cherry-picked from downstream decred/dcrd#19.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/624)
<!-- Reviewable:end -->
