### PR TITLE
build: Convert project to use glide.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ btcd.db
 # Folders
 _obj
 _test
+vendor
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,11 @@ sudo: false
 before_install:
   - gotools=golang.org/x/tools
 install:
-  - go get -d -t -v ./...
+  - go get -v github.com/Masterminds/glide
+  - glide install
   - go get -v $gotools/cmd/cover
-  - go get -v github.com/bradfitz/goimports
   - go get -v github.com/golang/lint/golint
 script:
   - export PATH=$PATH:$HOME/gopath/bin
+  - export GO15VENDOREXPERIMENT=1
   - ./goclean.sh

--- a/README.md
+++ b/README.md
@@ -55,18 +55,26 @@ $ go env GOROOT GOPATH
 
 NOTE: The `GOROOT` and `GOPATH` above must not be the same path.  It is
 recommended that `GOPATH` is set to a directory in your home directory such as
-`~/goprojects` to avoid write permission issues.
+`~/goprojects` to avoid write permission issues.  It is also recommended to add
+`$GOPATH/bin` to your `PATH` at this point.
 
-- Run the following command to obtain btcd, all dependencies, and install it:
+**NOTE:** If you are using Go 1.5, you must manually enable the vendor
+experiment by setting the `GO15VENDOREXPERIMENT` environment variable to `1`.
+This step is not required for Go 1.6.
+
+- Run the following commands to obtain btcd, all dependencies, and install it:
 
 ```bash
-$ go get -u github.com/btcsuite/btcd/...
+$ go get -u github.com/Masterminds/glide
+$ git clone https://github.com/btcsuite/btcd $GOPATH/src/github.com/btcsuite/btcd
+$ cd $GOPATH/src/github.com/btcsuite/btcd
+$ glide install
+$ go install . ./cmd/...
 ```
 
-- btcd (and utilities) will now be installed in either ```$GOROOT/bin``` or
-  ```$GOPATH/bin``` depending on your configuration.  If you did not already
-  add the bin directory to your system path during Go installation, we
-  recommend you do so now.
+- btcd (and utilities) will now be installed in ```$GOPATH/bin```.  If you did
+  not already add the bin directory to your system path during Go installation,
+  we recommend you do so now.
 
 ## Updating
 
@@ -76,10 +84,12 @@ Install a newer MSI
 
 #### Linux/BSD/MacOSX/POSIX - Build from Source
 
-- Run the following command to update btcd, all dependencies, and install it:
+- Run the following commands to update btcd, all dependencies, and install it:
 
 ```bash
-$ go get -u -v github.com/btcsuite/btcd/...
+$ cd $GOPATH/src/github.com/btcsuite/btcd
+$ git pull && glide install
+$ go install . ./cmd/...
 ```
 
 ## Getting Started

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,57 @@
+hash: 9b8ff781a12daad991983e9a421a320e905eecc4e9ff0b0643e790f472bc78c8
+updated: 2016-05-06T10:10:16.348595-05:00
+imports:
+- name: github.com/btcsuite/btclog
+  version: f96df2375f37300305f329b8e5258764b4f19a7f
+- name: github.com/btcsuite/btcutil
+  version: 2c26dd81a59fd671a2218d63ad138a6dd4d693bd
+  subpackages:
+  - .
+  - bloom
+  - base58
+- name: github.com/btcsuite/fastsha256
+  version: 302ad4db268b46f9ebda3078f6f7397f96047735
+- name: github.com/btcsuite/go-flags
+  version: 6c288d648c1cc1befcb90cb5511dcacf64ae8e61
+- name: github.com/btcsuite/go-socks
+  version: cfe8b59e565c1a5bd4e2005d77cd9aa8b2e14524
+  subpackages:
+  - socks
+- name: github.com/btcsuite/golangcrypto
+  version: 53f62d9b43e87a6c56975cf862af7edf33a8d0df
+  subpackages:
+  - ripemd160
+- name: github.com/btcsuite/goleveldb
+  version: 7834afc9e8cd15233b6c3d97e12674a31ca24602
+  subpackages:
+  - leveldb
+  - leveldb/comparer
+  - leveldb/errors
+  - leveldb/filter
+  - leveldb/iterator
+  - leveldb/opt
+  - leveldb/util
+  - leveldb/cache
+  - leveldb/journal
+  - leveldb/memdb
+  - leveldb/storage
+  - leveldb/table
+- name: github.com/btcsuite/seelog
+  version: 313961b101eb55f65ae0f03ddd4e322731763b6c
+- name: github.com/btcsuite/snappy-go
+  version: 0bdef8d067237991ddaa1bb6072a740bc40601ba
+- name: github.com/btcsuite/websocket
+  version: 31079b6807923eb23992c421b114992b95131b55
+- name: github.com/btcsuite/winsvc
+  version: f8fb11f83f7e860e3769a08e6811d1b399a43722
+  subpackages:
+  - eventlog
+  - mgr
+  - svc
+  - registry
+  - winapi
+- name: github.com/davecgh/go-spew
+  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  subpackages:
+  - spew
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,35 @@
+package: github.com/btcsuite/btcd
+import:
+- package: github.com/btcsuite/btclog
+- package: github.com/btcsuite/btcutil
+  subpackages:
+  - .
+  - bloom
+  - base58
+- package: github.com/btcsuite/fastsha256
+- package: github.com/btcsuite/go-flags
+- package: github.com/btcsuite/go-socks
+  subpackages:
+  - socks
+- package: github.com/btcsuite/golangcrypto
+  subpackages:
+  - ripemd160
+- package: github.com/btcsuite/goleveldb
+  subpackages:
+  - leveldb
+  - leveldb/comparer
+  - leveldb/errors
+  - leveldb/filter
+  - leveldb/iterator
+  - leveldb/opt
+  - leveldb/util
+- package: github.com/btcsuite/seelog
+- package: github.com/btcsuite/websocket
+- package: github.com/btcsuite/winsvc
+  subpackages:
+  - eventlog
+  - mgr
+  - svc
+- package: github.com/davecgh/go-spew
+  subpackages:
+  - spew

