### PR TITLE
addblock: Add support for generating indexes.

### DIFF
--- a/cmd/addblock/addblock.go
+++ b/cmd/addblock/addblock.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 
 	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/blockchain/indexers"
 	"github.com/btcsuite/btcd/database"
 	"github.com/btcsuite/btcd/limits"
 	"github.com/btcsuite/btclog"
@@ -73,6 +74,7 @@ func realMain() error {
 	log = btclog.NewSubsystemLogger(backendLogger, "")
 	database.UseLogger(btclog.NewSubsystemLogger(backendLogger, "BCDB: "))
 	blockchain.UseLogger(btclog.NewSubsystemLogger(backendLogger, "CHAN: "))
+	indexers.UseLogger(btclog.NewSubsystemLogger(backendLogger, "INDX: "))
 
 	// Load the block database.
 	db, err := loadBlockDB()

--- a/cmd/addblock/config.go
+++ b/cmd/addblock/config.go
@@ -40,6 +40,8 @@ type config struct {
 	RegressionTest bool   `long:"regtest" description:"Use the regression test network"`
 	SimNet         bool   `long:"simnet" description:"Use the simulation test network"`
 	InFile         string `short:"i" long:"infile" description:"File containing the block(s)"`
+	TxIndex        bool   `long:"txindex" description:"Build a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
+	AddrIndex      bool   `long:"addrindex" description:"Build a full address-based transaction index which makes the searchrawtransactions RPC available"`
 	Progress       int    `short:"p" long:"progress" description:"Show a progress message each time this number of seconds have passed -- Use 0 to disable progress announcements"`
 }
 

--- a/cmd/addblock/import.go
+++ b/cmd/addblock/import.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/blockchain/indexers"
 	"github.com/btcsuite/btcd/database"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
@@ -295,9 +296,40 @@ func (bi *blockImporter) Import() chan *importResults {
 // newBlockImporter returns a new importer for the provided file reader seeker
 // and database.
 func newBlockImporter(db database.DB, r io.ReadSeeker) (*blockImporter, error) {
+	// Create the transaction and address indexes if needed.
+	//
+	// CAUTION: the txindex needs to be first in the indexes array because
+	// the addrindex uses data from the txindex during catchup.  If the
+	// addrindex is run first, it may not have the transactions from the
+	// current block indexed.
+	var indexes []indexers.Indexer
+	if cfg.TxIndex || cfg.AddrIndex {
+		// Enable transaction index if address index is enabled since it
+		// requires it.
+		if !cfg.TxIndex {
+			log.Infof("Transaction index enabled because it is " +
+				"required by the address index")
+			cfg.TxIndex = true
+		} else {
+			log.Info("Transaction index is enabled")
+		}
+		indexes = append(indexes, indexers.NewTxIndex(db))
+	}
+	if cfg.AddrIndex {
+		log.Info("Address index is enabled")
+		indexes = append(indexes, indexers.NewAddrIndex(db, activeNetParams))
+	}
+
+	// Create an index manager if any of the optional indexes are enabled.
+	var indexManager blockchain.IndexManager
+	if len(indexes) > 0 {
+		indexManager = indexers.NewManager(db, indexes)
+	}
+
 	chain, err := blockchain.New(&blockchain.Config{
-		DB:          db,
-		ChainParams: activeNetParams,
+		DB:           db,
+		ChainParams:  activeNetParams,
+		IndexManager: indexManager,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This adds two new flags, `--txindex` and `--addrindex`, to the `addblock` utility which mirror the flags on `btcd`.  They serve to to specify that the transaction index and/or address index, respectively, should be
built while importing from the bootstrap file.

This is technically not 100% required since `btcd` will build the indexes on the first load (when enabled) if they aren't already built, however it is much faster to build the indexes as the blocks are being validated (particularly for the address index), so this makes the capability available.