### PR TITLE
txscript: Reduce script parse opcode allocs.

### DIFF
--- a/txscript/script.go
+++ b/txscript/script.go
@@ -105,8 +105,8 @@ func parseScriptTemplate(script []byte, opcodes *[256]opcode) ([]parsedOpcode, e
 	retScript := make([]parsedOpcode, 0, len(script))
 	for i := 0; i < len(script); {
 		instr := script[i]
-		op := opcodes[instr]
-		pop := parsedOpcode{opcode: &op}
+		op := &opcodes[instr]
+		pop := parsedOpcode{opcode: op}
 
 		// Parse data out of instruction.
 		switch {


### PR DESCRIPTION
This changes the script template parsing function to use a pointer into the constant global opcode array for parsed opcodes as opposed to making a copy of the opcode entries which causes unnecessary allocations.

Profiling showed that after roughly 48 hours of operation, this copy was the culprit of 207 million unnecessary allocations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/677)
<!-- Reviewable:end -->