--- a/goclean.sh
+++ b/goclean.sh
@@ -1,20 +1,18 @@
 #!/bin/bash
 # The script does automatic checking on a Go package and its sub-packages, including:
 # 1. gofmt         (http://golang.org/cmd/gofmt/)
-# 2. goimports     (https://github.com/bradfitz/goimports)
-# 3. golint        (https://github.com/golang/lint)
-# 4. go vet        (http://golang.org/cmd/vet)
-# 5. race detector (http://blog.golang.org/race-detector)
-# 6. test coverage (http://blog.golang.org/cover)
+# 2. golint        (https://github.com/golang/lint)
+# 3. go vet        (http://golang.org/cmd/vet)
+# 4. race detector (http://blog.golang.org/race-detector)
+# 5. test coverage (http://blog.golang.org/cover)
 
 set -ex
 
 # Automatic checks
-test -z "$(gofmt -l -w . | tee /dev/stderr)"
-test -z "$(goimports -l -w . | tee /dev/stderr)"
-test -z "$(golint ./... | grep -v 'ALL_CAPS\|OP_\|NewFieldVal\|RpcCommand\|RpcRawCommand\|RpcSend\|Dns' | tee /dev/stderr)"
-test -z "$(go tool vet . 2>&1 | grep -v 'Example\|newestSha' | tee /dev/stderr)"
-env GORACE="halt_on_error=1" go test -v -race ./...
+test -z "$(go fmt $(glide novendor) | tee /dev/stderr)"
+test -z "$(for package in $(glide novendor); do golint $package; done | grep -v 'ALL_CAPS\|OP_\|NewFieldVal' | tee /dev/stderr)"
+test -z "$(go vet $(glide novendor) 2>&1 | tee /dev/stderr)"
+env GORACE="halt_on_error=1" go test -v -race $(glide novendor)
 
 # Run test coverage on each subdirectories and merge the coverage profile.
 
@@ -23,7 +21,8 @@ echo "mode: count" > profile.cov
 
 # Standard go tooling behavior is to ignore dirs with leading underscores.
 for dir in $(find . -maxdepth 10 -not -path '.' -not -path './.git*' \
-    -not -path '*/_*' -not -path './cmd*' -not -path './release*' -type d)
+    -not -path '*/_*' -not -path './cmd*' -not -path './release*' \
+    -not -path './vendor*' -type d)
 do
 if ls $dir/*.go &> /dev/null; then
   go test -covermode=count -coverprofile=$dir/profile.tmp $dir


### PR DESCRIPTION
This converts the project to allow `btcd` to be used with the `glide` package manager in order to provide stable and reproducible builds without the user having to jump through all of the hoops as they do today.

It consists of adding a `glide.yaml` file which identifies the project dependencies and locations along with a `glide.lock` file which contains the complete dependency tree pinned to specific versions.  Glide uses these files to download the packages (or updates) to a local `vendor` directory and checkout the correct pinned versions.  The go tool, in turn, is used to build/install `btcd` and will use the pinned versions in the `vendor` directory.

This also updates TravisCI to build using glide, removes some of the exceptions in the lint checks which are no longer required, and updates the `README.md` with the new instructions needed to build the project with `glide`.

Closes #676.