### PR TITLE
btcd: Remove peer-specific logging funcs.

### DIFF
--- a/log.go
+++ b/log.go
@@ -7,8 +7,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"strings"
-	"time"
 
 	"github.com/btcsuite/btcd/addrmgr"
 	"github.com/btcsuite/btcd/blockchain"
@@ -16,7 +14,6 @@ import (
 	"github.com/btcsuite/btcd/database"
 	"github.com/btcsuite/btcd/peer"
 	"github.com/btcsuite/btcd/txscript"
-	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btclog"
 	"github.com/btcsuite/seelog"
 )
@@ -209,154 +206,4 @@ func directionString(inbound bool) string {
 		return "inbound"
 	}
 	return "outbound"
-}
-
-// formatLockTime returns a transaction lock time as a human-readable string.
-func formatLockTime(lockTime uint32) string {
-	// The lock time field of a transaction is either a block height at
-	// which the transaction is finalized or a timestamp depending on if the
-	// value is before the txscript.LockTimeThreshold.  When it is under the
-	// threshold it is a block height.
-	if lockTime < txscript.LockTimeThreshold {
-		return fmt.Sprintf("height %d", lockTime)
-	}
-
-	return time.Unix(int64(lockTime), 0).String()
-}
-
-// invSummary returns an inventory message as a human-readable string.
-func invSummary(invList []*wire.InvVect) string {
-	// No inventory.
-	invLen := len(invList)
-	if invLen == 0 {
-		return "empty"
-	}
-
-	// One inventory item.
-	if invLen == 1 {
-		iv := invList[0]
-		switch iv.Type {
-		case wire.InvTypeError:
-			return fmt.Sprintf("error %s", iv.Hash)
-		case wire.InvTypeBlock:
-			return fmt.Sprintf("block %s", iv.Hash)
-		case wire.InvTypeTx:
-			return fmt.Sprintf("tx %s", iv.Hash)
-		}
-
-		return fmt.Sprintf("unknown (%d) %s", uint32(iv.Type), iv.Hash)
-	}
-
-	// More than one inv item.
-	return fmt.Sprintf("size %d", invLen)
-}
-
-// locatorSummary returns a block locator as a human-readable string.
-func locatorSummary(locator []*wire.ShaHash, stopHash *wire.ShaHash) string {
-	if len(locator) > 0 {
-		return fmt.Sprintf("locator %s, stop %s", locator[0], stopHash)
-	}
-
-	return fmt.Sprintf("no locator, stop %s", stopHash)
-
-}
-
-// sanitizeString strips any characters which are even remotely dangerous, such
-// as html control characters, from the passed string.  It also limits it to
-// the passed maximum size, which can be 0 for unlimited.  When the string is
-// limited, it will also add "..." to the string to indicate it was truncated.
-func sanitizeString(str string, maxLength uint) string {
-	const safeChars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXY" +
-		"Z01234567890 .,;_/:?@"
-
-	// Strip any characters not in the safeChars string removed.
-	str = strings.Map(func(r rune) rune {
-		if strings.IndexRune(safeChars, r) >= 0 {
-			return r
-		}
-		return -1
-	}, str)
-
-	// Limit the string to the max allowed length.
-	if maxLength > 0 && uint(len(str)) > maxLength {
-		str = str[:maxLength]
-		str = str + "..."
-	}
-	return str
-}
-
-// messageSummary returns a human-readable string which summarizes a message.
-// Not all messages have or need a summary.  This is used for debug logging.
-func messageSummary(msg wire.Message) string {
-	switch msg := msg.(type) {
-	case *wire.MsgVersion:
-		return fmt.Sprintf("agent %s, pver %d, block %d",
-			msg.UserAgent, msg.ProtocolVersion, msg.LastBlock)
-
-	case *wire.MsgVerAck:
-		// No summary.
-
-	case *wire.MsgGetAddr:
-		// No summary.
-
-	case *wire.MsgAddr:
-		return fmt.Sprintf("%d addr", len(msg.AddrList))
-
-	case *wire.MsgPing:
-		// No summary - perhaps add nonce.
-
-	case *wire.MsgPong:
-		// No summary - perhaps add nonce.
-
-	case *wire.MsgAlert:
-		// No summary.
-
-	case *wire.MsgMemPool:
-		// No summary.
-
-	case *wire.MsgTx:
-		return fmt.Sprintf("hash %s, %d inputs, %d outputs, lock %s",
-			msg.TxSha(), len(msg.TxIn), len(msg.TxOut),
-			formatLockTime(msg.LockTime))
-
-	case *wire.MsgBlock:
-		header := &msg.Header
-		return fmt.Sprintf("hash %s, ver %d, %d tx, %s", msg.BlockSha(),
-			header.Version, len(msg.Transactions), header.Timestamp)
-
-	case *wire.MsgInv:
-		return invSummary(msg.InvList)
-
-	case *wire.MsgNotFound:
-		return invSummary(msg.InvList)
-
-	case *wire.MsgGetData:
-		return invSummary(msg.InvList)
-
-	case *wire.MsgGetBlocks:
-		return locatorSummary(msg.BlockLocatorHashes, &msg.HashStop)
-
-	case *wire.MsgGetHeaders:
-		return locatorSummary(msg.BlockLocatorHashes, &msg.HashStop)
-
-	case *wire.MsgHeaders:
-		return fmt.Sprintf("num %d", len(msg.Headers))
-
-	case *wire.MsgReject:
-		// Ensure the variable length strings don't contain any
-		// characters which are even remotely dangerous such as HTML
-		// control characters, etc.  Also limit them to sane length for
-		// logging.
-		rejCommand := sanitizeString(msg.Cmd, wire.CommandSize)
-		rejReason := sanitizeString(msg.Reason, maxRejectReasonLen)
-		summary := fmt.Sprintf("cmd %v, code %v, reason %v", rejCommand,
-			msg.Code, rejReason)
-		if rejCommand == wire.CmdBlock || rejCommand == wire.CmdTx {
-			summary += fmt.Sprintf(", hash %v", msg.Hash)
-		}
-		return summary
-	}
-
-	// No summary for other messages.
-	return ""
 }


### PR DESCRIPTION
This removes the logging functions that are now implemented in the peer package as they are no longer used by `btcd` itself and should have been removed when they were copied into the peer package.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/675)
<!-- Reviewable:end -->
