### PR TITLE
chaincfg: Register networks instead of hard coding.

### DIFF
--- a/chaincfg/params_test.go
+++ b/chaincfg/params_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package chaincfg
+
+import "testing"
+
+// TestMustRegisterPanic ensures the mustRegister function panics when used to
+// register an invalid network.
+func TestMustRegisterPanic(t *testing.T) {
+	t.Parallel()
+
+	// Setup a defer to catch the expected panic to ensure it actually
+	// paniced.
+	defer func() {
+		if err := recover(); err == nil {
+			t.Error("mustRegister did not panic as expected")
+		}
+	}()
+
+	// Intentionally try to register duplicate params to force a panic.
+	mustRegister(&MainNetParams)
+}


### PR DESCRIPTION
This modifies the `chaincfg` package to register the default network params via the `init` function instead of manually hard coding their data into the maps.  This is less error prone when adding new default networks.

A new function named `MustRegister` has been introduced that panics if there are any errors when registering the network that the new code makes use of and appropriate tests have been added.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/660)
<!-- Reviewable:end -->
