### PR TITLE
btcd: Simplify shutdown signal handling logic.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3508,7 +3508,10 @@ func handleSetGenerate(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 
 // handleStop implements the stop command.
 func handleStop(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
-	s.server.Stop()
+	select {
+	case s.requestProcessShutdown <- struct{}{}:
+	default:
+	}
 	return "btcd stopping.", nil
 }
 
@@ -3678,23 +3681,24 @@ func handleVerifyMessage(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 // rpcServer holds the items the rpc server may need to access (config,
 // shutdown, main server, etc.)
 type rpcServer struct {
-	started      int32
-	shutdown     int32
-	policy       *mining.Policy
-	server       *server
-	chain        *blockchain.BlockChain
-	authsha      [fastsha256.Size]byte
-	limitauthsha [fastsha256.Size]byte
-	ntfnMgr      *wsNotificationManager
-	numClients   int32
-	statusLines  map[int]string
-	statusLock   sync.RWMutex
-	wg           sync.WaitGroup
-	listeners    []net.Listener
-	workState    *workState
-	gbtWorkState *gbtWorkState
-	helpCacher   *helpCacher
-	quit         chan int
+	started                int32
+	shutdown               int32
+	policy                 *mining.Policy
+	server                 *server
+	chain                  *blockchain.BlockChain
+	authsha                [fastsha256.Size]byte
+	limitauthsha           [fastsha256.Size]byte
+	ntfnMgr                *wsNotificationManager
+	numClients             int32
+	statusLines            map[int]string
+	statusLock             sync.RWMutex
+	wg                     sync.WaitGroup
+	listeners              []net.Listener
+	workState              *workState
+	gbtWorkState           *gbtWorkState
+	helpCacher             *helpCacher
+	requestProcessShutdown chan struct{}
+	quit                   chan int
 }
 
 // httpStatusLine returns a response Status-Line (RFC 2616 Section 6.1)
@@ -3776,6 +3780,13 @@ func (s *rpcServer) Stop() error {
 	s.wg.Wait()
 	rpcsLog.Infof("RPC server shutdown complete")
 	return nil
+}
+
+// RequestedProcessShutdown returns a channel that is sent to when an authorized
+// RPC client requests the process to shutdown.  If the request can not be read
+// immediately, it is dropped.
+func (s *rpcServer) RequestedProcessShutdown() <-chan struct{} {
+	return s.requestProcessShutdown
 }
 
 // limitConnections responds with a 503 service unavailable and returns true if
@@ -4159,14 +4170,15 @@ func genCertPair(certFile, keyFile string) error {
 // newRPCServer returns a new instance of the rpcServer struct.
 func newRPCServer(listenAddrs []string, policy *mining.Policy, s *server) (*rpcServer, error) {
 	rpc := rpcServer{
-		policy:       policy,
-		server:       s,
-		chain:        s.blockManager.chain,
-		statusLines:  make(map[int]string),
-		workState:    newWorkState(),
-		gbtWorkState: newGbtWorkState(s.timeSource),
-		helpCacher:   newHelpCacher(),
-		quit:         make(chan int),
+		policy:                 policy,
+		server:                 s,
+		chain:                  s.blockManager.chain,
+		statusLines:            make(map[int]string),
+		workState:              newWorkState(),
+		gbtWorkState:           newGbtWorkState(s.timeSource),
+		helpCacher:             newHelpCacher(),
+		requestProcessShutdown: make(chan struct{}),
+		quit: make(chan int),
 	}
 	if cfg.RPCUser != "" && cfg.RPCPass != "" {
 		login := cfg.RPCUser + ":" + cfg.RPCPass

--- a/server.go
+++ b/server.go
@@ -2555,6 +2555,12 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		if err != nil {
 			return nil, err
 		}
+
+		// Signal process shutdown when the RPC server requests it.
+		go func() {
+			<-s.rpcServer.RequestedProcessShutdown()
+			shutdownRequestChannel <- struct{}{}
+		}()
 	}
 
 	return &s, nil

--- a/service_windows.go
+++ b/service_windows.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 The btcsuite developers
+// Copyright (c) 2013-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -85,18 +85,8 @@ loop:
 				// more commands while pending.
 				changes <- svc.Status{State: svc.StopPending}
 
-				// Stop the main server gracefully when it is
-				// already setup or just break out and allow
-				// the service to exit immediately if it's not
-				// setup yet.  Note that calling Stop will cause
-				// btcdMain to exit in the goroutine above which
-				// will in turn send a signal (and a potential
-				// error) to doneChan.
-				if mainServer != nil {
-					mainServer.Stop()
-				} else {
-					break loop
-				}
+				// Signal the main function to exit.
+				shutdownRequestChannel <- struct{}{}
 
 			default:
 				elog.Error(1, fmt.Sprintf("Unexpected control "+

--- a/signalsigterm.go
+++ b/signalsigterm.go
@@ -12,5 +12,5 @@ import (
 )
 
 func init() {
-	signals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+	interruptSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
 }


### PR DESCRIPTION
This rewrites the shutdown logic to simplify the shutdown signalling.  All cleanup is now run from deferred functions in the main function and channels are used to signal shutdown either from OS signals or from
other subsystems such as the RPC server and windows service controller.

The RPC server has been modified to use a new channel for signalling shutdown that is exposed via the `RequestedProcessShutdown` function instead of directly calling `Stop` on the server as it previously did.

Finally, it adds a few checks for early termination during the main start sequence so the process can be stopped without starting all the subsystems if desired.

This is a backport of the equivalent logic from Decred with a few slight modifications.  Credits go to @jrick.