### PR TITLE
btcd: sendheaders server support

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -1190,7 +1190,7 @@ func (b *blockManager) handleNotifyMsg(notification *blockchain.Notification) {
 
 		// Generate the inventory vector and relay it.
 		iv := wire.NewInvVect(wire.InvTypeBlock, block.Sha())
-		b.server.RelayInventory(iv, nil)
+		b.server.RelayInventory(iv, block.MsgBlock().Header)
 
 	// A block has been connected to the main block chain.
 	case blockchain.NTBlockConnected:

--- a/server.go
+++ b/server.go
@@ -1302,6 +1302,26 @@ func (s *server) handleRelayInvMsg(state *peerState, msg relayMsg) {
 			return
 		}
 
+		// If the inventory is a block and the peer prefers headers,
+		// generate and send a headers message instead of an inventory
+		// message.
+		if msg.invVect.Type == wire.InvTypeBlock && sp.WantsHeaders() {
+			blockHeader, ok := msg.data.(wire.BlockHeader)
+			if !ok {
+				peerLog.Warnf("Underlying data for headers" +
+					" is not a block header")
+				return
+			}
+			msgHeaders := wire.NewMsgHeaders()
+			if err := msgHeaders.AddBlockHeader(&blockHeader); err != nil {
+				peerLog.Errorf("Failed to add block"+
+					" header: %v", err)
+				return
+			}
+			sp.QueueMessage(msgHeaders, nil)
+			return
+		}
+
 		if msg.invVect.Type == wire.InvTypeTx {
 			// Don't relay the transaction to the peer when it has
 			// transaction relaying disabled.
@@ -1533,7 +1553,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 		ChainParams:      sp.server.chainParams,
 		Services:         sp.server.services,
 		DisableRelayTx:   cfg.BlocksOnly,
-		ProtocolVersion:  70011,
+		ProtocolVersion:  wire.SendHeadersVersion,
 	}
 }
 


### PR DESCRIPTION
This adds support for serving headers instead of inventory messages in accordance with BIP0130.  btcd itself does not yet make use of the feature when receiving data.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/671)
<!-- Reviewable:end -->
