### PR TITLE
Mempool-only BIP 113: Median Time Past for lock-time calculations

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -59,6 +59,11 @@ type Config struct {
 	// the current best chain.
 	BestHeight func() int32
 
+	// MedianTimePast defines the function to use in order to access the
+	// median time past calculated from the point-of-view of the current
+	// chain tip within the best chain.
+	MedianTimePast func() time.Time
+
 	// SigCache defines a signature cache to use.
 	SigCache *txscript.SigCache
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -67,9 +67,6 @@ type Config struct {
 	// SigCache defines a signature cache to use.
 	SigCache *txscript.SigCache
 
-	// TimeSource defines the timesource to use.
-	TimeSource blockchain.MedianTimeSource
-
 	// AddrIndex defines the optional address index instance to use for
 	// indexing the unconfirmed transactions in the memory pool.
 	// This can be nil if the address index is not enabled.
@@ -551,8 +548,9 @@ func (mp *TxPool) maybeAcceptTransaction(tx *btcutil.Tx, isNew, rateLimit bool) 
 	// Don't allow non-standard transactions if the network parameters
 	// forbid their relaying.
 	if !mp.cfg.Policy.RelayNonStd {
-		err := checkTransactionStandard(tx, nextBlockHeight,
-			mp.cfg.TimeSource, mp.cfg.Policy.MinRelayTxFee)
+		medianTimePast := mp.cfg.MedianTimePast()
+		err = checkTransactionStandard(tx, nextBlockHeight,
+			medianTimePast, mp.cfg.Policy.MinRelayTxFee)
 		if err != nil {
 			// Attempt to extract a reject code from the error so
 			// it can be retained.  When not possible, fall back to

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec"
@@ -24,8 +25,9 @@ import (
 // transations to be appear as though they are spending completely valid utxos.
 type fakeChain struct {
 	sync.RWMutex
-	utxos         *blockchain.UtxoViewpoint
-	currentHeight int32
+	utxos          *blockchain.UtxoViewpoint
+	currentHeight  int32
+	medianTimePast time.Time
 }
 
 // FetchUtxoView loads utxo details about the input transactions referenced by
@@ -69,6 +71,23 @@ func (s *fakeChain) BestHeight() int32 {
 func (s *fakeChain) SetHeight(height int32) {
 	s.Lock()
 	s.currentHeight = height
+	s.Unlock()
+}
+
+// MedianTimePast returns the current median time past associated with the fake
+// chain instance.
+func (s *fakeChain) MedianTimePast() time.Time {
+	s.RLock()
+	mtp := s.medianTimePast
+	s.RUnlock()
+	return mtp
+}
+
+// SetMedianTimePast sets the current median time past associated with the fake
+// chain instance.
+func (s *fakeChain) SetMedianTimePast(mtp time.Time) {
+	s.Lock()
+	s.medianTimePast = mtp
 	s.Unlock()
 }
 
@@ -282,12 +301,12 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 				MaxSigOpsPerTx:       blockchain.MaxSigOpsPerBlock / 5,
 				MinRelayTxFee:        1000, // 1 Satoshi per byte
 			},
-			ChainParams:   chainParams,
-			FetchUtxoView: chain.FetchUtxoView,
-			BestHeight:    chain.BestHeight,
-			SigCache:      nil,
-			TimeSource:    blockchain.NewMedianTime(),
-			AddrIndex:     nil,
+			ChainParams:    chainParams,
+			FetchUtxoView:  chain.FetchUtxoView,
+			BestHeight:     chain.BestHeight,
+			MedianTimePast: chain.MedianTimePast,
+			SigCache:       nil,
+			AddrIndex:      nil,
 		}),
 	}
 

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -6,6 +6,7 @@ package mempool
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/txscript"
@@ -326,7 +327,9 @@ func isDust(txOut *wire.TxOut, minRelayTxFee btcutil.Amount) bool {
 // finalized, conforming to more stringent size constraints, having scripts
 // of recognized forms, and not containing "dust" outputs (those that are
 // so small it costs more to process them than they are worth).
-func checkTransactionStandard(tx *btcutil.Tx, height int32, timeSource blockchain.MedianTimeSource, minRelayTxFee btcutil.Amount) error {
+func checkTransactionStandard(tx *btcutil.Tx, height int32,
+	medianTimePast time.Time, minRelayTxFee btcutil.Amount) error {
+
 	// The transaction must be a currently supported version.
 	msgTx := tx.MsgTx()
 	if msgTx.Version > wire.TxVersion || msgTx.Version < 1 {
@@ -338,8 +341,7 @@ func checkTransactionStandard(tx *btcutil.Tx, height int32, timeSource blockchai
 
 	// The transaction must be finalized to be standard and therefore
 	// considered for inclusion in a block.
-	adjustedTime := timeSource.AdjustedTime()
-	if !blockchain.IsFinalizedTransaction(tx, height, adjustedTime) {
+	if !blockchain.IsFinalizedTransaction(tx, height, medianTimePast) {
 		return txRuleError(wire.RejectNonstandard,
 			"transaction is not finalized")
 	}

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -7,8 +7,8 @@ package mempool
 import (
 	"bytes"
 	"testing"
+	"time"
 
-	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -466,11 +466,11 @@ func TestCheckTransactionStandard(t *testing.T) {
 		},
 	}
 
-	timeSource := blockchain.NewMedianTime()
+	pastMedianTime := time.Now()
 	for _, test := range tests {
 		// Ensure standardness is as expected.
 		err := checkTransactionStandard(btcutil.NewTx(&test.tx),
-			test.height, timeSource, DefaultMinRelayTxFee)
+			test.height, pastMedianTime, DefaultMinRelayTxFee)
 		if err == nil && test.isStandard {
 			// Test passes since function returned standard for a
 			// transaction which is intended to be standard.

--- a/server.go
+++ b/server.go
@@ -2582,12 +2582,12 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 			MaxSigOpsPerTx:       blockchain.MaxSigOpsPerBlock / 5,
 			MinRelayTxFee:        cfg.minRelayTxFee,
 		},
-		ChainParams:   chainParams,
-		FetchUtxoView: s.blockManager.chain.FetchUtxoView,
-		BestHeight:    func() int32 { return bm.chain.BestSnapshot().Height },
-		SigCache:      s.sigCache,
-		TimeSource:    s.timeSource,
-		AddrIndex:     s.addrIndex,
+		ChainParams:    chainParams,
+		FetchUtxoView:  s.blockManager.chain.FetchUtxoView,
+		BestHeight:     func() int32 { return bm.chain.BestSnapshot().Height },
+		MedianTimePast: func() time.Time { return bm.chain.BestSnapshot().MedianTime },
+		SigCache:       s.sigCache,
+		AddrIndex:      s.addrIndex,
 	}
 	s.txMemPool = mempool.New(&txC)
 


### PR DESCRIPTION
This PR implements [BIP 113](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki) which modifies the time-lock threshold Bitcoin nodes use to determine if a transaction's lock-time has been satisfied or not. Before BIP 113, simply the time stamp within the blockheader of the block including a candidate transaction was consulted. However, this allows miners to fiddle with the timestamp on their blocks in order to include transactions which haven't yet matured by wall-clock time, thereby collecting more fees. 

After this PR, the MTP of the prior 11 blocks will be used in order to calculate the currently lock-time threshold for all transactions accepted into the mempool. 

A brief summary of this PR follows: 
 * A new closure within the `mempool`'s Policy config has been added which returns the current MTP as calculated from the tip of the best chain. Introducing such a closure which typically has the value cached should reduce the performance impact of the new MTP checks within the mempool. Otherwise, the MTP would need to be calculated from scratch each time negatively impacting validation efficiency. 
 * Transaction finality checks within the `mempool` now use the MTP of the past 11 blocks. As a result, the `TimeSource` field within the mempool's config has been removed, as MTP is now always used. 

This PR partially fixes #645. 