### PR TITLE
mining: Stop transactions losing their dependants.

### DIFF
--- a/mining.go
+++ b/mining.go
@@ -554,12 +554,8 @@ mempoolLoop:
 		prioItem := heap.Pop(priorityQueue).(*txPrioItem)
 		tx := prioItem.tx
 
-		// Grab the list of transactions which depend on this one (if
-		// any) and remove the entry for this transaction as it will
-		// either be included or skipped, but in either case the deps
-		// are no longer needed.
+		// Grab the list of transactions which depend on this one (if any).
 		deps := dependers[*tx.Hash()]
-		delete(dependers, *tx.Hash())
 
 		// Enforce maximum block size.  Also check for overflow.
 		txSize := uint32(tx.MsgTx().SerializeSize())


### PR DESCRIPTION
This fixes a bug where a transaction would loose reference to other transactions dependant on it when being considered for inclusion in a new block template. The issue only occurs when the transaction being considered triggers a change of priority queue ordering to ordering by fee. It results in none of the dependant transactions being considered for inclusion in the new block template.