### PR TITLE
TravisCI: Remove Go 1.4.3 tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: go
 go:
-  - 1.4.3
   - 1.5.3
   - 1.6
 sudo: false


### PR DESCRIPTION
Since the latest `golint` no longer works with on Go 1.4 and Go 1.4 is no longer officially supported by btcsuite, remove it from the configurations tested by TravisCI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/651)
<!-- Reviewable:end -->
