### PR TITLE
Mempool-only BIP 68: relative lock-time via consensus-enforced sequence numbers

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -46,15 +46,6 @@ func (b *BlockChain) maybeAcceptBlock(block *btcutil.Block, flags BehaviorFlags)
 		return false, err
 	}
 
-	// Prune block nodes which are no longer needed before creating
-	// a new node.
-	if !dryRun {
-		err = b.pruneBlockNodes()
-		if err != nil {
-			return false, err
-		}
-	}
-
 	// Create a new block node for the block and add it to the in-memory
 	// block chain (could be either a side chain or the main chain).
 	blockHeader := &block.MsgBlock().Header

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -828,6 +828,24 @@ func (b *BlockChain) calcSequenceLock(tx *btcutil.Tx, utxoView *UtxoViewpoint,
 	return sequenceLock, nil
 }
 
+// LockTimeToSequence converts the passed relative locktime to a sequence
+// number in accordance to BIP-68.
+// See: https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki
+//  * (Compatibility)
+func LockTimeToSequence(isSeconds bool, locktime uint32) uint32 {
+	// If we're expressing the relative lock time in blocks, then the
+	// corresponding sequence number is simply the desired input age.
+	if !isSeconds {
+		return locktime
+	}
+
+	// Set the 22nd bit which indicates the lock time is in seconds, then
+	// shift the locktime over by 9 since the time granularity is in
+	// 512-second intervals (2^9). This results in a max lock-time of
+	// 33,553,920 seconds, or 1.1 years.
+	return wire.SequenceLockTimeIsSeconds | uint32(locktime>>wire.SequenceLockTimeGranularity)
+}
+
 // getReorganizeNodes finds the fork point between the main chain and the passed
 // node and returns a list of block nodes that would need to be detached from
 // the main chain and a list of block nodes that would need to be attached to

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 )
 
