### PR TITLE
btcec: Minor correction to GenerateSharedSecret documentation.

### DIFF
--- a/btcec/ciphering.go
+++ b/btcec/ciphering.go
@@ -41,7 +41,7 @@ var (
 )
 
 // GenerateSharedSecret generates a shared secret based on a private key and a
-// private key using Diffie-Hellman key exchange (ECDH) (RFC 4753).
+// public key using Diffie-Hellman key exchange (ECDH) (RFC 4753).
 // RFC5903 Section 9 states we should only return x.
 func GenerateSharedSecret(privkey *PrivateKey, pubkey *PublicKey) []byte {
 	x, _ := pubkey.Curve.ScalarMult(pubkey.X, pubkey.Y, privkey.D.Bytes())


### PR DESCRIPTION
This really bothered me when I read it for some reason...