### PR TITLE
wire: Don't allocate new readers in benchmarks.

### DIFF
--- a/wire/bench_test.go
+++ b/wire/bench_test.go
@@ -152,8 +152,10 @@ func BenchmarkWriteVarInt9(b *testing.B) {
 // a single byte variable length integer.
 func BenchmarkReadVarInt1(b *testing.B) {
 	buf := []byte{0x01}
+	r := bytes.NewReader(buf)
 	for i := 0; i < b.N; i++ {
-		ReadVarInt(bytes.NewReader(buf), 0)
+		r.Seek(0, 0)
+		ReadVarInt(r, 0)
 	}
 }
 
@@ -161,8 +163,10 @@ func BenchmarkReadVarInt1(b *testing.B) {
 // a three byte variable length integer.
 func BenchmarkReadVarInt3(b *testing.B) {
 	buf := []byte{0x0fd, 0xff, 0xff}
+	r := bytes.NewReader(buf)
 	for i := 0; i < b.N; i++ {
-		ReadVarInt(bytes.NewReader(buf), 0)
+		r.Seek(0, 0)
+		ReadVarInt(r, 0)
 	}
 }
 
@@ -170,8 +174,10 @@ func BenchmarkReadVarInt3(b *testing.B) {
 // a five byte variable length integer.
 func BenchmarkReadVarInt5(b *testing.B) {
 	buf := []byte{0xfe, 0xff, 0xff, 0xff, 0xff}
+	r := bytes.NewReader(buf)
 	for i := 0; i < b.N; i++ {
-		ReadVarInt(bytes.NewReader(buf), 0)
+		r.Seek(0, 0)
+		ReadVarInt(r, 0)
 	}
 }
 
@@ -179,8 +185,10 @@ func BenchmarkReadVarInt5(b *testing.B) {
 // a nine byte variable length integer.
 func BenchmarkReadVarInt9(b *testing.B) {
 	buf := []byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}
+	r := bytes.NewReader(buf)
 	for i := 0; i < b.N; i++ {
-		ReadVarInt(bytes.NewReader(buf), 0)
+		r.Seek(0, 0)
+		ReadVarInt(r, 0)
 	}
 }
 
@@ -188,8 +196,10 @@ func BenchmarkReadVarInt9(b *testing.B) {
 // four byte variable length string.
 func BenchmarkReadVarStr4(b *testing.B) {
 	buf := []byte{0x04, 't', 'e', 's', 't'}
+	r := bytes.NewReader(buf)
 	for i := 0; i < b.N; i++ {
-		ReadVarString(bytes.NewReader(buf), 0)
+		r.Seek(0, 0)
+		ReadVarString(r, 0)
 	}
 }
 
@@ -197,8 +207,10 @@ func BenchmarkReadVarStr4(b *testing.B) {
 // ten byte variable length string.
 func BenchmarkReadVarStr10(b *testing.B) {
 	buf := []byte{0x0a, 't', 'e', 's', 't', '0', '1', '2', '3', '4', '5'}
+	r := bytes.NewReader(buf)
 	for i := 0; i < b.N; i++ {
-		ReadVarString(bytes.NewReader(buf), 0)
+		r.Seek(0, 0)
+		ReadVarString(r, 0)
 	}
 }
 
@@ -228,9 +240,11 @@ func BenchmarkReadOutPoint(b *testing.B) {
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Previous output hash
 		0xff, 0xff, 0xff, 0xff, // Previous output index
 	}
+	r := bytes.NewReader(buf)
 	var op OutPoint
 	for i := 0; i < b.N; i++ {
-		readOutPoint(bytes.NewReader(buf), 0, 0, &op)
+		r.Seek(0, 0)
+		readOutPoint(r, 0, 0, &op)
 	}
 }
 
@@ -264,9 +278,11 @@ func BenchmarkReadTxOut(b *testing.B) {
 		0xee, // 65-byte signature
 		0xac, // OP_CHECKSIG
 	}
+	r := bytes.NewReader(buf)
 	var txOut TxOut
 	for i := 0; i < b.N; i++ {
-		readTxOut(bytes.NewReader(buf), 0, 0, &txOut)
+		r.Seek(0, 0)
+		readTxOut(r, 0, 0, &txOut)
 	}
 }
 
@@ -292,9 +308,11 @@ func BenchmarkReadTxIn(b *testing.B) {
 		0x04, 0xff, 0xff, 0x00, 0x1d, 0x01, 0x04, // Signature script
 		0xff, 0xff, 0xff, 0xff, // Sequence
 	}
+	r := bytes.NewReader(buf)
 	var txIn TxIn
 	for i := 0; i < b.N; i++ {
-		readTxIn(bytes.NewReader(buf), 0, 0, &txIn)
+		r.Seek(0, 0)
+		readTxIn(r, 0, 0, &txIn)
 	}
 }
 
@@ -337,9 +355,12 @@ func BenchmarkDeserializeTxSmall(b *testing.B) {
 		0xac,                   // OP_CHECKSIG
 		0x00, 0x00, 0x00, 0x00, // Lock time
 	}
+
+	r := bytes.NewReader(buf)
 	var tx MsgTx
 	for i := 0; i < b.N; i++ {
-		tx.Deserialize(bytes.NewReader(buf))
+		r.Seek(0, 0)
+		tx.Deserialize(r)
 	}
 }
 
@@ -358,9 +379,11 @@ func BenchmarkDeserializeTxLarge(b *testing.B) {
 		b.Fatalf("Failed to read transaction data: %v", err)
 	}
 
+	r := bytes.NewReader(buf)
 	var tx MsgTx
 	for i := 0; i < b.N; i++ {
-		tx.Deserialize(bytes.NewReader(buf))
+		r.Seek(0, 0)
+		tx.Deserialize(r)
 	}
 }
 
@@ -392,9 +415,11 @@ func BenchmarkReadBlockHeader(b *testing.B) {
 		0xf3, 0xe0, 0x01, 0x00, // Nonce
 		0x00, // TxnCount Varint
 	}
+	r := bytes.NewReader(buf)
 	var header BlockHeader
 	for i := 0; i < b.N; i++ {
-		readBlockHeader(bytes.NewReader(buf), 0, &header)
+		r.Seek(0, 0)
+		readBlockHeader(r, 0, &header)
 	}
 }
 


### PR DESCRIPTION
NOTE: This requires #678 in order for the reported allocation statistics to be correct.

This modifies the benchmarks in the wire package to avoid creating a new reader for each iteration.  This is useful since it means that showing the memory allocations will only show the function under test instead of the allocation for the benchmark setup as well.

The following is a before and after comparison of the allocations with the benchmarks that did not change removed:

```
benchmark              old allocs     new allocs     delta
------------------------------------------------------------
ReadVarInt1            2              1              -50.00%
ReadVarInt3            2              1              -50.00%
ReadVarInt5            2              1              -50.00%
ReadVarInt9            2              1              -50.00%
ReadVarStr4            4              3              -25.00%
ReadVarStr10           4              3              -25.00%
ReadOutPoint           2              1              -50.00%
ReadTxOut              4              3              -25.00%
ReadTxIn               6              5              -16.67%
DeserializeTxSmall     16             15             -6.25%
DeserializeTxLarge     33430          33428          -0.01%
ReadBlockHeader        8              7              -12.50%
```