@@ -108,6 +109,373 @@ func TestHaveBlock(t *testing.T) {
 			t.Errorf("HaveBlock #%d got %v want %v", i, result,
 				test.want)
 			continue
+		}
+	}
+}
+
+// TestCalcSequenceLock tests the LockTimeToSequence function, and the
+// CalcSequenceLock method of a Chain instance. The tests exercise several
+// combinations of inputs to the CalcSequenceLock function in order to ensure
+// the returned SequenceLocks are correct for each test instance.
+func TestCalcSequenceLock(t *testing.T) {
+	fileName := "blk_0_to_4.dat.bz2"
+	blockTmp, err := loadBlocks(fileName)
+	if err != nil {
+		t.Errorf("Error loading file: %v\n", err)
+		return
+	}
+	var blocks []*btcutil.Block
+	for _, block := range blockTmp {
+		blocks = append(blocks, block)
+	}
+
+	// Create a new database and chain instance to run tests against.
+	chain, teardownFunc, err := chainSetup("haveblock", &chaincfg.MainNetParams)
+	if err != nil {
+		t.Errorf("Failed to setup chain instance: %v", err)
+		return
+	}
+	defer teardownFunc()
+
+	// Since we're not dealing with the real block chain, disable
+	// checkpoints and set the coinbase maturity to 1.
+	chain.DisableCheckpoints(true)
+	chain.TstSetCoinbaseMaturity(1)
+
+	// Load all the blocks into our test chain.
+	for i := 1; i < len(blocks); i++ {
+		_, isOrphan, err := chain.ProcessBlock(blocks[i], blockchain.BFNone)
+		if err != nil {
+			t.Errorf("ProcessBlock fail on block %v: %v\n", i, err)
+			return
+		}
+		if isOrphan {
+			t.Errorf("ProcessBlock incorrectly returned block %v "+
+				"is an orphan\n", i)
+			return
+		}
+	}
+
+	// Create with all the utxos within the create created above.
+	utxoView := blockchain.NewUtxoViewpoint()
+	for blockHeight, block := range blocks {
+		for _, tx := range block.Transactions() {
+			utxoView.AddTxOuts(tx, int32(blockHeight))
+		}
+	}
+	utxoView.SetBestHash(blocks[len(blocks)-1].Hash())
+
+	// The median past time from the point of view of the second to last
+	// block in the chain.
+	medianTime := blocks[2].MsgBlock().Header.Timestamp.Unix()
+
+	// The median past time of the *next* block will be the timestamp of
+	// the 2nd block due to the way MTP is calculated in order to be
+	// compatible with Bitcoin Core.
+	nextMedianTime := blocks[2].MsgBlock().Header.Timestamp.Unix()
+
+	// We'll refer to this utxo within each input in the transactions
+	// created below. This block that includes this UTXO has a height of 4.
+	targetTx := blocks[4].Transactions()[0]
+	utxo := wire.OutPoint{
+		Hash:  *targetTx.Hash(),
+		Index: 0,
+	}
+
+	// Add an additional transaction which will serve as our unconfirmed
+	// output.
+	var fakeScript []byte
+	unConfTx := &wire.MsgTx{
+		TxOut: []*wire.TxOut{
+			&wire.TxOut{
+				PkScript: fakeScript,
+				Value:    5,
+			},
+		},
+	}
+	unConfUtxo := wire.OutPoint{
+		Hash:  unConfTx.TxHash(),
+		Index: 0,
+	}
+	// Adding a utxo with a height of 0x7fffffff indicates that the output
+	// is currently unmined.
+	utxoView.AddTxOuts(btcutil.NewTx(unConfTx), 0x7fffffff)
+
+	tests := []struct {
+		tx   *btcutil.Tx
+		view *blockchain.UtxoViewpoint
+
+		want *blockchain.SequenceLock
+
+		mempool bool
+	}{
+		// A transaction of version one should disable sequence locks
+		// as the new sequence number semantics only apply to
+		// transactions version 2 or higher.
+		{
+			tx: btcutil.NewTx(&wire.MsgTx{
+				Version: 1,
+				TxIn: []*wire.TxIn{
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         blockchain.LockTimeToSequence(false, 3),
+					},
+				},
+			}),
+			view: utxoView,
+			want: &blockchain.SequenceLock{
+				Seconds:     -1,
+				BlockHeight: -1,
+			},
+		},
+		// A transaction with a single input, that a max int sequence
+		// number. This sequence number has the high bit set, so
+		// sequence locks should be disabled.
+		{
+			tx: btcutil.NewTx(&wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         wire.MaxTxInSequenceNum,
+					},
+				},
+			}),
+			view: utxoView,
+			want: &blockchain.SequenceLock{
+				Seconds:     -1,
+				BlockHeight: -1,
+			},
+		},
+		// A transaction with a single input whose lock time is
+		// expressed in seconds. However, the specified lock time is
+		// below the required floor for time based lock times since
+		// they have time granularity of 512 seconds. As a result, the
+		// seconds lock-time should be just before the median time of
+		// the targeted block.
+		{
+			tx: btcutil.NewTx(&wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         blockchain.LockTimeToSequence(true, 2),
+					},
+				},
+			}),
+			view: utxoView,
+			want: &blockchain.SequenceLock{
+				Seconds:     medianTime - 1,
+				BlockHeight: -1,
+			},
+		},
+		// A transaction with a single input whose lock time is
+		// expressed in seconds. The number of seconds should be 1023
+		// seconds after the median past time of the last block in the
+		// chain.
+		{
+			tx: btcutil.NewTx(&wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         blockchain.LockTimeToSequence(true, 1024),
+					},
+				},
+			}),
+			view: utxoView,
+			want: &blockchain.SequenceLock{
+				Seconds:     medianTime + 1023,
+				BlockHeight: -1,
+			},
+		},
+		// A transaction with multiple inputs. The first input has a
+		// sequence lock in blocks with a value of 4. The last input
+		// has a sequence number with a value of 5, but has the disable
+		// bit set. So the first lock should be selected as it's the
+		// target lock as its the furthest in the future lock that
+		// isn't disabled.
+		{
+			tx: btcutil.NewTx(&wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         blockchain.LockTimeToSequence(true, 2560),
+					},
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence: blockchain.LockTimeToSequence(false, 3) |
+							wire.SequenceLockTimeDisabled,
+					},
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         blockchain.LockTimeToSequence(false, 3),
+					},
+				},
+			}),
+			view: utxoView,
+			want: &blockchain.SequenceLock{
+				Seconds:     medianTime + (5 << wire.SequenceLockTimeGranularity) - 1,
+				BlockHeight: 6,
+			},
+		},
+		// Transaction has a single input spending the genesis block
+		// transaction. The input's sequence number is encodes a
+		// relative lock-time in blocks (3 blocks). The sequence lock
+		// should have a value of -1 for seconds, but a block height of
+		// 6 meaning it can be included at height 7.
+		{
+			tx: btcutil.NewTx(&wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         blockchain.LockTimeToSequence(false, 3),
+					},
+				},
+			}),
+			view: utxoView,
+			want: &blockchain.SequenceLock{
+				Seconds:     -1,
+				BlockHeight: 6,
+			},
+		},
+		// A transaction with two inputs with lock times expressed in
+		// seconds. The selected sequence lock value for seconds should
+		// be the time further in the future.
+		{
+			tx: btcutil.NewTx(&wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         blockchain.LockTimeToSequence(true, 5120),
+					},
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         blockchain.LockTimeToSequence(true, 2560),
+					},
+				},
+			}),
+			view: utxoView,
+			want: &blockchain.SequenceLock{
+				Seconds:     medianTime + (10 << wire.SequenceLockTimeGranularity) - 1,
+				BlockHeight: -1,
+			},
+		},
+		// A transaction with two inputs with lock times expressed in
+		// seconds. The selected sequence lock value for blocks should
+		// be the height further in the future, so a height of 10
+		// indicating in can be included at height 7.
+		{
+			tx: btcutil.NewTx(&wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         blockchain.LockTimeToSequence(false, 1),
+					},
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         blockchain.LockTimeToSequence(false, 7),
+					},
+				},
+			}),
+			view: utxoView,
+			want: &blockchain.SequenceLock{
+				Seconds:     -1,
+				BlockHeight: 10,
+			},
+		},
+		// A transaction with multiple inputs. Two inputs are time
+		// based, and the other two are input maturity based. The lock
+		// lying further into the future for both inputs should be
+		// chosen.
+		{
+			tx: btcutil.NewTx(&wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         blockchain.LockTimeToSequence(true, 2560),
+					},
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         blockchain.LockTimeToSequence(true, 6656),
+					},
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         blockchain.LockTimeToSequence(false, 3),
+					},
+					&wire.TxIn{
+						PreviousOutPoint: utxo,
+						Sequence:         blockchain.LockTimeToSequence(false, 9),
+					},
+				},
+			}),
+			view: utxoView,
+			want: &blockchain.SequenceLock{
+				Seconds:     medianTime + (13 << wire.SequenceLockTimeGranularity) - 1,
+				BlockHeight: 12,
+			},
+		},
+		// A transaction with a single unconfirmed input. As the input
+		// is confirmed, the height of the input should be interpreted
+		// as the height of the *next* block. So the relative block
+		// lock should be based from a height of 5 rather than a height
+		// of 4.
+		{
+			tx: btcutil.NewTx(&wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					&wire.TxIn{
+						PreviousOutPoint: unConfUtxo,
+						Sequence:         blockchain.LockTimeToSequence(false, 2),
+					},
+				},
+			}),
+			view: utxoView,
+			want: &blockchain.SequenceLock{
+				Seconds:     -1,
+				BlockHeight: 6,
+			},
+		},
+		// A transaction with a single unconfirmed input. The input has
+		// a time based lock, so the lock time should be based off the
+		// MTP of the *next* block.
+		{
+			tx: btcutil.NewTx(&wire.MsgTx{
+				Version: 2,
+				TxIn: []*wire.TxIn{
+					&wire.TxIn{
+						PreviousOutPoint: unConfUtxo,
+						Sequence:         blockchain.LockTimeToSequence(true, 1024),
+					},
+				},
+			}),
+			view: utxoView,
+			want: &blockchain.SequenceLock{
+				Seconds:     nextMedianTime + 1023,
+				BlockHeight: -1,
+			},
+		},
+	}
+
+	t.Logf("Running %v SequenceLock tests", len(tests))
+	for i, test := range tests {
+		seqLock, err := chain.CalcSequenceLock(test.tx, test.view, test.mempool)
+		if err != nil {
+			t.Fatalf("test #%d, unable to calc sequence lock: %v", i, err)
+		}
+
+		if seqLock.Seconds != test.want.Seconds {
+			t.Fatalf("test #%d got %v seconds want %v seconds",
+				i, seqLock.Seconds, test.want.Seconds)
+		}
+		if seqLock.BlockHeight != test.want.BlockHeight {
+			t.Fatalf("test #%d got height of %v want height of %v ",
+				i, seqLock.BlockHeight, test.want.BlockHeight)
 		}
 	}
 }

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -118,6 +118,23 @@ func IsCoinBase(tx *btcutil.Tx) bool {
 	return IsCoinBaseTx(tx.MsgTx())
 }
 
