### PR TITLE
Look in datadir for RPC cert+key.

### DIFF
--- a/config.go
+++ b/config.go
@@ -435,6 +435,18 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
+	// If an alternate data directory was specified, and paths with defaults
+	// relative to the data dir are unchanged, modify each path to be
+	// relative to the new data dir.
+	if cfg.DataDir != defaultDataDir {
+		if cfg.RPCKey == defaultRPCKeyFile {
+			cfg.RPCKey = filepath.Join(cfg.DataDir, "rpc.key")
+		}
+		if cfg.RPCCert == defaultRPCCertFile {
+			cfg.RPCCert = filepath.Join(cfg.DataDir, "rpc.cert")
+		}
+	}
+
 	// Multiple networks can't be selected simultaneously.
 	numNets := 0
 	// Count number of network flags passed; assign active network params


### PR DESCRIPTION
btcwallet sets the path for the rpc cert and key
to the directory specified by the datadir option.

This adds the same logic to btcd.

Pointed out in decred/dcrd#52

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/635)
<!-- Reviewable:end -->
