### PR TITLE
blockchain: Remove unused root field.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -179,7 +179,6 @@ type BlockChain struct {
 
 	// These fields are related to the memory block index.  They are
 	// protected by the chain lock.
-	root     *blockNode
 	bestNode *blockNode
 	index    map[wire.ShaHash]*blockNode
 	depNodes map[wire.ShaHash][]*blockNode
@@ -423,7 +422,6 @@ func (b *BlockChain) loadBlockNode(dbTx database.Tx, hash *wire.ShaHash) (*block
 		for _, childNode := range childNodes {
 			childNode.parent = node
 			node.children = append(node.children, childNode)
-			b.root = node
 		}
 
 	} else {
@@ -582,9 +580,6 @@ func (b *BlockChain) pruneBlockNodes() error {
 			return err
 		}
 	}
-
-	// Set the new root node.
-	b.root = newRootNode
 
 	return nil
 }
@@ -1456,7 +1451,6 @@ func New(config *Config) (*BlockChain, error) {
 		notifications:       config.Notifications,
 		sigCache:            config.SigCache,
 		indexManager:        config.IndexManager,
-		root:                nil,
 		bestNode:            nil,
 		index:               make(map[wire.ShaHash]*blockNode),
 		depNodes:            make(map[wire.ShaHash][]*blockNode),

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1047,14 +1047,12 @@ func dbPutBestState(dbTx database.Tx, snapshot *BestState, workSum *big.Int) err
 // genesis block.  This includes creating the necessary buckets and inserting
 // the genesis block, so it must only be called on an uninitialized database.
 func (b *BlockChain) createChainState() error {
-	// Create a new node from the genesis block and set it as both the root
-	// node and the best node.
+	// Create a new node from the genesis block and set it as the best node.
 	genesisBlock := btcutil.NewBlock(b.chainParams.GenesisBlock)
 	header := &genesisBlock.MsgBlock().Header
 	node := newBlockNode(header, genesisBlock.Sha(), 0)
 	node.inMainChain = true
 	b.bestNode = node
-	b.root = node
 
 	// Add the new node to the index which is used for faster lookups.
 	b.index[*node.hash] = node
@@ -1147,15 +1145,13 @@ func (b *BlockChain) initChainState() error {
 			return err
 		}
 
-		// Create a new node and set it as both the root node and the
-		// best node.  The preceding nodes will be loaded on demand as
-		// needed.
+		// Create a new node and set it as the best node.  The preceding
+		// nodes will be loaded on demand as needed.
 		header := &block.Header
 		node := newBlockNode(header, &state.hash, int32(state.height))
 		node.inMainChain = true
 		node.workSum = state.workSum
 		b.bestNode = node
-		b.root = node
 
 		// Add the new node to the indices for faster lookups.
 		prevHash := node.parentHash


### PR DESCRIPTION
This removes the root field and all references to it from the `BlockChain` struct since it is no longer required.

It was previously required because the chain state was not initialized when the instance was created.  However, that is no longer the case, so there is no reason to keep it around any longer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/btcsuite/btcd/680)
<!-- Reviewable:end -->