+// SequenceLockActive determines if a transaction's sequence locks have been
+// met, meaning that all the inputs of a given transaction have reached a
+// height or time sufficient for their relative lock-time maturity.
+func SequenceLockActive(sequenceLock *SequenceLock, blockHeight int32,
+	medianTimePast time.Time) bool {
+
+	// If either the seconds, or height relative-lock time has not yet
+	// reached, then the transaction is not yet mature according to its
+	// sequence locks.
+	if sequenceLock.Seconds >= medianTimePast.Unix() ||
+		sequenceLock.BlockHeight >= blockHeight {
+		return false
+	}
+
+	return true
+}
+
 // IsFinalizedTransaction determines whether or not a transaction is finalized.
 func IsFinalizedTransaction(tx *btcutil.Tx, blockHeight int32, blockTime time.Time) bool {
 	msgTx := tx.MsgTx()

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -67,6 +67,11 @@ type Config struct {
 	// chain tip within the best chain.
 	MedianTimePast func() time.Time
 
+	// CalcSequenceLock defines the function to use in order to generate
+	// the current sequence lock for the given transaction using the passed
+	// utxo view.
+	CalcSequenceLock func(*btcutil.Tx, *blockchain.UtxoViewpoint) (*blockchain.SequenceLock, error)
+
 	// SigCache defines a signature cache to use.
 	SigCache *txscript.SigCache
 

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -84,6 +84,11 @@ type Config struct {
 // Policy houses the policy (configuration parameters) which is used to
 // control the mempool.
 type Policy struct {
+	// MaxTxVersion is the transaction version that the mempool should
+	// accept.  All transactions above this version are rejected as
+	// non-standard.
+	MaxTxVersion int32
+
 	// DisableRelayPriority defines whether to relay free or low-fee
 	// transactions that do not have enough priority to be relayed.
 	DisableRelayPriority bool
@@ -625,7 +630,8 @@ func (mp *TxPool) maybeAcceptTransaction(tx *btcutil.Tx, isNew, rateLimit, rejec
 	// forbid their acceptance.
 	if !mp.cfg.Policy.AcceptNonStd {
 		err = checkTransactionStandard(tx, nextBlockHeight,
-			medianTimePast, mp.cfg.Policy.MinRelayTxFee)
+			medianTimePast, mp.cfg.Policy.MinRelayTxFee,
+			mp.cfg.Policy.MaxTxVersion)
 		if err != nil {
 			// Attempt to extract a reject code from the error so
 			// it can be retained.  When not possible, fall back to

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -92,6 +92,17 @@ func (s *fakeChain) SetMedianTimePast(mtp time.Time) {
 	s.Unlock()
 }
 
+// CalcSequenceLock returns the current sequence lock for the passed
+// transaction associated with the fake chain instance.
+func (s *fakeChain) CalcSequenceLock(tx *btcutil.Tx,
+	view *blockchain.UtxoViewpoint) (*blockchain.SequenceLock, error) {
+
+	return &blockchain.SequenceLock{
+		Seconds:     -1,
+		BlockHeight: -1,
+	}, nil
+}
+
 // spendableOutput is a convenience type that houses a particular utxo and the
 // amount associated with it.
 type spendableOutput struct {
@@ -302,12 +313,13 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 				MaxSigOpsPerTx:       blockchain.MaxSigOpsPerBlock / 5,
 				MinRelayTxFee:        1000, // 1 Satoshi per byte
 			},
-			ChainParams:    chainParams,
-			FetchUtxoView:  chain.FetchUtxoView,
-			BestHeight:     chain.BestHeight,
-			MedianTimePast: chain.MedianTimePast,
-			SigCache:       nil,
-			AddrIndex:      nil,
+			ChainParams:      chainParams,
+			FetchUtxoView:    chain.FetchUtxoView,
+			BestHeight:       chain.BestHeight,
+			MedianTimePast:   chain.MedianTimePast,
+			CalcSequenceLock: chain.CalcSequenceLock,
+			SigCache:         nil,
+			AddrIndex:        nil,
 		}),
 	}
 
@@ -328,6 +340,7 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 		outputs = append(outputs, txOutToSpendableOut(coinbase, i))
 	}
 	harness.chain.SetHeight(int32(chainParams.CoinbaseMaturity) + curHeight)
+	harness.chain.SetMedianTimePast(time.Now())
 
 	return &harness, outputs, nil
 }

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -312,6 +312,7 @@ func newPoolHarness(chainParams *chaincfg.Params) (*poolHarness, []spendableOutp
 				MaxOrphanTxSize:      1000,
 				MaxSigOpsPerTx:       blockchain.MaxSigOpsPerBlock / 5,
 				MinRelayTxFee:        1000, // 1 Satoshi per byte
+				MaxTxVersion:         1,
 			},
 			ChainParams:      chainParams,
 			FetchUtxoView:    chain.FetchUtxoView,

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -252,14 +252,15 @@ func isDust(txOut *wire.TxOut, minRelayTxFee btcutil.Amount) bool {
 // of recognized forms, and not containing "dust" outputs (those that are
 // so small it costs more to process them than they are worth).
 func checkTransactionStandard(tx *btcutil.Tx, height int32,
-	medianTimePast time.Time, minRelayTxFee btcutil.Amount) error {
+	medianTimePast time.Time, minRelayTxFee btcutil.Amount,
+	maxTxVersion int32) error {
 
 	// The transaction must be a currently supported version.
 	msgTx := tx.MsgTx()
-	if msgTx.Version > wire.TxVersion || msgTx.Version < 1 {
+	if msgTx.Version > maxTxVersion || msgTx.Version < 1 {
 		str := fmt.Sprintf("transaction version %d is not in the "+
 			"valid range of %d-%d", msgTx.Version, 1,
-			wire.TxVersion)
+			maxTxVersion)
 		return txRuleError(wire.RejectNonstandard, str)
 	}
 

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -470,7 +470,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 	for _, test := range tests {
 		// Ensure standardness is as expected.
 		err := checkTransactionStandard(btcutil.NewTx(&test.tx),
-			test.height, pastMedianTime, DefaultMinRelayTxFee)
+			test.height, pastMedianTime, DefaultMinRelayTxFee, 1)
 		if err == nil && test.isStandard {
 			// Test passes since function returned standard for a
 			// transaction which is intended to be standard.

--- a/mining.go
+++ b/mining.go
@@ -481,7 +481,6 @@ mempoolLoop:
 		}
 		if !blockchain.IsFinalizedTransaction(tx, nextBlockHeight,
 			timeSource.AdjustedTime()) {
-
 			minrLog.Tracef("Skipping non-finalized tx %s", tx.Hash())
 			continue
 		}

--- a/server.go
+++ b/server.go
@@ -2355,6 +2355,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 			MaxOrphanTxSize:      defaultMaxOrphanTxSize,
 			MaxSigOpsPerTx:       blockchain.MaxSigOpsPerBlock / 5,
 			MinRelayTxFee:        cfg.minRelayTxFee,
+			MaxTxVersion:         2,
 		},
 		ChainParams:    chainParams,
 		FetchUtxoView:  s.blockManager.chain.FetchUtxoView,

--- a/server.go
+++ b/server.go
@@ -2360,8 +2360,11 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		FetchUtxoView:  s.blockManager.chain.FetchUtxoView,
 		BestHeight:     func() int32 { return bm.chain.BestSnapshot().Height },
 		MedianTimePast: func() time.Time { return bm.chain.BestSnapshot().MedianTime },
-		SigCache:       s.sigCache,
-		AddrIndex:      s.addrIndex,
+		CalcSequenceLock: func(tx *btcutil.Tx, view *blockchain.UtxoViewpoint) (*blockchain.SequenceLock, error) {
+			return bm.chain.CalcSequenceLock(tx, view, true)
+		},
+		SigCache:  s.sigCache,
+		AddrIndex: s.addrIndex,
 	}
 	s.txMemPool = mempool.New(&txC)
 

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -39,6 +39,13 @@ const (
 	// when masked against the transaction input sequence number.
 	SequenceLockTimeMask = 0x0000ffff
 
+	// SequenceLockTimeGranularity is the defined time based granularity
+	// for seconds-based relative time locks. When converting from seconds
+	// to a sequence number, the value is right shifted by this amount,
+	// therefore the granularity of relative time locks in 512 or 2^9
+	// seconds. Enforced relative lock times are multiples of 512 seconds.
+	SequenceLockTimeGranularity = 9
+
 	// defaultTxInOutAlloc is the default size used for the backing array for
 	// transaction inputs and outputs.  The array will dynamically grow as needed,
 	// but this figure is intended to provide enough space for the number of


### PR DESCRIPTION
This commit implements [BIP 68](https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki) which repurposes the sequence number as defined within the `wire.TxIn`'s of a transaction. This repurposing allows for consensus enforced _relative_ lock-times based on the set sequence numbers of all inputs within a transaction. Transactions which violate the required input maturity governed by sequence numbers are not allowed into the mempool, rejected when found within a block, and skipped over when assembling blocks. This PR currently only enforces the behavior when accepting candidate transaction to the mempool. 

This PR is dependent on #712 as it rebases on top of the latest changes to that branch. By *default* all checks for input maturity based on sequence numbers must use the MTP of the block prior to the one which includes the referenced output in the case of a relative lock-time expressed in _seconds_. 

A brief summary of the changes in this PR follows: 
  * A new data-structure `SequenceLocks`, along with a new method on `BlockChain` to calculate sequence locks based on a transaction and `utxoView` has have been added to the `blockchain` package. 
    * Sequence locks are essentially the evaluated absolute lock-time based on an attempt to include a transaction within a block, accept to the mempool, or accept as valid within a new block. 
    * Currently in the implementation there's a `true` value in a boolean statement which determines if sequence locks should be enforced or not. Once BIP 9 has been implemented, this should instead be a check to the `versionbits` state to determine if the CSV package has been activated+locked-in. 
    * This function _takes_ a `UtxoViewPoint` rather than generating one internally in order to allow callers to properly populate the utxo view depending on the context. For example, when accepting a transaction into the mempool, any inputs referenced which are in the mempool may potentially need to be considered. Similarly when validating a block, the UTXO's of any transactions within the block, but not yet in the DB also need to be considered.  

* A new function `SequenceLocksActive` similar to `IsFinalizedTransaction` has been added to the `blockchain` package. This function is used to determine if the relative lock-times (sequence locks) for a transaction have reached maturity from the point-of-view of a block height or MTP. 

* When accepting a transaction into the mempool, validating a block, or assembling a new block template relative-time locks are currently _unconditionally_ evaluated. This OK for the mempool case, but when dealing with blocks, BIP 9 `versionbits` state should be examined to ensure we're enforcing the new consensus behavior at the correct time. 

This PR partially fixes #645. 