### PR TITLE
Update TravisCI and README for Go 1.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: go
 go:
-  - 1.4.2
-  - 1.5.1
+  - 1.4.3
+  - 1.5.3
+  - 1.6
 sudo: false
 before_install:
   - gotools=golang.org/x/tools

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ active development.
 
 ## Requirements
 
-[Go](http://golang.org) 1.3 or newer.
+[Go](http://golang.org) 1.5 or newer.
 
 ## Installation
 


### PR DESCRIPTION
Now that Go 1.6 has been released, update the required Go version in the `README` to 1.5 and add Go 1.6 to the configurations tested by TravisCI.

Also, while here, update the Go 1.4 and 1.5 versions tested by TravisCI to the latest point releases.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/638)
<!-- Reviewable:end -->
