### PR TITLE
chaincfg/blockchain: Parameterize more chain consts.

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -46,7 +46,7 @@ func TestHaveBlock(t *testing.T) {
 	// Since we're not dealing with the real block chain, disable
 	// checkpoints and set the coinbase maturity to 1.
 	chain.DisableCheckpoints(true)
-	blockchain.TstSetCoinbaseMaturity(1)
+	chain.TstSetCoinbaseMaturity(1)
 
 	for i := 1; i < len(blocks); i++ {
 		isOrphan, err := chain.ProcessBlock(blocks[i], blockchain.BFNone)

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -107,10 +107,14 @@ func chainSetup(dbName string) (*blockchain.BlockChain, func(), error) {
 		}
 	}
 
+	// Copy the chain params to ensure any modifications the tests do to
+	// the chain parameters do not affect the global instance.
+	mainNetParams := chaincfg.MainNetParams
+
 	// Create the main chain instance.
 	chain, err := blockchain.New(&blockchain.Config{
 		DB:          db,
-		ChainParams: &chaincfg.MainNetParams,
+		ChainParams: &mainNetParams,
 		TimeSource:  blockchain.NewMedianTime(),
 	})
 	if err != nil {

--- a/blockchain/internal_test.go
+++ b/blockchain/internal_test.go
@@ -19,8 +19,8 @@ import (
 
 // TstSetCoinbaseMaturity makes the ability to set the coinbase maturity
 // available to the test package.
-func TstSetCoinbaseMaturity(maturity int32) {
-	coinbaseMaturity = maturity
+func (b *BlockChain) TstSetCoinbaseMaturity(maturity uint16) {
+	b.chainParams.CoinbaseMaturity = maturity
 }
 
 // TstTimeSorter makes the internal timeSorter type available to the test

--- a/blockchain/reorganization_test.go
+++ b/blockchain/reorganization_test.go
@@ -56,7 +56,7 @@ func TestReorganization(t *testing.T) {
 	// Since we're not dealing with the real block chain, disable
 	// checkpoints and set the coinbase maturity to 1.
 	chain.DisableCheckpoints(true)
-	blockchain.TstSetCoinbaseMaturity(1)
+	chain.TstSetCoinbaseMaturity(1)
 
 	expectedOrphans := map[int]struct{}{5: {}, 6: {}}
 	for i := 1; i < len(blocks); i++ {

--- a/mempool.go
+++ b/mempool.go
@@ -596,7 +596,7 @@ func (mp *txMemPool) maybeAcceptTransaction(tx *btcutil.Tx, isNew, rateLimit boo
 	// Also returns the fees associated with the transaction which will be
 	// used later.
 	txFee, err := blockchain.CheckTransactionInputs(tx, nextBlockHeight,
-		utxoView)
+		utxoView, activeNetParams.Params)
 	if err != nil {
 		if cerr, ok := err.(blockchain.RuleError); ok {
 			return nil, chainRuleError(cerr)

--- a/mining.go
+++ b/mining.go
@@ -651,7 +651,7 @@ mempoolLoop:
 		// Ensure the transaction inputs pass all of the necessary
 		// preconditions before allowing it to be added to the block.
 		_, err = blockchain.CheckTransactionInputs(tx, nextBlockHeight,
-			blockUtxos)
+			blockUtxos, activeNetParams.Params)
 		if err != nil {
 			minrLog.Tracef("Skipping tx %s due to error in "+
 				"CheckTransactionInputs: %v", tx.Hash(), err)
@@ -781,7 +781,7 @@ func UpdateBlockTime(msgBlock *wire.MsgBlock, bManager *blockManager) error {
 
 	// If running on a network that requires recalculating the difficulty,
 	// do so now.
-	if activeNetParams.ResetMinDifficulty {
+	if activeNetParams.ReduceMinDifficulty {
 		difficulty, err := bManager.chain.CalcNextRequiredDifficulty(
 			newTimestamp)
 		if err != nil {

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2104,6 +2104,11 @@ func handleGetNetworkHashPS(s *rpcServer, cmd interface{}, closeChan <-chan stru
 		endHeight = best.Height
 	}
 
+	// Calculate the number of blocks per retarget interval based on the
+	// chain parameters.
+	blocksPerRetarget := int32(s.server.chainParams.TargetTimespan /
+		s.server.chainParams.TargetTimePerBlock)
+
 	// Calculate the starting block height based on the passed number of
 	// blocks.  When the passed value is negative, use the last block the
 	// difficulty changed as the starting height.  Also make sure the
@@ -2114,7 +2119,7 @@ func handleGetNetworkHashPS(s *rpcServer, cmd interface{}, closeChan <-chan stru
 	}
 	var startHeight int32
 	if numBlocks <= 0 {
-		startHeight = endHeight - ((endHeight % blockchain.BlocksPerRetarget) + 1)
+		startHeight = endHeight - ((endHeight % blocksPerRetarget) + 1)
 	} else {
 		startHeight = endHeight - numBlocks
 	}


### PR DESCRIPTION
This moves several of the chain constants to the `Params` struct in the `chaincfg` package which is intended for that purpose.  This is mostly a backport of the same modifications made in `Decred` along with a few additional things cleaned up.

The following is an overview of the changes:

- Comment all fields in the `Params` struct definition
- Add locals to `BlockChain` instance for the calculated values based on the provided chain params
- Rename the following param fields:
  - `SubsidyHalvingInterval` -> `SubsidyReductionInterval`
  - `ResetMinDifficulty` -> `ReduceMinDifficulty`
- Add new Param fields:
  - `CoinbaseMaturity`
  - `TargetTimePerBlock`
  - `TargetTimespan`
  - `BlocksPerRetarget`
  - `RetargetAdjustmentFactor`
  - `MinDiffReductionTime`