### PR TITLE
wire: Significantly reduce decoding allocs.

### DIFF
--- a/wire/bench_test.go
+++ b/wire/bench_test.go
@@ -285,6 +285,7 @@ func BenchmarkReadTxOut(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		r.Seek(0, 0)
 		readTxOut(r, 0, 0, &txOut)
+		scriptPool.Return(txOut.PkScript)
 	}
 }
 
@@ -315,6 +316,7 @@ func BenchmarkReadTxIn(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		r.Seek(0, 0)
 		readTxIn(r, 0, 0, &txIn)
+		scriptPool.Return(txIn.SignatureScript)
 	}
 }
 

--- a/wire/blockheader.go
+++ b/wire/blockheader.go
@@ -115,13 +115,11 @@ func NewBlockHeader(prevHash *ShaHash, merkleRootHash *ShaHash, bits uint32,
 // decoding block headers stored to disk, such as in a database, as opposed to
 // decoding from the wire.
 func readBlockHeader(r io.Reader, pver uint32, bh *BlockHeader) error {
-	var sec uint32
-	err := readElements(r, &bh.Version, &bh.PrevBlock, &bh.MerkleRoot, &sec,
-		&bh.Bits, &bh.Nonce)
+	err := readElements(r, &bh.Version, &bh.PrevBlock, &bh.MerkleRoot,
+		(*uint32Time)(&bh.Timestamp), &bh.Bits, &bh.Nonce)
 	if err != nil {
 		return err
 	}
-	bh.Timestamp = time.Unix(int64(sec), 0)
 
 	return nil
 }

--- a/wire/common.go
+++ b/wire/common.go
@@ -14,8 +14,161 @@ import (
 	"github.com/btcsuite/fastsha256"
 )
 
-// MaxVarIntPayload is the maximum payload size for a variable length integer.
-const MaxVarIntPayload = 9
+const (
+	// MaxVarIntPayload is the maximum payload size for a variable length integer.
+	MaxVarIntPayload = 9
+
+	// binaryFreeListMaxItems is the number of buffers to keep in the free
+	// list to use for binary serialization and deserialization.
+	binaryFreeListMaxItems = 1024
+)
+
+var (
+	// littleEndian is a convenience variable since binary.LittleEndian is
+	// quite long.
+	littleEndian = binary.LittleEndian
+
+	// bigEndian is a convenience variable since binary.BigEndian is quite
+	// long.
+	bigEndian = binary.BigEndian
+)
+
+// binaryFreeList defines a concurrent safe free list of byte slices (up to the
+// maximum number defined by the binaryFreeListMaxItems constant) that have a
+// cap of 8 (thus it supports up to a uint64).  It is used to provide temporary
+// buffers for serializing and deserializing primitive numbers to and from their
+// binary encoding in order to greatly reduce the number of allocations
+// required.
+//
+// For convenience, functions are provided for each of the primitive unsigned
+// integers that automatically obtain a buffer from the free list, perform the
+// necessary binary conversion, read from or write to the given io.Reader or
+// io.Writer, and return the buffer to the free list.
+type binaryFreeList chan []byte
+
+// Borrow returns a byte slice from the free list with a length of 8.  A new
+// buffer is allocated if there are not any available on the free list.
+func (l binaryFreeList) Borrow() []byte {
+	var buf []byte
+	select {
+	case buf = <-l:
+	default:
+		buf = make([]byte, 8)
+	}
+	return buf[:8]
+}
+
+// Return puts the provided byte slice back on the free list.  The buffer MUST
+// have been obtained via the Borrow function and therefore have a cap of 8.
+func (l binaryFreeList) Return(buf []byte) {
+	select {
+	case l <- buf:
+	default:
+		// Let it go to the garbage collector.
+	}
+}
+
+// Uint8 reads a single byte from the provided reader using a buffer from the
+// free list and returns it as a uint8.
+func (l binaryFreeList) Uint8(r io.Reader) (uint8, error) {
+	buf := l.Borrow()[:1]
+	if _, err := io.ReadFull(r, buf); err != nil {
+		l.Return(buf)
+		return 0, err
+	}
+	rv := buf[0]
+	l.Return(buf)
+	return rv, nil
+}
+
+// Uint16 reads two bytes from the provided reader using a buffer from the
+// free list, converts it to a number using the provided byte order, and returns
+// the resulting uint16.
+func (l binaryFreeList) Uint16(r io.Reader, byteOrder binary.ByteOrder) (uint16, error) {
+	buf := l.Borrow()[:2]
+	if _, err := io.ReadFull(r, buf); err != nil {
+		l.Return(buf)
+		return 0, err
+	}
+	rv := byteOrder.Uint16(buf)
+	l.Return(buf)
+	return rv, nil
+}
+
+// Uint32 reads four bytes from the provided reader using a buffer from the
+// free list, converts it to a number using the provided byte order, and returns
+// the resulting uint32.
+func (l binaryFreeList) Uint32(r io.Reader, byteOrder binary.ByteOrder) (uint32, error) {
+	buf := l.Borrow()[:4]
+	if _, err := io.ReadFull(r, buf); err != nil {
+		l.Return(buf)
+		return 0, err
+	}
+	rv := byteOrder.Uint32(buf)
+	l.Return(buf)
+	return rv, nil
+}
+
+// Uint64 reads eight bytes from the provided reader using a buffer from the
+// free list, converts it to a number using the provided byte order, and returns
+// the resulting uint64.
+func (l binaryFreeList) Uint64(r io.Reader, byteOrder binary.ByteOrder) (uint64, error) {
+	buf := l.Borrow()[:8]
+	if _, err := io.ReadFull(r, buf); err != nil {
+		l.Return(buf)
+		return 0, err
+	}
+	rv := byteOrder.Uint64(buf)
+	l.Return(buf)
+	return rv, nil
+}
+
+// PutUint8 copies the provided uint8 into a buffer from the free list and
+// writes the resulting byte to the given writer.
+func (l binaryFreeList) PutUint8(w io.Writer, val uint8) error {
+	buf := l.Borrow()[:1]
+	buf[0] = val
+	_, err := w.Write(buf)
+	l.Return(buf)
+	return err
+}
+
+// PutUint16 serializes the provided uint16 using the given byte order into a
+// buffer from the free list and writes the resulting two bytes to the given
+// writer.
+func (l binaryFreeList) PutUint16(w io.Writer, byteOrder binary.ByteOrder, val uint16) error {
+	buf := l.Borrow()[:2]
+	byteOrder.PutUint16(buf, val)
+	_, err := w.Write(buf)
+	l.Return(buf)
+	return err
+}
+
+// PutUint32 serializes the provided uint32 using the given byte order into a
+// buffer from the free list and writes the resulting four bytes to the given
+// writer.
+func (l binaryFreeList) PutUint32(w io.Writer, byteOrder binary.ByteOrder, val uint32) error {
+	buf := l.Borrow()[:4]
+	byteOrder.PutUint32(buf, val)
+	_, err := w.Write(buf)
+	l.Return(buf)
+	return err
+}
+
+// PutUint64 serializes the provided uint64 using the given byte order into a
+// buffer from the free list and writes the resulting eight bytes to the given
+// writer.
+func (l binaryFreeList) PutUint64(w io.Writer, byteOrder binary.ByteOrder, val uint64) error {
+	buf := l.Borrow()[:8]
+	byteOrder.PutUint64(buf, val)
+	_, err := w.Write(buf)
+	l.Return(buf)
+	return err
+}
+
+// binarySerializer provides a free list of buffers to use for serializing and
+// deserializing primitive integer values to and from io.Readers and io.Writers.
+var binarySerializer binaryFreeList = make(chan []byte, binaryFreeListMaxItems)
 
 // errNonCanonicalVarInt is the common format string used for non-canonically
 // encoded variable length integer errors.
@@ -25,54 +178,47 @@ var errNonCanonicalVarInt = "non-canonical varint %x - discriminant %x must " +
 // readElement reads the next sequence of bytes from r using little endian
 // depending on the concrete type of element pointed to.
 func readElement(r io.Reader, element interface{}) error {
-	var scratch [8]byte
-
 	// Attempt to read the element based on the concrete type via fast
 	// type assertions first.
 	switch e := element.(type) {
 	case *int32:
-		b := scratch[0:4]
-		_, err := io.ReadFull(r, b)
+		rv, err := binarySerializer.Uint32(r, littleEndian)
 		if err != nil {
 			return err
 		}
-		*e = int32(binary.LittleEndian.Uint32(b))
+		*e = int32(rv)
 		return nil
 
 	case *uint32:
-		b := scratch[0:4]
-		_, err := io.ReadFull(r, b)
+		rv, err := binarySerializer.Uint32(r, littleEndian)
 		if err != nil {
 			return err
 		}
-		*e = binary.LittleEndian.Uint32(b)
+		*e = rv
 		return nil
 
 	case *int64:
-		b := scratch[0:8]
-		_, err := io.ReadFull(r, b)
+		rv, err := binarySerializer.Uint64(r, littleEndian)
 		if err != nil {
 			return err
 		}
-		*e = int64(binary.LittleEndian.Uint64(b))
+		*e = int64(rv)
 		return nil
 
 	case *uint64:
-		b := scratch[0:8]
-		_, err := io.ReadFull(r, b)
+		rv, err := binarySerializer.Uint64(r, littleEndian)
 		if err != nil {
 			return err
 		}
-		*e = binary.LittleEndian.Uint64(b)
+		*e = rv
 		return nil
 
 	case *bool:
-		b := scratch[0:1]
-		_, err := io.ReadFull(r, b)
+		rv, err := binarySerializer.Uint8(r)
 		if err != nil {
 			return err
 		}
-		if b[0] == 0x00 {
+		if rv == 0x00 {
 			*e = false
 		} else {
 			*e = true
@@ -111,54 +257,49 @@ func readElement(r io.Reader, element interface{}) error {
 		return nil
 
 	case *ServiceFlag:
-		b := scratch[0:8]
-		_, err := io.ReadFull(r, b)
+		rv, err := binarySerializer.Uint64(r, littleEndian)
 		if err != nil {
 			return err
 		}
-		*e = ServiceFlag(binary.LittleEndian.Uint64(b))
+		*e = ServiceFlag(rv)
 		return nil
 
 	case *InvType:
-		b := scratch[0:4]
-		_, err := io.ReadFull(r, b)
+		rv, err := binarySerializer.Uint32(r, littleEndian)
 		if err != nil {
 			return err
 		}
-		*e = InvType(binary.LittleEndian.Uint32(b))
+		*e = InvType(rv)
 		return nil
 
 	case *BitcoinNet:
-		b := scratch[0:4]
-		_, err := io.ReadFull(r, b)
+		rv, err := binarySerializer.Uint32(r, littleEndian)
 		if err != nil {
 			return err
 		}
-		*e = BitcoinNet(binary.LittleEndian.Uint32(b))
+		*e = BitcoinNet(rv)
 		return nil
 
 	case *BloomUpdateType:
-		b := scratch[0:1]
-		_, err := io.ReadFull(r, b)
+		rv, err := binarySerializer.Uint8(r)
 		if err != nil {
 			return err
 		}
-		*e = BloomUpdateType(b[0])
+		*e = BloomUpdateType(rv)
 		return nil
 
 	case *RejectCode:
-		b := scratch[0:1]
-		_, err := io.ReadFull(r, b)
+		rv, err := binarySerializer.Uint8(r)
 		if err != nil {
 			return err
 		}
-		*e = RejectCode(b[0])
+		*e = RejectCode(rv)
 		return nil
 	}
 
 	// Fall back to the slower binary.Read if a fast path was not available
 	// above.
-	return binary.Read(r, binary.LittleEndian, element)
+	return binary.Read(r, littleEndian, element)
 }
 
 // readElements reads multiple items from r.  It is equivalent to multiple
@@ -175,55 +316,44 @@ func readElements(r io.Reader, elements ...interface{}) error {
 
 // writeElement writes the little endian representation of element to w.
 func writeElement(w io.Writer, element interface{}) error {
-	var scratch [8]byte
-
 	// Attempt to write the element based on the concrete type via fast
 	// type assertions first.
 	switch e := element.(type) {
 	case int32:
-		b := scratch[0:4]
-		binary.LittleEndian.PutUint32(b, uint32(e))
-		_, err := w.Write(b)
+		err := binarySerializer.PutUint32(w, littleEndian, uint32(e))
 		if err != nil {
 			return err
 		}
 		return nil
 
 	case uint32:
-		b := scratch[0:4]
-		binary.LittleEndian.PutUint32(b, e)
-		_, err := w.Write(b)
+		err := binarySerializer.PutUint32(w, littleEndian, e)
 		if err != nil {
 			return err
 		}
 		return nil
 
 	case int64:
-		b := scratch[0:8]
-		binary.LittleEndian.PutUint64(b, uint64(e))
-		_, err := w.Write(b)
+		err := binarySerializer.PutUint64(w, littleEndian, uint64(e))
 		if err != nil {
 			return err
 		}
 		return nil
 
 	case uint64:
-		b := scratch[0:8]
-		binary.LittleEndian.PutUint64(b, e)
-		_, err := w.Write(b)
+		err := binarySerializer.PutUint64(w, littleEndian, e)
 		if err != nil {
 			return err
 		}
 		return nil
 
 	case bool:
-		b := scratch[0:1]
+		var err error
 		if e == true {
-			b[0] = 0x01
+			err = binarySerializer.PutUint8(w, 0x01)
 		} else {
-			b[0] = 0x00
+			err = binarySerializer.PutUint8(w, 0x00)
 		}
-		_, err := w.Write(b)
 		if err != nil {
 			return err
 		}
@@ -261,45 +391,35 @@ func writeElement(w io.Writer, element interface{}) error {
 		return nil
 
 	case ServiceFlag:
-		b := scratch[0:8]
-		binary.LittleEndian.PutUint64(b, uint64(e))
-		_, err := w.Write(b)
+		err := binarySerializer.PutUint64(w, littleEndian, uint64(e))
 		if err != nil {
 			return err
 		}
 		return nil
 
 	case InvType:
-		b := scratch[0:4]
-		binary.LittleEndian.PutUint32(b, uint32(e))
-		_, err := w.Write(b)
+		err := binarySerializer.PutUint32(w, littleEndian, uint32(e))
 		if err != nil {
 			return err
 		}
 		return nil
 
 	case BitcoinNet:
-		b := scratch[0:4]
-		binary.LittleEndian.PutUint32(b, uint32(e))
-		_, err := w.Write(b)
+		err := binarySerializer.PutUint32(w, littleEndian, uint32(e))
 		if err != nil {
 			return err
 		}
 		return nil
 
 	case BloomUpdateType:
-		b := scratch[0:1]
-		b[0] = uint8(e)
-		_, err := w.Write(b)
+		err := binarySerializer.PutUint8(w, uint8(e))
 		if err != nil {
 			return err
 		}
 		return nil
 
 	case RejectCode:
-		b := scratch[0:1]
-		b[0] = uint8(e)
-		_, err := w.Write(b)
+		err := binarySerializer.PutUint8(w, uint8(e))
 		if err != nil {
 			return err
 		}
@@ -308,7 +428,7 @@ func writeElement(w io.Writer, element interface{}) error {
 
 	// Fall back to the slower binary.Write if a fast path was not available
 	// above.
-	return binary.Write(w, binary.LittleEndian, element)
+	return binary.Write(w, littleEndian, element)
 }
 
 // writeElements writes multiple items to w.  It is equivalent to multiple
@@ -325,21 +445,19 @@ func writeElements(w io.Writer, elements ...interface{}) error {
 
 // ReadVarInt reads a variable length integer from r and returns it as a uint64.
 func ReadVarInt(r io.Reader, pver uint32) (uint64, error) {
-	var b [8]byte
-	_, err := io.ReadFull(r, b[0:1])
+	discriminant, err := binarySerializer.Uint8(r)
 	if err != nil {
 		return 0, err
 	}
 
 	var rv uint64
-	discriminant := uint8(b[0])
 	switch discriminant {
 	case 0xff:
-		_, err := io.ReadFull(r, b[:])
+		sv, err := binarySerializer.Uint64(r, littleEndian)
 		if err != nil {
 			return 0, err
 		}
-		rv = binary.LittleEndian.Uint64(b[:])
+		rv = sv
 
 		// The encoding is not canonical if the value could have been
 		// encoded using fewer bytes.
@@ -350,11 +468,11 @@ func ReadVarInt(r io.Reader, pver uint32) (uint64, error) {
 		}
 
 	case 0xfe:
-		_, err := io.ReadFull(r, b[0:4])
+		sv, err := binarySerializer.Uint32(r, littleEndian)
 		if err != nil {
 			return 0, err
 		}
-		rv = uint64(binary.LittleEndian.Uint32(b[:]))
+		rv = uint64(sv)
 
 		// The encoding is not canonical if the value could have been
 		// encoded using fewer bytes.
@@ -365,11 +483,11 @@ func ReadVarInt(r io.Reader, pver uint32) (uint64, error) {
 		}
 
 	case 0xfd:
-		_, err := io.ReadFull(r, b[0:2])
+		sv, err := binarySerializer.Uint16(r, littleEndian)
 		if err != nil {
 			return 0, err
 		}
-		rv = uint64(binary.LittleEndian.Uint16(b[:]))
+		rv = uint64(sv)
 
 		// The encoding is not canonical if the value could have been
 		// encoded using fewer bytes.
@@ -390,31 +508,30 @@ func ReadVarInt(r io.Reader, pver uint32) (uint64, error) {
 // on its value.
 func WriteVarInt(w io.Writer, pver uint32, val uint64) error {
 	if val < 0xfd {
-		_, err := w.Write([]byte{uint8(val)})
-		return err
+		return binarySerializer.PutUint8(w, uint8(val))
 	}
 
 	if val <= math.MaxUint16 {
-		var buf [3]byte
-		buf[0] = 0xfd
-		binary.LittleEndian.PutUint16(buf[1:], uint16(val))
-		_, err := w.Write(buf[:])
-		return err
+		err := binarySerializer.PutUint8(w, 0xfd)
+		if err != nil {
+			return err
+		}
+		return binarySerializer.PutUint16(w, littleEndian, uint16(val))
 	}
 
 	if val <= math.MaxUint32 {
-		var buf [5]byte
-		buf[0] = 0xfe
-		binary.LittleEndian.PutUint32(buf[1:], uint32(val))
-		_, err := w.Write(buf[:])
-		return err
+		err := binarySerializer.PutUint8(w, 0xfe)
+		if err != nil {
+			return err
+		}
+		return binarySerializer.PutUint32(w, littleEndian, uint32(val))
 	}
 
-	var buf [9]byte
-	buf[0] = 0xff
-	binary.LittleEndian.PutUint64(buf[1:], val)
-	_, err := w.Write(buf[:])
-	return err
+	err := binarySerializer.PutUint8(w, 0xff)
+	if err != nil {
+		return err
+	}
+	return binarySerializer.PutUint64(w, littleEndian, val)
 }
 
 // VarIntSerializeSize returns the number of bytes it would take to serialize
@@ -536,12 +653,11 @@ func WriteVarBytes(w io.Writer, pver uint32, bytes []byte) error {
 // unexported version takes a reader primarily to ensure the error paths
 // can be properly tested by passing a fake reader in the tests.
 func randomUint64(r io.Reader) (uint64, error) {
-	var b [8]byte
-	_, err := io.ReadFull(r, b[:])
+	rv, err := binarySerializer.Uint64(r, bigEndian)
 	if err != nil {
 		return 0, err
 	}
-	return binary.BigEndian.Uint64(b[:]), nil
+	return rv, nil
 }
 
 // RandomUint64 returns a cryptographically random uint64 value.

--- a/wire/common.go
+++ b/wire/common.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"time"
 
 	"github.com/btcsuite/fastsha256"
 )
@@ -175,6 +176,16 @@ var binarySerializer binaryFreeList = make(chan []byte, binaryFreeListMaxItems)
 var errNonCanonicalVarInt = "non-canonical varint %x - discriminant %x must " +
 	"encode a value greater than %x"
 
+// uint32Time represents a unix timestamp encoded with a uint32.  It is used as
+// a way to signal the readElement function how to decode a timestamp into a Go
+// time.Time since it is otherwise ambiguous.
+type uint32Time time.Time
+
+// int64Time represents a unix timestamp encoded with an int64.  It is used as
+// a way to signal the readElement function how to decode a timestamp into a Go
+// time.Time since it is otherwise ambiguous.
+type int64Time time.Time
+
 // readElement reads the next sequence of bytes from r using little endian
 // depending on the concrete type of element pointed to.
 func readElement(r io.Reader, element interface{}) error {
@@ -223,6 +234,24 @@ func readElement(r io.Reader, element interface{}) error {
 		} else {
 			*e = true
 		}
+		return nil
+
+	// Unix timestamp encoded as a uint32.
+	case *uint32Time:
+		rv, err := binarySerializer.Uint32(r, binary.LittleEndian)
+		if err != nil {
+			return err
+		}
+		*e = uint32Time(time.Unix(int64(rv), 0))
+		return nil
+
+	// Unix timestamp encoded as an int64.
+	case *int64Time:
+		rv, err := binarySerializer.Uint64(r, binary.LittleEndian)
+		if err != nil {
+			return err
+		}
+		*e = int64Time(time.Unix(int64(rv), 0))
 		return nil
 
 	// Message header checksum.

--- a/wire/msgaddr.go
+++ b/wire/msgaddr.go
@@ -70,14 +70,15 @@ func (msg *MsgAddr) BtcDecode(r io.Reader, pver uint32) error {
 		return messageError("MsgAddr.BtcDecode", str)
 	}
 
+	addrList := make([]NetAddress, count)
 	msg.AddrList = make([]*NetAddress, 0, count)
 	for i := uint64(0); i < count; i++ {
-		na := NetAddress{}
-		err := readNetAddress(r, pver, &na, true)
+		na := &addrList[i]
+		err := readNetAddress(r, pver, na, true)
 		if err != nil {
 			return err
 		}
-		msg.AddAddress(&na)
+		msg.AddAddress(na)
 	}
 	return nil
 }

--- a/wire/msggetblocks.go
+++ b/wire/msggetblocks.go
@@ -65,14 +65,17 @@ func (msg *MsgGetBlocks) BtcDecode(r io.Reader, pver uint32) error {
 		return messageError("MsgGetBlocks.BtcDecode", str)
 	}
 
+	// Create a contiguous slice of hashes to deserialize into in order to
+	// reduce the number of allocations.
+	locatorHashes := make([]ShaHash, count)
 	msg.BlockLocatorHashes = make([]*ShaHash, 0, count)
 	for i := uint64(0); i < count; i++ {
-		sha := ShaHash{}
-		err := readElement(r, &sha)
+		hash := &locatorHashes[i]
+		err := readElement(r, hash)
 		if err != nil {
 			return err
 		}
-		msg.AddBlockLocatorHash(&sha)
+		msg.AddBlockLocatorHash(hash)
 	}
 
 	err = readElement(r, &msg.HashStop)

--- a/wire/msggetdata.go
+++ b/wire/msggetdata.go
@@ -49,14 +49,17 @@ func (msg *MsgGetData) BtcDecode(r io.Reader, pver uint32) error {
 		return messageError("MsgGetData.BtcDecode", str)
 	}
 
+	// Create a contiguous slice of inventory vectors to deserialize into in
+	// order to reduce the number of allocations.
+	invList := make([]InvVect, count)
 	msg.InvList = make([]*InvVect, 0, count)
 	for i := uint64(0); i < count; i++ {
-		iv := InvVect{}
-		err := readInvVect(r, pver, &iv)
+		iv := &invList[i]
+		err := readInvVect(r, pver, iv)
 		if err != nil {
 			return err
 		}
-		msg.AddInvVect(&iv)
+		msg.AddInvVect(iv)
 	}
 
 	return nil

--- a/wire/msggetheaders.go
+++ b/wire/msggetheaders.go
@@ -62,14 +62,17 @@ func (msg *MsgGetHeaders) BtcDecode(r io.Reader, pver uint32) error {
 		return messageError("MsgGetHeaders.BtcDecode", str)
 	}
 
+	// Create a contiguous slice of hashes to deserialize into in order to
+	// reduce the number of allocations.
+	locatorHashes := make([]ShaHash, count)
 	msg.BlockLocatorHashes = make([]*ShaHash, 0, count)
 	for i := uint64(0); i < count; i++ {
-		sha := ShaHash{}
-		err := readElement(r, &sha)
+		hash := &locatorHashes[i]
+		err := readElement(r, hash)
 		if err != nil {
 			return err
 		}
-		msg.AddBlockLocatorHash(&sha)
+		msg.AddBlockLocatorHash(hash)
 	}
 
 	err = readElement(r, &msg.HashStop)

--- a/wire/msgheaders.go
+++ b/wire/msgheaders.go
@@ -49,10 +49,13 @@ func (msg *MsgHeaders) BtcDecode(r io.Reader, pver uint32) error {
 		return messageError("MsgHeaders.BtcDecode", str)
 	}
 
+	// Create a contiguous slice of headers to deserialize into in order to
+	// reduce the number of allocations.
+	headers := make([]BlockHeader, count)
 	msg.Headers = make([]*BlockHeader, 0, count)
 	for i := uint64(0); i < count; i++ {
-		bh := BlockHeader{}
-		err := readBlockHeader(r, pver, &bh)
+		bh := &headers[i]
+		err := readBlockHeader(r, pver, bh)
 		if err != nil {
 			return err
 		}
@@ -68,7 +71,7 @@ func (msg *MsgHeaders) BtcDecode(r io.Reader, pver uint32) error {
 				"transactions [count %v]", txCount)
 			return messageError("MsgHeaders.BtcDecode", str)
 		}
-		msg.AddBlockHeader(&bh)
+		msg.AddBlockHeader(bh)
 	}
 
 	return nil

--- a/wire/msginv.go
+++ b/wire/msginv.go
@@ -57,14 +57,17 @@ func (msg *MsgInv) BtcDecode(r io.Reader, pver uint32) error {
 		return messageError("MsgInv.BtcDecode", str)
 	}
 
+	// Create a contiguous slice of inventory vectors to deserialize into in
+	// order to reduce the number of allocations.
+	invList := make([]InvVect, count)
 	msg.InvList = make([]*InvVect, 0, count)
 	for i := uint64(0); i < count; i++ {
-		iv := InvVect{}
-		err := readInvVect(r, pver, &iv)
+		iv := &invList[i]
+		err := readInvVect(r, pver, iv)
 		if err != nil {
 			return err
 		}
-		msg.AddInvVect(&iv)
+		msg.AddInvVect(iv)
 	}
 
 	return nil

--- a/wire/msgmerkleblock.go
+++ b/wire/msgmerkleblock.go
@@ -68,14 +68,17 @@ func (msg *MsgMerkleBlock) BtcDecode(r io.Reader, pver uint32) error {
 		return messageError("MsgMerkleBlock.BtcDecode", str)
 	}
 
+	// Create a contiguous slice of hashes to deserialize into in order to
+	// reduce the number of allocations.
+	hashes := make([]ShaHash, count)
 	msg.Hashes = make([]*ShaHash, 0, count)
 	for i := uint64(0); i < count; i++ {
-		var sha ShaHash
-		err := readElement(r, &sha)
+		hash := &hashes[i]
+		err := readElement(r, hash)
 		if err != nil {
 			return err
 		}
-		msg.AddTxHash(&sha)
+		msg.AddTxHash(hash)
 	}
 
 	msg.Flags, err = ReadVarBytes(r, pver, maxFlagsPerMerkleBlock,

--- a/wire/msgnotfound.go
+++ b/wire/msgnotfound.go
@@ -46,14 +46,17 @@ func (msg *MsgNotFound) BtcDecode(r io.Reader, pver uint32) error {
 		return messageError("MsgNotFound.BtcDecode", str)
 	}
 
+	// Create a contiguous slice of inventory vectors to deserialize into in
+	// order to reduce the number of allocations.
+	invList := make([]InvVect, count)
 	msg.InvList = make([]*InvVect, 0, count)
 	for i := uint64(0); i < count; i++ {
-		iv := InvVect{}
-		err := readInvVect(r, pver, &iv)
+		iv := &invList[i]
+		err := readInvVect(r, pver, iv)
 		if err != nil {
 			return err
 		}
-		msg.AddInvVect(&iv)
+		msg.AddInvVect(iv)
 	}
 
 	return nil

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -24,14 +24,14 @@ const (
 	MaxPrevOutIndex uint32 = 0xffffffff
 )
 
-// defaultTxInOutAlloc is the default size used for the backing array for
-// transaction inputs and outputs.  The array will dynamically grow as needed,
-// but this figure is intended to provide enough space for the number of
-// inputs and outputs in a typical transaction without needing to grow the
-// backing array multiple times.
-const defaultTxInOutAlloc = 15
-
 const (
+	// defaultTxInOutAlloc is the default size used for the backing array
+	// for transaction inputs and outputs.  The array will dynamically grow
+	// as needed, but this figure is intended to provide enough space for
+	// the number of inputs and outputs in a typical transaction without
+	// needing to grow the backing array multiple times.
+	defaultTxInOutAlloc = 15
+
 	// minTxInPayload is the minimum payload size for a transaction input.
 	// PreviousOutPoint.Hash + PreviousOutPoint.Index 4 bytes + Varint for
 	// SignatureScript length 1 byte + Sequence 4 bytes.
@@ -57,7 +57,79 @@ const (
 	// number of transaction outputs 1 byte + LockTime 4 bytes + min input
 	// payload + min output payload.
 	minTxPayload = 10
+
+	// freeListMaxScriptSize is the size of each buffer in the free list
+	// that	is used for deserializing scripts from the wire before they are
+	// concatenated into a single contiguous buffers.  This value was chosen
+	// because it is slightly more than twice the size of the vast majority
+	// of all "standard" scripts.  Larger scripts are still deserialized
+	// properly as the free list will simply be bypassed for them.
+	freeListMaxScriptSize = 512
+
+	// freeListMaxItems is the number of buffers to keep in the free list
+	// to use for script deserialization.  This value allows up to 100
+	// scripts per transaction being simultaneously deserialized by 125
+	// peers.  Thus, the peak usage of the free list is 12,500 * 512 =
+	// 6,400,000 bytes.
+	freeListMaxItems = 12500
 )
+
+// scriptFreeList defines a free list of byte slices (up to the maximum number
+// defined by the freeListMaxItems constant) that have a cap according to the
+// freeListMaxScriptSize constant.  It is used to provide temporary buffers for
+// deserializing scripts in order to greatly reduce the number of allocations
+// required.
+//
+// The caller can obtain a buffer from the free list by calling the Borrow
+// function and should return it via the Return function when done using it.
+type scriptFreeList chan []byte
+
+// Borrow returns a byte slice from the free list with a length according the
+// provided size.  A new buffer is allocated if there are any items available.
+//
+// When the size is larger than the max size allowed for items on the free list
+// a new buffer of the appropriate size is allocated and returned.  It is safe
+// to attempt to return said buffer via the Return function as it will be
+// ignored and allowed to go the garbage collector.
+func (c scriptFreeList) Borrow(size uint64) []byte {
+	if size > freeListMaxScriptSize {
+		return make([]byte, size, size)
+	}
+
+	var buf []byte
+	select {
+	case buf = <-c:
+	default:
+		buf = make([]byte, freeListMaxScriptSize)
+	}
+	return buf[:size]
+}
+
+// Return puts the provided byte slice back on the free list when it has a cap
+// of the expected length.  The buffer is expected to have been obtained via
+// the Borrow function.  Any slices that are not of the appropriate size, such
+// as those whose size is greater than the largest allowed free list item size
+// are simply ignored so they can go to the garbage collector.
+func (c scriptFreeList) Return(buf []byte) {
+	// Ignore any buffers returned that aren't the expected size for the
+	// free list.
+	if cap(buf) != freeListMaxScriptSize {
+		return
+	}
+
+	// Return the buffer to the free list when it's not full.  Otherwise let
+	// it be garbage collected.
+	select {
+	case c <- buf:
+	default:
+		// Let it go to the garbage collector.
+	}
+}
+
+// Create the concurrent safe free list to use for script deserialization.  As
+// previously described, this free list is maintained to significantly reduce
+// the number of allocations.
+var scriptPool scriptFreeList = make(chan []byte, freeListMaxItems)
 
 // OutPoint defines a bitcoin data type that is used to track previous
 // transaction outputs.
@@ -263,20 +335,46 @@ func (msg *MsgTx) BtcDecode(r io.Reader, pver uint32) error {
 		return messageError("MsgTx.BtcDecode", str)
 	}
 
+	// returnScriptBuffers is a closure that returns any script buffers that
+	// were borrowed from the pool when there are any deserialization
+	// errors.  This is only valid to call before the final step which
+	// replaces the scripts with the location in a contiguous buffer and
+	// returns them.
+	returnScriptBuffers := func() {
+		for _, txIn := range msg.TxIn {
+			if txIn == nil || txIn.SignatureScript == nil {
+				continue
+			}
+			scriptPool.Return(txIn.SignatureScript)
+		}
+		for _, txOut := range msg.TxOut {
+			if txOut == nil || txOut.PkScript == nil {
+				continue
+			}
+			scriptPool.Return(txOut.PkScript)
+		}
+	}
+
 	// Deserialize the inputs.
+	var totalScriptSize uint64
 	txIns := make([]TxIn, count)
 	msg.TxIn = make([]*TxIn, count)
 	for i := uint64(0); i < count; i++ {
+		// The pointer is set now in case a script buffer is borrowed
+		// and needs to be returned to the pool on error.
 		ti := &txIns[i]
+		msg.TxIn[i] = ti
 		err = readTxIn(r, pver, msg.Version, ti)
 		if err != nil {
+			returnScriptBuffers()
 			return err
 		}
-		msg.TxIn[i] = ti
+		totalScriptSize += uint64(len(ti.SignatureScript))
 	}
 
 	count, err = ReadVarInt(r, pver)
 	if err != nil {
+		returnScriptBuffers()
 		return err
 	}
 
@@ -284,6 +382,7 @@ func (msg *MsgTx) BtcDecode(r io.Reader, pver uint32) error {
 	// message.  It would be possible to cause memory exhaustion and panics
 	// without a sane upper bound on this count.
 	if count > uint64(maxTxOutPerMessage) {
+		returnScriptBuffers()
 		str := fmt.Sprintf("too many output transactions to fit into "+
 			"max message size [count %d, max %d]", count,
 			maxTxOutPerMessage)
@@ -294,17 +393,71 @@ func (msg *MsgTx) BtcDecode(r io.Reader, pver uint32) error {
 	txOuts := make([]TxOut, count)
 	msg.TxOut = make([]*TxOut, count)
 	for i := uint64(0); i < count; i++ {
+		// The pointer is set now in case a script buffer is borrowed
+		// and needs to be returned to the pool on error.
 		to := &txOuts[i]
+		msg.TxOut[i] = to
 		err = readTxOut(r, pver, msg.Version, to)
 		if err != nil {
+			returnScriptBuffers()
 			return err
 		}
-		msg.TxOut[i] = to
+		totalScriptSize += uint64(len(to.PkScript))
 	}
 
 	msg.LockTime, err = binarySerializer.Uint32(r, littleEndian)
 	if err != nil {
+		returnScriptBuffers()
 		return err
+	}
+
+	// Create a single allocation to house all of the scripts and set each
+	// input signature script and output public key script to the
+	// appropriate subslice of the overall contiguous buffer.  Then, return
+	// each individual script buffer back to the pool so they can be reused
+	// for future deserializations.  This is done because it significantly
+	// reduces the number of allocations the garbage collector needs to
+	// track, which in turn improves performance and drastically reduces the
+	// amount of runtime overhead that would otherwise be needed to keep
+	// track of millions of small allocations.
+	//
+	// NOTE: It is no longer valid to call the returnScriptBuffers closure
+	// after these blocks of code run because it is already done and the
+	// scripts in the transaction inputs and outputs no longer point to the
+	// buffers.
+	var offset uint64
+	scripts := make([]byte, totalScriptSize)
+	for i := 0; i < len(msg.TxIn); i++ {
+		// Copy the signature script into the contiguous buffer at the
+		// appropriate offset.
+		signatureScript := msg.TxIn[i].SignatureScript
+		copy(scripts[offset:], signatureScript)
+
+		// Reset the signature script of the transaction input to the
+		// slice of the contiguous buffer where the script lives.
+		scriptSize := uint64(len(signatureScript))
+		end := offset + scriptSize
+		msg.TxIn[i].SignatureScript = scripts[offset:end:end]
+		offset += scriptSize
+
+		// Return the temporary script buffer to the pool.
+		scriptPool.Return(signatureScript)
+	}
+	for i := 0; i < len(msg.TxOut); i++ {
+		// Copy the public key script into the contiguous buffer at the
+		// appropriate offset.
+		pkScript := msg.TxOut[i].PkScript
+		copy(scripts[offset:], pkScript)
+
+		// Reset the public key script of the transaction output to the
+		// slice of the contiguous buffer where the script lives.
+		scriptSize := uint64(len(pkScript))
+		end := offset + scriptSize
+		msg.TxOut[i].PkScript = scripts[offset:end:end]
+		offset += scriptSize
+
+		// Return the temporary script buffer to the pool.
+		scriptPool.Return(pkScript)
 	}
 
 	return nil
@@ -500,17 +653,46 @@ func writeOutPoint(w io.Writer, pver uint32, version int32, op *OutPoint) error 
 	return nil
 }
 
+// readScript reads a variable length byte array that represents a transaction
+// script.  It is encoded as a varInt containing the length of the array
+// followed by the bytes themselves.  An error is returned if the length is
+// greater than the passed maxAllowed parameter which helps protect against
+// memory exhuastion attacks and forced panics thorugh malformed messages.  The
+// fieldName parameter is only used for the error message so it provides more
+// context in the error.
+func readScript(r io.Reader, pver uint32, maxAllowed uint32, fieldName string) ([]byte, error) {
+	count, err := ReadVarInt(r, pver)
+	if err != nil {
+		return nil, err
+	}
+
+	// Prevent byte array larger than the max message size.  It would
+	// be possible to cause memory exhaustion and panics without a sane
+	// upper bound on this count.
+	if count > uint64(maxAllowed) {
+		str := fmt.Sprintf("%s is larger than the max allowed size "+
+			"[count %d, max %d]", fieldName, count, maxAllowed)
+		return nil, messageError("readScript", str)
+	}
+
+	b := scriptPool.Borrow(count)
+	_, err = io.ReadFull(r, b)
+	if err != nil {
+		scriptPool.Return(b)
+		return nil, err
+	}
+	return b, nil
+}
+
 // readTxIn reads the next sequence of bytes from r as a transaction input
 // (TxIn).
 func readTxIn(r io.Reader, pver uint32, version int32, ti *TxIn) error {
-	var op OutPoint
-	err := readOutPoint(r, pver, version, &op)
+	err := readOutPoint(r, pver, version, &ti.PreviousOutPoint)
 	if err != nil {
 		return err
 	}
-	ti.PreviousOutPoint = op
 
-	ti.SignatureScript, err = ReadVarBytes(r, pver, MaxMessagePayload,
+	ti.SignatureScript, err = readScript(r, pver, MaxMessagePayload,
 		"transaction input signature script")
 	if err != nil {
 		return err
@@ -553,7 +735,7 @@ func readTxOut(r io.Reader, pver uint32, version int32, to *TxOut) error {
 		return err
 	}
 
-	to.PkScript, err = ReadVarBytes(r, pver, MaxMessagePayload,
+	to.PkScript, err = readScript(r, pver, MaxMessagePayload,
 		"transaction output public key script")
 	if err != nil {
 		return err

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -263,14 +263,16 @@ func (msg *MsgTx) BtcDecode(r io.Reader, pver uint32) error {
 		return messageError("MsgTx.BtcDecode", str)
 	}
 
+	// Deserialize the inputs.
+	txIns := make([]TxIn, count)
 	msg.TxIn = make([]*TxIn, count)
 	for i := uint64(0); i < count; i++ {
-		ti := TxIn{}
-		err = readTxIn(r, pver, msg.Version, &ti)
+		ti := &txIns[i]
+		err = readTxIn(r, pver, msg.Version, ti)
 		if err != nil {
 			return err
 		}
-		msg.TxIn[i] = &ti
+		msg.TxIn[i] = ti
 	}
 
 	count, err = ReadVarInt(r, pver)
@@ -288,14 +290,16 @@ func (msg *MsgTx) BtcDecode(r io.Reader, pver uint32) error {
 		return messageError("MsgTx.BtcDecode", str)
 	}
 
+	// Deserialize the outputs.
+	txOuts := make([]TxOut, count)
 	msg.TxOut = make([]*TxOut, count)
 	for i := uint64(0); i < count; i++ {
-		to := TxOut{}
-		err = readTxOut(r, pver, msg.Version, &to)
+		to := &txOuts[i]
+		err = readTxOut(r, pver, msg.Version, to)
 		if err != nil {
 			return err
 		}
-		msg.TxOut[i] = &to
+		msg.TxOut[i] = to
 	}
 
 	msg.LockTime, err = binarySerializer.Uint32(r, littleEndian)

--- a/wire/msgversion.go
+++ b/wire/msgversion.go
@@ -84,12 +84,11 @@ func (msg *MsgVersion) BtcDecode(r io.Reader, pver uint32) error {
 			"*bytes.Buffer")
 	}
 
-	var sec int64
-	err := readElements(buf, &msg.ProtocolVersion, &msg.Services, &sec)
+	err := readElements(buf, &msg.ProtocolVersion, &msg.Services,
+		(*int64Time)(&msg.Timestamp))
 	if err != nil {
 		return err
 	}
-	msg.Timestamp = time.Unix(sec, 0)
 
 	err = readNetAddress(buf, pver, &msg.AddrYou, false)
 	if err != nil {

--- a/wire/netaddress.go
+++ b/wire/netaddress.go
@@ -108,7 +108,6 @@ func readNetAddress(r io.Reader, pver uint32, na *NetAddress, ts bool) error {
 	var timestamp time.Time
 	var services ServiceFlag
 	var ip [16]byte
-	var port uint16
 
 	// NOTE: The bitcoin protocol uses a uint32 for the timestamp so it will
 	// stop working somewhere around 2106.  Also timestamp wasn't added until
@@ -127,7 +126,7 @@ func readNetAddress(r io.Reader, pver uint32, na *NetAddress, ts bool) error {
 		return err
 	}
 	// Sigh.  Bitcoin protocol mixes little and big endian.
-	err = binary.Read(r, binary.BigEndian, &port)
+	port, err := binarySerializer.Uint16(r, bigEndian)
 	if err != nil {
 		return err
 	}
@@ -163,7 +162,7 @@ func writeNetAddress(w io.Writer, pver uint32, na *NetAddress, ts bool) error {
 	}
 
 	// Sigh.  Bitcoin protocol mixes little and big endian.
-	err = binary.Write(w, binary.BigEndian, na.Port)
+	err = binary.Write(w, bigEndian, na.Port)
 	if err != nil {
 		return err
 	}

--- a/wire/netaddress.go
+++ b/wire/netaddress.go
@@ -105,7 +105,6 @@ func NewNetAddress(addr net.Addr, services ServiceFlag) (*NetAddress, error) {
 // version and whether or not the timestamp is included per ts.  Some messages
 // like version do not include the timestamp.
 func readNetAddress(r io.Reader, pver uint32, na *NetAddress, ts bool) error {
-	var timestamp time.Time
 	var services ServiceFlag
 	var ip [16]byte
 
@@ -113,12 +112,10 @@ func readNetAddress(r io.Reader, pver uint32, na *NetAddress, ts bool) error {
 	// stop working somewhere around 2106.  Also timestamp wasn't added until
 	// protocol version >= NetAddressTimeVersion
 	if ts && pver >= NetAddressTimeVersion {
-		var stamp uint32
-		err := readElement(r, &stamp)
+		err := readElement(r, (*uint32Time)(&na.Timestamp))
 		if err != nil {
 			return err
 		}
-		timestamp = time.Unix(int64(stamp), 0)
 	}
 
 	err := readElements(r, &services, &ip)
@@ -131,7 +128,6 @@ func readNetAddress(r io.Reader, pver uint32, na *NetAddress, ts bool) error {
 		return err
 	}
 
-	na.Timestamp = timestamp
 	na.Services = services
 	na.SetAddress(net.IP(ip[:]), port)
 	return nil


### PR DESCRIPTION
Live profiling data pulled from an instance of btcd running for a week shows that the vast majority of in-use (aka live) objects were the result of the deserialization process in wire.  In particular, the following were the top two entries of live objects when the memory pool contained 46,396 transactions:

```
4,637,941 39.44% 39.44%  wire.(*MsgTx).BtcDecode
4,511,685 38.37% 77.81%  wire.ReadVarBytes
```

This clearly shows that `77.81%` of all live allocations were allocated by transaction decoding and amounted to a total of `9,149,626` allocations.  Combining this with the fact there were `46,396` transactions in the memory pool, the average number of live allocations per deserialized transaction can be calculated as `196`.

Also, as shown by the following graph, the runtime overhead of tracking the massive amount of allocations was over `500MB` and climbing.

![pr_memstats_before](https://cloud.githubusercontent.com/assets/2115102/14804604/9a982b84-0b2a-11e6-8001-56b61f96a2cb.png)

Consequently, this pull request consists of a series of commits which significantly reduce the number of allocations the wire package performs with a focus on transactions since the profiling data showed they were the biggest offender.  It has been split into a series of logical commits that each reduce the number of allocations the wire package performs across the board.  Each commit contains the benchmark comparisons to show the effects of each change.

The end result of all changes in this PR is the number of allocations required to deserialize a transaction has been reduced to 6 regardless of the number of inputs and outputs.  In effect this equates to a `1-(6/196) ~= 97%` reduction in the number of live allocations across the total deserialized transactions.

The following graph shows the same running time and a very similar number of transaction in the mempool with this pull request applied.  As can be seen, the runtime overhead stabalized around `300MB` and, as a result, the overall memory usage for the entire process dropped by approximately `200MB`.  NOTE: This graph also includes PR #686.

![pr_memstats_after](https://cloud.githubusercontent.com/assets/2115102/14804665/fb3cf4ba-0b2a-11e6-9f57-0124fde51cdf.png)

Finally, the following is a before and after comparison of the allocations:
```
benchmark              old allocs     new allocs     delta
-------------------------------------------------------------
WriteVarInt1           1              0              -100.00%
WriteVarInt3           1              0              -100.00%
WriteVarInt5           1              0              -100.00%
WriteVarInt9           1              0              -100.00%
ReadVarInt1            1              0              -100.00%
ReadVarInt3            1              0              -100.00%
ReadVarInt5            1              0              -100.00%
ReadVarInt9            1              0              -100.00%
ReadVarStr4            3              2              -33.33%
ReadVarStr10           3              2              -33.33%
WriteVarStr4           2              1              -50.00%
WriteVarStr10          2              1              -50.00%
ReadOutPoint           1              0              -100.00%
WriteOutPoint          1              0              -100.00%
ReadTxOut              3              0              -100.00%
WriteTxOut             2              0              -100.00%
ReadTxIn               5              0              -100.00%
WriteTxIn              3              0              -100.00%
DeserializeTxSmall     15             5              -66.67%
DeserializeTxLarge     33428          6              -99.98%
SerializeTx            8              0              -100.00%
ReadBlockHeader        7              0              -100.00%
WriteBlockHeader       10             4              -60.00%
DecodeGetHeaders       1004           2              -99.80%
DecodeHeaders          18002          2              -99.99%
DecodeGetBlocks        1004           2              -99.80%
DecodeAddr             9002           2002           -77.76%
DecodeInv              150005         2              -100.00%
DecodeNotFound         150004         3              -100.00%
DecodeMerkleBlock      222            3              -98.65%
TxSha                  10             2              -80.00%
```