### PR TITLE
main: Limit garbage collection percentage.

### DIFF
--- a/btcd.go
+++ b/btcd.go
@@ -11,6 +11,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"runtime"
+	"runtime/debug"
 	"runtime/pprof"
 
 	"github.com/btcsuite/btcd/blockchain/indexers"
@@ -149,6 +150,12 @@ func btcdMain(serverChan chan<- *server) error {
 func main() {
 	// Use all processor cores.
 	runtime.GOMAXPROCS(runtime.NumCPU())
+
+	// Block and transaction processing can cause bursty allocations.  This
+	// limits the garbage collector from excessively overallocating during
+	// bursts.  This value was arrived at with the help of profiling live
+	// usage.
+	debug.SetGCPercent(10)
 
 	// Up some limits.
 	if err := limits.SetLimits(); err != nil {


### PR DESCRIPTION
This reduces the target ratio of freshly allocated data to live data to 10% in order to limit excessive overallocations by the garbage collector during data bursts such as processing complex blocks or rapidly receiving a lot of large transactions.

This is part of the work towards addressing #649.