### PR TITLE
TravisCI: Set vendor experiment variable earlier.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
 sudo: false
 before_install:
   - gotools=golang.org/x/tools
+  - export GO15VENDOREXPERIMENT=1
 install:
   - go get -v github.com/Masterminds/glide
   - glide install
@@ -12,5 +13,4 @@ install:
   - go get -v github.com/golang/lint/golint
 script:
   - export PATH=$PATH:$HOME/gopath/bin
-  - export GO15VENDOREXPERIMENT=1
   - ./goclean.sh


### PR DESCRIPTION
This sets the `GO15VENDOREXPERIMENT` environment variable before glide is installed so vendoring is used when installing it as well.