### PR TITLE
server: Drain relay notification channel.

### DIFF
--- a/server.go
+++ b/server.go
@@ -2018,6 +2018,7 @@ out:
 cleanup:
 	for {
 		select {
+		case <-s.relayNtfnChan:
 		case <-s.modifyRebroadcastInv:
 		default:
 			break cleanup


### PR DESCRIPTION
A new channel to handle inventory relaying asynchronous to the mempool was added when the `mempoolConfig` struct was introduced in commit 83bcfea271da8b0c890ede7ef374c5a74ec5aad7.

However, the new channel was not also added to the cleanup code which drains the channels and, as a result, it led to the possibility for the server to hang during shutdown.

This pull request resolves that issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/652)
<!-- Reviewable:end -->
