### PR TITLE
fix memory alignment for 32-bit architectures

### DIFF
--- a/server.go
+++ b/server.go
@@ -170,11 +170,12 @@ func (ps *peerState) forAllPeers(closure func(sp *serverPeer)) {
 // bitcoin peers.
 type server struct {
 	// The following variables must only be used atomically.
+	// Putting the uint64s first makes them 64-bit aligned for 32-bit systems.
+	bytesReceived uint64 // Total bytes received from all peers since start.
+	bytesSent     uint64 // Total bytes sent by all peers since start.
 	started       int32
 	shutdown      int32
 	shutdownSched int32
-	bytesReceived uint64 // Total bytes received from all peers since start.
-	bytesSent     uint64 // Total bytes sent by all peers since start.
 
 	listeners            []net.Listener
 	chainParams          *chaincfg.Params


### PR DESCRIPTION
having 3 int32s above the uint64s in the struct
will cause mis-alignment for some 32-bit architectures.
see https://golang.org/pkg/sync/atomic/#pkg-note-BUG
This alligns bytesReceived and bytesSent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/668)
<!-- Reviewable:end -->
