### PR TITLE
mining: Export block template fields.

### DIFF
--- a/cpuminer.go
+++ b/cpuminer.go
@@ -318,8 +318,8 @@ out:
 		// with false when conditions that trigger a stale block, so
 		// a new block template can be generated.  When the return is
 		// true a solution was found, so submit the solved block.
-		if m.solveBlock(template.block, curHeight+1, ticker, quit) {
-			block := btcutil.NewBlock(template.block)
+		if m.solveBlock(template.Block, curHeight+1, ticker, quit) {
+			block := btcutil.NewBlock(template.Block)
 			m.submitBlock(block)
 		}
 	}
@@ -580,8 +580,8 @@ func (m *CPUMiner) GenerateNBlocks(n uint32) ([]*wire.ShaHash, error) {
 		// with false when conditions that trigger a stale block, so
 		// a new block template can be generated.  When the return is
 		// true a solution was found, so submit the solved block.
-		if m.solveBlock(template.block, curHeight+1, ticker, nil) {
-			block := btcutil.NewBlock(template.block)
+		if m.solveBlock(template.Block, curHeight+1, ticker, nil) {
+			block := btcutil.NewBlock(template.Block)
 			m.submitBlock(block)
 			blockHashes[i] = block.Sha()
 			i++

--- a/mining.go
+++ b/mining.go
@@ -156,11 +156,30 @@ func newTxPriorityQueue(reserve int, sortByFee bool) *txPriorityQueue {
 // details about the fees and the number of signature operations for each
 // transaction in the block.
 type BlockTemplate struct {
-	block           *wire.MsgBlock
-	fees            []int64
-	sigOpCounts     []int64
-	height          int32
-	validPayAddress bool
+	// Block is a block that is ready to be solved by miners.  Thus, it is
+	// completely valid with the exception of satisfying the proof-of-work
+	// requirement.
+	Block *wire.MsgBlock
+
+	// Fees contains the amount of fees each transaction in the generated
+	// template pays in base units.  Since the first transaction is the
+	// coinbase, the first entry (offset 0) will contain the negative of the
+	// sum of the fees of all other transactions.
+	Fees []int64
+
+	// SigOpCounts contains the number of signature operations each
+	// transaction in the generated template performs.
+	SigOpCounts []int64
+
+	// Height is the height at which the block template connects to the main
+	// chain.
+	Height int32
+
+	// ValidPayAddress indicates whether or not the template coinbase pays
+	// to an address or is redeemable by anyone.  See the documentation on
+	// NewBlockTemplate for details on which this can be useful to generate
+	// templates without a coinbase payment address.
+	ValidPayAddress bool
 }
 
 // mergeTxStore adds all of the transactions in txStoreB to txStoreA.  The
@@ -750,11 +769,11 @@ mempoolLoop:
 		blockSize, blockchain.CompactToBig(msgBlock.Header.Bits))
 
 	return &BlockTemplate{
-		block:           &msgBlock,
-		fees:            txFees,
-		sigOpCounts:     txSigOpCounts,
-		height:          nextBlockHeight,
-		validPayAddress: payToAddress != nil,
+		Block:           &msgBlock,
+		Fees:            txFees,
+		SigOpCounts:     txSigOpCounts,
+		Height:          nextBlockHeight,
+		ValidPayAddress: payToAddress != nil,
 	}, nil
 }
 


### PR DESCRIPTION
This simply exports and adds some comments to the fields of the `BlockTemplate` struct.

This is primarily being done as a step toward being able to separate the mining code into its own package, but also it makes sense on its own because code that requests new block template necessarily examines the returned fields which implies they should be exported.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/659)
<!-- Reviewable:end -->
