### PR TITLE
rpc method estimatefee

### DIFF
--- a/mempool/estimatefee.go
+++ b/mempool/estimatefee.go
@@ -34,6 +34,15 @@ const (
 	// can be made by the txs found in a given block.
 	estimateFeeMaxReplacements = 10
 
+	// DefaultEstimateFeeMaxRollback is the default number of rollbacks
+	// allowed by the fee estimator for orphaned blocks.
+	DefaultEstimateFeeMaxRollback = 2
+
+	// DefaultEstimateFeeMinRegisteredBlocks is the default minimum
+	// number of blocks which must be observed by the fee estimator before
+	// it will provide fee estimations.
+	DefaultEstimateFeeMinRegisteredBlocks = 3
+
 	bytePerKb = 1024
 
 	btcPerSatoshi = 1E-8

--- a/mempool/estimatefee.go
+++ b/mempool/estimatefee.go
@@ -1,0 +1,493 @@
+// Copyright (c) 2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package mempool
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"sync"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/mining"
+	"github.com/btcsuite/btcutil"
+)
+
+// TODO incorporate Alex Morcos' modifications to Gavin's initial model
+// https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2014-October/006824.html
+
+// TODO store and restore the FeeEstimator state in the database.
+
+const (
+	// estimateFeeDepth is the maximum number of blocks before a transaction
+	// is confirmed that we want to track.
+	estimateFeeDepth = 25
+
+	// estimateFeeBinSize is the number of txs stored in each bin.
+	estimateFeeBinSize = 100
+
+	// estimateFeeMaxReplacements is the max number of replacements that
+	// can be made by the txs found in a given block.
+	estimateFeeMaxReplacements = 10
+)
+
+// SatoshiPerByte is number with units of satoshis per byte.
+type SatoshiPerByte float64
+
+// ToSatoshiPerKb returns a float value that represents the given
+// SatoshiPerByte converted to satoshis per kb.
+func (rate SatoshiPerByte) ToSatoshiPerKb() float64 {
+	// If our rate is the error value, return that.
+	if rate == SatoshiPerByte(-1.0) {
+		return -1.0
+	}
+
+	return float64(rate) * 1024
+}
+
+// Fee returns the fee for a transaction of a given size for
+// the given fee rate.
+func (rate SatoshiPerByte) Fee(size uint32) btcutil.Amount {
+	// If our rate is the error value, return that.
+	if rate == SatoshiPerByte(-1) {
+		return btcutil.Amount(-1)
+	}
+
+	return btcutil.Amount(float64(rate) * float64(size))
+}
+
+// NewSatoshiPerByte creates a SatoshiPerByte from an Amount and a
+// size in bytes.
+func NewSatoshiPerByte(fee btcutil.Amount, size uint32) SatoshiPerByte {
+	return SatoshiPerByte(float64(fee) / float64(size))
+}
+
+// observedTransaction represents an observed transaction and some
+// additional data required for the fee estimation algorithm.
+type observedTransaction struct {
+	// A transaction hash.
+	hash chainhash.Hash
+
+	// The fee per byte of the transaction in satoshis.
+	feeRate SatoshiPerByte
+
+	// The block height when it was observed.
+	observed int32
+
+	// The height of the block in which it was mined.
+	// If the transaction has not yet been mined, it is zero.
+	mined int32
+}
+
+// registeredBlock has the hash of a block and the list of transactions
+// it mined which had been previously observed by the FeeEstimator. It
+// is used if Rollback is called to reverse the effect of registering
+// a block.
+type registeredBlock struct {
+	hash         *chainhash.Hash
+	transactions []*observedTransaction
+}
+
+// FeeEstimator manages the data necessary to create
+// fee estimations. It is safe for concurrent access.
+type FeeEstimator struct {
+	maxRollback uint32
+	binSize     int
+
+	// The maximum number of replacements that can be made in a single
+	// bin per block. Default is estimateFeeMaxReplacements
+	maxReplacements int
+
+	// The minimum number of blocks that can be registered with the fee
+	// estimator before it will provide answers.
+	minRegisteredBlocks uint32
+
+	// The last known height.
+	lastKnownHeight int32
+
+	sync.RWMutex
+	observed            map[chainhash.Hash]observedTransaction
+	bin                 [estimateFeeDepth][]*observedTransaction
+	numBlocksRegistered uint32 // The number of blocks that have been registered.
+
+	// The cached estimates.
+	cached []SatoshiPerByte
+
+	// Transactions that have been removed from the bins. This allows us to
+	// revert in case of an orphaned block.
+	dropped []registeredBlock
+}
+
+// NewFeeEstimator creates a FeeEstimator for which at most maxRollback blocks
+// can be unregistered and which returns an error unless minRegisteredBlocks
+// have been registered with it.
+func NewFeeEstimator(maxRollback, minRegisteredBlocks uint32) *FeeEstimator {
+	return &FeeEstimator{
+		maxRollback:         maxRollback,
+		minRegisteredBlocks: minRegisteredBlocks,
+		lastKnownHeight:     mining.UnminedHeight,
+		binSize:             estimateFeeBinSize,
+		maxReplacements:     estimateFeeMaxReplacements,
+		observed:            make(map[chainhash.Hash]observedTransaction),
+		dropped:             make([]registeredBlock, 0, maxRollback),
+	}
+}
+
+// ObserveTransaction is called when a new transaction is observed in the mempool.
+func (ef *FeeEstimator) ObserveTransaction(t *TxDesc) {
+	ef.Lock()
+	defer ef.Unlock()
+
+	hash := *t.Tx.Hash()
+	if _, ok := ef.observed[hash]; !ok {
+		size := uint32(t.Tx.MsgTx().SerializeSize())
+
+		ef.observed[hash] = observedTransaction{
+			hash:     hash,
+			feeRate:  NewSatoshiPerByte(btcutil.Amount(t.Fee), size),
+			observed: t.Height,
+			mined:    mining.UnminedHeight,
+		}
+	}
+}
+
+// RegisterBlock informs the fee estimator of a new block to take into account.
+func (ef *FeeEstimator) RegisterBlock(block *btcutil.Block) error {
+	ef.Lock()
+	defer ef.Unlock()
+
+	// The previous sorted list is invalid, so delete it.
+	ef.cached = nil
+
+	height := block.Height()
+	if height != ef.lastKnownHeight+1 && ef.lastKnownHeight != mining.UnminedHeight {
+		return fmt.Errorf("intermediate block not recorded; current height is %d; new height is %d",
+			ef.lastKnownHeight, height)
+	}
+
+	// Update the last known height.
+	ef.lastKnownHeight = height
+	ef.numBlocksRegistered++
+
+	// Randomly order txs in block.
+	transactions := make(map[*btcutil.Tx]struct{})
+	for _, t := range block.Transactions() {
+		transactions[t] = struct{}{}
+	}
+
+	// Count the number of replacements we make per bin so that we don't
+	// replace too many.
+	var replacementCounts [estimateFeeDepth]int
+
+	// Keep track of which txs were dropped in case of an orphan block.
+	dropped := registeredBlock{
+		hash:         block.Hash(),
+		transactions: make([]*observedTransaction, 0, 100),
+	}
+
+	// Go through the txs in the block.
+	for t := range transactions {
+		hash := *t.Hash()
+
+		// Have we observed this tx in the mempool?
+		o, ok := ef.observed[hash]
+		if !ok {
+			continue
+		}
+
+		// Put the observed tx in the oppropriate bin.
+		o.mined = height
+
+		blocksToConfirm := height - o.observed - 1
+
+		// This shouldn't happen but check just in case to avoid
+		// a panic later.
+		if blocksToConfirm >= estimateFeeDepth {
+			continue
+		}
+
+		// Make sure we do not replace too many transactions per min.
+		if replacementCounts[blocksToConfirm] == ef.maxReplacements {
+			continue
+		}
+
+		replacementCounts[blocksToConfirm]++
+
+		bin := ef.bin[blocksToConfirm]
+
+		// Remove a random element and replace it with this new tx.
+		if len(bin) == ef.binSize {
+			l := ef.binSize - replacementCounts[blocksToConfirm]
+			drop := rand.Intn(l)
+			dropped.transactions = append(dropped.transactions, bin[drop])
+
+			bin[drop] = bin[l-1]
+			bin[l-1] = &o
+		} else {
+			ef.bin[blocksToConfirm] = append(bin, &o)
+		}
+	}
+
+	// Go through the mempool for txs that have been in too long.
+	for hash, o := range ef.observed {
+		if height-o.observed >= estimateFeeDepth {
+			delete(ef.observed, hash)
+		}
+	}
+
+	// Add dropped list to history.
+	if ef.maxRollback == 0 {
+		return nil
+	}
+
+	if uint32(len(ef.dropped)) == ef.maxRollback {
+		ef.dropped = append(ef.dropped[1:], dropped)
+	} else {
+		ef.dropped = append(ef.dropped, dropped)
+	}
+
+	return nil
+}
+
+// Rollback unregisters a recently registered block from the FeeEstimator.
+// This can be used to reverse the effect of an orphaned block on the fee
+// estimator. The maximum number of rollbacks allowed is given by
+// maxRollbacks.
+//
+// Note: not everything can be rolled back because some transactions are
+// deleted if they have been observed too long ago. That means the result
+// of Rollback won't always be exactly the same as if the last block had not
+// happened, but it should be close enough.
+func (ef *FeeEstimator) Rollback(block *btcutil.Block) error {
+	ef.Lock()
+	defer ef.Unlock()
+
+	hash := block.Hash()
+
+	// Find this block in the stack of recent registered blocks.
+	var n int
+	for n = 1; n < len(ef.dropped); n++ {
+		if ef.dropped[len(ef.dropped)-n].hash.IsEqual(hash) {
+			break
+		}
+	}
+
+	if n == len(ef.dropped) {
+		return errors.New("no such block was recently registered")
+	}
+
+	for i := 0; i < n; i++ {
+		err := ef.rollback()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// rollback rolls back the effect of the last block in the stack
+// of registered blocks.
+func (ef *FeeEstimator) rollback() error {
+
+	// The previous sorted list is invalid, so delete it.
+	ef.cached = nil
+
+	// pop the last list of dropped txs from the stack.
+	last := len(ef.dropped) - 1
+	if last == -1 {
+		// Return if we cannot rollback.
+		return errors.New("max rollbacks reached")
+	}
+
+	ef.numBlocksRegistered--
+
+	dropped := ef.dropped[last]
+	ef.dropped = ef.dropped[0:last]
+
+	// where we are in each bin as we replace txs?
+	var replacementCounters [estimateFeeDepth]int
+
+	var err error
+
+	// Go through the txs in the dropped block.
+	for _, o := range dropped.transactions {
+		// Which bin was this tx in?
+		blocksToConfirm := o.mined - o.observed - 1
+
+		bin := ef.bin[blocksToConfirm]
+
+		var counter = replacementCounters[blocksToConfirm]
+
+		// Continue to go through that bin where we left off.
+		for {
+			if counter >= len(bin) {
+				// Create an error but keep going in case we can roll back
+				// more transactions successfully.
+				err = errors.New("illegal state: cannot rollback dropped transaction")
+			}
+
+			prev := bin[counter]
+
+			if prev.mined == ef.lastKnownHeight {
+				prev.mined = mining.UnminedHeight
+
+				bin[counter] = o
+
+				counter++
+				break
+			}
+
+			counter++
+		}
+	}
+
+	// Continue going through bins to find other txs to remove
+	// which did not replace any other when they were entered.
+	for i, j := range replacementCounters {
+		for {
+			l := len(ef.bin[i])
+			if j >= l {
+				break
+			}
+
+			prev := ef.bin[i][j]
+
+			if prev.mined == ef.lastKnownHeight {
+				prev.mined = mining.UnminedHeight
+
+				newBin := append(ef.bin[i][0:j], ef.bin[i][j+1:l]...)
+				// TODO This line should prevent an unintentional memory
+				// leak but it causes a panic when it is uncommented.
+				// ef.bin[i][j] = nil
+				ef.bin[i] = newBin
+
+				continue
+			}
+
+			j++
+		}
+	}
+
+	ef.lastKnownHeight--
+
+	return err
+}
+
+// estimateFeeSet is a set of txs that can that is sorted
+// by the fee per kb rate.
+type estimateFeeSet struct {
+	feeRate []SatoshiPerByte
+	bin     [estimateFeeDepth]uint32
+}
+
+func (b *estimateFeeSet) Len() int { return len(b.feeRate) }
+
+func (b *estimateFeeSet) Less(i, j int) bool {
+	return b.feeRate[i] > b.feeRate[j]
+}
+
+func (b *estimateFeeSet) Swap(i, j int) {
+	b.feeRate[i], b.feeRate[j] = b.feeRate[j], b.feeRate[i]
+}
+
+// estimateFee returns the estimated fee for a transaction
+// to confirm in confirmations blocks from now, given
+// the data set we have collected.
+func (b *estimateFeeSet) estimateFee(confirmations int) SatoshiPerByte {
+	if confirmations <= 0 {
+		return SatoshiPerByte(math.Inf(1))
+	}
+
+	if confirmations > estimateFeeDepth {
+		return 0
+	}
+
+	var min, max uint32 = 0, 0
+	for i := 0; i < confirmations-1; i++ {
+		min += b.bin[i]
+	}
+
+	max = min + b.bin[confirmations-1]
+
+	// We don't have any transactions!
+	if min == 0 && max == 0 {
+		return 0
+	}
+
+	return b.feeRate[(min+max-1)/2] * 1E-8
+}
+
+// newEstimateFeeSet creates a temporary data structure that
+// can be used to find all fee estimates.
+func (ef *FeeEstimator) newEstimateFeeSet() *estimateFeeSet {
+	set := &estimateFeeSet{}
+
+	capacity := 0
+	for i, b := range ef.bin {
+		l := len(b)
+		set.bin[i] = uint32(l)
+		capacity += l
+	}
+
+	set.feeRate = make([]SatoshiPerByte, capacity)
+
+	i := 0
+	for _, b := range ef.bin {
+		for _, o := range b {
+			set.feeRate[i] = o.feeRate
+			i++
+		}
+	}
+
+	sort.Sort(set)
+
+	return set
+}
+
+// estimates returns the set of all fee estimates from 1 to estimateFeeDepth
+// confirmations from now.
+func (ef *FeeEstimator) estimates() []SatoshiPerByte {
+	set := ef.newEstimateFeeSet()
+
+	estimates := make([]SatoshiPerByte, estimateFeeDepth)
+	for i := 0; i < estimateFeeDepth; i++ {
+		estimates[i] = set.estimateFee(i + 1)
+	}
+
+	return estimates
+}
+
+// EstimateFee estimates the fee per byte to have a tx confirmed a given
+// number of blocks from now.
+func (ef *FeeEstimator) EstimateFee(numBlocks uint32) (SatoshiPerByte, error) {
+	ef.Lock()
+	defer ef.Unlock()
+
+	// If the number of registered blocks is below the minimum, return
+	// an error.
+	if ef.numBlocksRegistered < ef.minRegisteredBlocks {
+		return -1, errors.New("not enough blocks have been observed")
+	}
+
+	if numBlocks == 0 {
+		return -1, errors.New("cannot confirm transaction in zero blocks")
+	}
+
+	if numBlocks > estimateFeeDepth {
+		return -1, fmt.Errorf(
+			"can only estimate fees for up to %d blocks from now",
+			estimateFeeBinSize)
+	}
+
+	// If there are no cached results, generate them.
+	if ef.cached == nil {
+		ef.cached = ef.estimates()
+	}
+
+	return ef.cached[int(numBlocks)-1], nil
+}

--- a/mempool/estimatefee.go
+++ b/mempool/estimatefee.go
@@ -5,11 +5,15 @@
 package mempool
 
 import (
+	"bytes"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"math/rand"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -19,8 +23,6 @@ import (
 
 // TODO incorporate Alex Morcos' modifications to Gavin's initial model
 // https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2014-October/006824.html
-
-// TODO store and restore the FeeEstimator state in the database.
 
 const (
 	// estimateFeeDepth is the maximum number of blocks before a transaction
@@ -46,6 +48,12 @@ const (
 	bytePerKb = 1024
 
 	btcPerSatoshi = 1E-8
+)
+
+var (
+	// EstimateFeeDatabaseKey is the key that we use to
+	// store the fee estimator in the database.
+	EstimateFeeDatabaseKey = []byte("estimatefee")
 )
 
 // SatoshiPerByte is number with units of satoshis per byte.
@@ -99,6 +107,29 @@ type observedTransaction struct {
 	mined int32
 }
 
+func (o *observedTransaction) Serialize(w io.Writer) {
+	binary.Write(w, binary.BigEndian, o.hash)
+	binary.Write(w, binary.BigEndian, o.feeRate)
+	binary.Write(w, binary.BigEndian, o.observed)
+	binary.Write(w, binary.BigEndian, o.mined)
+}
+
+func deserializeObservedTransaction(r io.Reader) (*observedTransaction, error) {
+	ot := observedTransaction{}
+
+	// The first 32 bytes should be a hash.
+	binary.Read(r, binary.BigEndian, &ot.hash)
+
+	// The next 8 are SatoshiPerByte
+	binary.Read(r, binary.BigEndian, &ot.feeRate)
+
+	// And next there are two uint32's.
+	binary.Read(r, binary.BigEndian, &ot.observed)
+	binary.Read(r, binary.BigEndian, &ot.mined)
+
+	return &ot, nil
+}
+
 // registeredBlock has the hash of a block and the list of transactions
 // it mined which had been previously observed by the FeeEstimator. It
 // is used if Rollback is called to reverse the effect of registering
@@ -106,6 +137,15 @@ type observedTransaction struct {
 type registeredBlock struct {
 	hash         chainhash.Hash
 	transactions []*observedTransaction
+}
+
+func (rb *registeredBlock) serialize(w io.Writer, txs map[*observedTransaction]uint32) {
+	binary.Write(w, binary.BigEndian, rb.hash)
+
+	binary.Write(w, binary.BigEndian, uint32(len(rb.transactions)))
+	for _, o := range rb.transactions {
+		binary.Write(w, binary.BigEndian, txs[o])
+	}
 }
 
 // FeeEstimator manages the data necessary to create
@@ -532,4 +572,178 @@ func (ef *FeeEstimator) EstimateFee(numBlocks uint32) (BtcPerKilobyte, error) {
 	}
 
 	return ef.cached[int(numBlocks)-1].ToBtcPerKb(), nil
+}
+
+// In case the format for the serialized version of the FeeEstimator changes,
+// we use a version number. If the version number changes, it does not make
+// sense to try to upgrade a previous version to a new version. Instead, just
+// start fee estimation over.
+const estimateFeeSaveVersion = 1
+
+func deserializeRegisteredBlock(r io.Reader, txs map[uint32]*observedTransaction) (*registeredBlock, error) {
+	var lenTransactions uint32
+
+	rb := &registeredBlock{}
+	binary.Read(r, binary.BigEndian, &rb.hash)
+	binary.Read(r, binary.BigEndian, &lenTransactions)
+
+	rb.transactions = make([]*observedTransaction, lenTransactions)
+
+	for i := uint32(0); i < lenTransactions; i++ {
+		var index uint32
+		binary.Read(r, binary.BigEndian, &index)
+		rb.transactions[i] = txs[index]
+	}
+
+	return rb, nil
+}
+
+// FeeEstimatorState represents a saved FeeEstimator that can be
+// restored with data from an earlier session of the program.
+type FeeEstimatorState []byte
+
+// observedTxSet is a set of txs that can that is sorted
+// by hash. It exists for serialization purposes so that
+// a serialized state always comes out the same.
+type observedTxSet []*observedTransaction
+
+func (q observedTxSet) Len() int { return len(q) }
+
+func (q observedTxSet) Less(i, j int) bool {
+	return strings.Compare(q[i].hash.String(), q[j].hash.String()) < 0
+}
+
+func (q observedTxSet) Swap(i, j int) {
+	q[i], q[j] = q[j], q[i]
+}
+
+// Save records the current state of the FeeEstimator to a []byte that
+// can be restored later.
+func (ef *FeeEstimator) Save() FeeEstimatorState {
+	ef.mtx.Lock()
+	defer ef.mtx.Unlock()
+
+	// TODO figure out what the capacity should be.
+	w := bytes.NewBuffer(make([]byte, 0))
+
+	binary.Write(w, binary.BigEndian, uint32(estimateFeeSaveVersion))
+
+	// Insert basic parameters.
+	binary.Write(w, binary.BigEndian, &ef.maxRollback)
+	binary.Write(w, binary.BigEndian, &ef.binSize)
+	binary.Write(w, binary.BigEndian, &ef.maxReplacements)
+	binary.Write(w, binary.BigEndian, &ef.minRegisteredBlocks)
+	binary.Write(w, binary.BigEndian, &ef.lastKnownHeight)
+	binary.Write(w, binary.BigEndian, &ef.numBlocksRegistered)
+
+	// Put all the observed transactions in a sorted list.
+	var txCount uint32
+	ots := make([]*observedTransaction, len(ef.observed))
+	for hash := range ef.observed {
+		ots[txCount] = ef.observed[hash]
+		txCount++
+	}
+
+	sort.Sort(observedTxSet(ots))
+
+	txCount = 0
+	observed := make(map[*observedTransaction]uint32)
+	binary.Write(w, binary.BigEndian, uint32(len(ef.observed)))
+	for _, ot := range ots {
+		ot.Serialize(w)
+		observed[ot] = txCount
+		txCount++
+	}
+
+	// Save all the right bins.
+	for _, list := range ef.bin {
+
+		binary.Write(w, binary.BigEndian, uint32(len(list)))
+
+		for _, o := range list {
+			binary.Write(w, binary.BigEndian, observed[o])
+		}
+	}
+
+	// Dropped transactions.
+	binary.Write(w, binary.BigEndian, uint32(len(ef.dropped)))
+	for _, registered := range ef.dropped {
+		registered.serialize(w, observed)
+	}
+
+	// Commit the tx and return.
+	return FeeEstimatorState(w.Bytes())
+}
+
+// RestoreFeeEstimator takes a FeeEstimatorState that was previously
+// returned by Save and restores it to a FeeEstimator
+func RestoreFeeEstimator(data FeeEstimatorState) (*FeeEstimator, error) {
+	r := bytes.NewReader([]byte(data))
+
+	// Check version
+	var version uint32
+	err := binary.Read(r, binary.BigEndian, &version)
+	if err != nil {
+		return nil, err
+	}
+	if version != estimateFeeSaveVersion {
+		return nil, fmt.Errorf("Incorrect version: expected %d found %d", estimateFeeSaveVersion, version)
+	}
+
+	ef := &FeeEstimator{
+		observed: make(map[chainhash.Hash]*observedTransaction),
+	}
+
+	// Read basic parameters.
+	binary.Read(r, binary.BigEndian, &ef.maxRollback)
+	binary.Read(r, binary.BigEndian, &ef.binSize)
+	binary.Read(r, binary.BigEndian, &ef.maxReplacements)
+	binary.Read(r, binary.BigEndian, &ef.minRegisteredBlocks)
+	binary.Read(r, binary.BigEndian, &ef.lastKnownHeight)
+	binary.Read(r, binary.BigEndian, &ef.numBlocksRegistered)
+
+	// Read transactions.
+	var numObserved uint32
+	observed := make(map[uint32]*observedTransaction)
+	binary.Read(r, binary.BigEndian, &numObserved)
+	for i := uint32(0); i < numObserved; i++ {
+		ot, err := deserializeObservedTransaction(r)
+		if err != nil {
+			return nil, err
+		}
+		observed[i] = ot
+		ef.observed[ot.hash] = ot
+	}
+
+	// Read bins.
+	for i := 0; i < estimateFeeDepth; i++ {
+		var numTransactions uint32
+		binary.Read(r, binary.BigEndian, &numTransactions)
+		bin := make([]*observedTransaction, numTransactions)
+		for j := uint32(0); j < numTransactions; j++ {
+			var index uint32
+			binary.Read(r, binary.BigEndian, &index)
+
+			var exists bool
+			bin[j], exists = observed[index]
+			if !exists {
+				return nil, fmt.Errorf("Invalid transaction reference %d", index)
+			}
+		}
+		ef.bin[i] = bin
+	}
+
+	// Read dropped transactions.
+	var numDropped uint32
+	binary.Read(r, binary.BigEndian, &numDropped)
+	ef.dropped = make([]*registeredBlock, numDropped)
+	for i := uint32(0); i < numDropped; i++ {
+		var err error
+		ef.dropped[int(i)], err = deserializeRegisteredBlock(r, observed)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return ef, nil
 }

--- a/mempool/estimatefee_test.go
+++ b/mempool/estimatefee_test.go
@@ -1,0 +1,330 @@
+// Copyright (c) 2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package mempool
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/mining"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+)
+
+// newTestFeeEstimator creates a feeEstimator with some different parameters
+// for testing purposes.
+func newTestFeeEstimator(binSize, maxReplacements, maxRollback uint32) *FeeEstimator {
+	return &FeeEstimator{
+		maxRollback:         maxRollback,
+		lastKnownHeight:     mining.UnminedHeight,
+		binSize:             int(binSize),
+		minRegisteredBlocks: 0,
+		maxReplacements:     int(maxReplacements),
+		observed:            make(map[chainhash.Hash]observedTransaction),
+		dropped:             make([]registeredBlock, 0, maxRollback),
+	}
+}
+
+type estimateFeeTester struct {
+	t       *testing.T
+	version int32
+	height  int32
+}
+
+func (eft *estimateFeeTester) testTx(fee btcutil.Amount) *TxDesc {
+	eft.version++
+	return &TxDesc{
+		TxDesc: mining.TxDesc{
+			Tx: btcutil.NewTx(&wire.MsgTx{
+				Version: eft.version,
+			}),
+			Height: eft.height,
+			Fee:    int64(fee),
+		},
+		StartingPriority: 0,
+	}
+}
+
+func expectedFeePerByte(t *TxDesc) SatoshiPerByte {
+	size := float64(t.TxDesc.Tx.MsgTx().SerializeSize())
+	fee := float64(t.TxDesc.Fee)
+
+	return SatoshiPerByte(fee / size * 1E-8)
+}
+
+func (eft *estimateFeeTester) testBlock(txs []*wire.MsgTx) *btcutil.Block {
+
+	eft.height++
+	block := btcutil.NewBlock(&wire.MsgBlock{
+		Transactions: txs,
+	})
+	block.SetHeight(eft.height)
+
+	return block
+}
+
+func TestEstimateFee(t *testing.T) {
+	ef := newTestFeeEstimator(5, 3, 0)
+	eft := estimateFeeTester{t: t}
+
+	// Try with no txs and get zero for all queries.
+	expected := SatoshiPerByte(0.0)
+	for i := uint32(1); i <= estimateFeeDepth; i++ {
+		estimated, _ := ef.EstimateFee(i)
+
+		if estimated != expected {
+			t.Errorf("Estimate fee error: expected %f when estimator is empty; got %f", expected, estimated)
+		}
+	}
+
+	// Now insert a tx.
+	tx := eft.testTx(1000000)
+	ef.ObserveTransaction(tx)
+
+	// Expected should still be zero because this is still in the mempool.
+	expected = SatoshiPerByte(0.0)
+	for i := uint32(1); i <= estimateFeeDepth; i++ {
+		estimated, _ := ef.EstimateFee(i)
+
+		if estimated != expected {
+			t.Errorf("Estimate fee error: expected %f when estimator has one tx in mempool; got %f", expected, estimated)
+		}
+	}
+
+	// Change minRegisteredBlocks to make sure that works. Error return
+	// value expected.
+	ef.minRegisteredBlocks = 1
+	expected = SatoshiPerByte(-1.0)
+	for i := uint32(1); i <= estimateFeeDepth; i++ {
+		estimated, _ := ef.EstimateFee(i)
+
+		if estimated != expected {
+			t.Errorf("Estimate fee error: expected %f before any blocks have been registered; got %f", expected, estimated)
+		}
+	}
+
+	// Record a block.
+	ef.RegisterBlock(eft.testBlock([]*wire.MsgTx{tx.Tx.MsgTx()}))
+	expected = expectedFeePerByte(tx)
+	for i := uint32(1); i <= estimateFeeDepth; i++ {
+		estimated, _ := ef.EstimateFee(i)
+
+		if estimated != expected {
+			t.Errorf("Estimate fee error: expected %f when one tx is binned; got %f", expected, estimated)
+		}
+	}
+
+	// Create some more transactions.
+	txA := eft.testTx(500000)
+	txB := eft.testTx(2000000)
+	txC := eft.testTx(4000000)
+	ef.ObserveTransaction(txA)
+	ef.ObserveTransaction(txB)
+	ef.ObserveTransaction(txC)
+
+	// Record 8 empty blocks.
+	for i := 0; i < 8; i++ {
+		ef.RegisterBlock(eft.testBlock([]*wire.MsgTx{}))
+	}
+
+	// Mine the first tx.
+	ef.RegisterBlock(eft.testBlock([]*wire.MsgTx{txA.Tx.MsgTx()}))
+
+	// Now the estimated amount should depend on the value
+	// of the argument to estimate fee.
+	for i := uint32(1); i <= estimateFeeDepth; i++ {
+		estimated, _ := ef.EstimateFee(i)
+		if i > 8 {
+			expected = expectedFeePerByte(txA)
+		} else {
+			expected = expectedFeePerByte(tx)
+		}
+		if estimated != expected {
+			t.Errorf("Estimate fee error: expected %f on round %d; got %f", expected, i, estimated)
+		}
+	}
+
+	// Record 5 more empty blocks.
+	for i := 0; i < 5; i++ {
+		ef.RegisterBlock(eft.testBlock([]*wire.MsgTx{}))
+	}
+
+	// Mine the next tx.
+	ef.RegisterBlock(eft.testBlock([]*wire.MsgTx{txB.Tx.MsgTx()}))
+
+	// Now the estimated amount should depend on the value
+	// of the argument to estimate fee.
+	for i := uint32(1); i <= estimateFeeDepth; i++ {
+		estimated, _ := ef.EstimateFee(i)
+		if i <= 8 {
+			expected = expectedFeePerByte(txB)
+		} else if i <= 8+6 {
+			expected = expectedFeePerByte(tx)
+		} else {
+			expected = expectedFeePerByte(txA)
+		}
+
+		if estimated != expected {
+			t.Errorf("Estimate fee error: expected %f on round %d; got %f", expected, i, estimated)
+		}
+	}
+
+	// Record 9 more empty blocks.
+	for i := 0; i < 10; i++ {
+		ef.RegisterBlock(eft.testBlock([]*wire.MsgTx{}))
+	}
+
+	// Mine txC.
+	ef.RegisterBlock(eft.testBlock([]*wire.MsgTx{txC.Tx.MsgTx()}))
+
+	// This should have no effect on the outcome because too
+	// many blocks have been mined for txC to be recorded.
+	for i := uint32(1); i <= estimateFeeDepth; i++ {
+		estimated, _ := ef.EstimateFee(i)
+		if i <= 8 {
+			expected = expectedFeePerByte(txB)
+		} else if i <= 8+6 {
+			expected = expectedFeePerByte(tx)
+		} else {
+			expected = expectedFeePerByte(txA)
+		}
+
+		if estimated != expected {
+			t.Errorf("Estimate fee error: expected %f on round %d; got %f", expected, i, estimated)
+		}
+	}
+}
+
+func (eft *estimateFeeTester) estimates(ef *FeeEstimator) [estimateFeeDepth]SatoshiPerByte {
+
+	// Generate estimates
+	var estimates [estimateFeeDepth]SatoshiPerByte
+	for i := 0; i < estimateFeeDepth; i++ {
+		estimates[i], _ = ef.EstimateFee(1)
+	}
+
+	// Check that all estimated fee results go in descending order.
+	for i := 1; i < estimateFeeDepth; i++ {
+		if estimates[i] > estimates[i-1] {
+			eft.t.Error("Estimates not in descending order.")
+		}
+	}
+
+	return estimates
+}
+
+func (eft *estimateFeeTester) round(ef *FeeEstimator,
+	txHistory [][]*TxDesc, blockHistory []*btcutil.Block,
+	estimateHistory [][estimateFeeDepth]SatoshiPerByte,
+	txPerRound, txPerBlock, maxRollback uint32) ([][]*TxDesc,
+	[]*btcutil.Block, [][estimateFeeDepth]SatoshiPerByte) {
+
+	// generate new txs.
+	var newTxs []*TxDesc
+	for i := uint32(0); i < txPerRound; i++ {
+		newTx := eft.testTx(btcutil.Amount(rand.Intn(1000000)))
+		ef.ObserveTransaction(newTx)
+		newTxs = append(newTxs, newTx)
+	}
+
+	// Construct new tx history.
+	txHistory = append(txHistory, newTxs)
+	if len(txHistory) > estimateFeeDepth {
+		txHistory = txHistory[1 : estimateFeeDepth+1]
+	}
+
+	// generate new block, with no duplicates.
+	newBlockTxs := make(map[chainhash.Hash]*wire.MsgTx)
+	i := uint32(0)
+	for i < txPerBlock {
+		n := rand.Intn(len(txHistory))
+		m := rand.Intn(int(txPerRound))
+
+		tx := txHistory[n][m]
+		hash := *tx.Tx.Hash()
+
+		if _, ok := newBlockTxs[hash]; ok {
+			continue
+		}
+
+		newBlockTxs[hash] = tx.Tx.MsgTx()
+		i++
+	}
+
+	var newBlockList []*wire.MsgTx
+	for _, tx := range newBlockTxs {
+		newBlockList = append(newBlockList, tx)
+	}
+
+	newBlock := eft.testBlock(newBlockList)
+	ef.RegisterBlock(newBlock)
+
+	// return results.
+	estimates := eft.estimates(ef)
+
+	// Return results
+	blockHistory = append(blockHistory, newBlock)
+	if len(blockHistory) > int(maxRollback) {
+		blockHistory = blockHistory[1 : maxRollback+1]
+	}
+
+	return txHistory, blockHistory, append(estimateHistory, estimates)
+}
+
+func TestEstimateFeeRollback(t *testing.T) {
+	txPerRound := uint32(20)
+	txPerBlock := uint32(10)
+	binSize := uint32(5)
+	maxReplacements := uint32(3)
+	stepsBack := 2
+	rounds := 30
+
+	ef := newTestFeeEstimator(binSize, maxReplacements, uint32(stepsBack))
+	eft := estimateFeeTester{t: t}
+	var txHistory [][]*TxDesc
+	var blockHistory []*btcutil.Block
+	estimateHistory := [][estimateFeeDepth]SatoshiPerByte{eft.estimates(ef)}
+
+	// Make some initial rounds so that we have room to step back.
+	for round := 0; round < stepsBack-1; round++ {
+		txHistory, blockHistory, estimateHistory =
+			eft.round(ef, txHistory, blockHistory, estimateHistory,
+				txPerRound, txPerBlock, uint32(stepsBack))
+	}
+
+	for round := 0; round < rounds; round++ {
+		txHistory, blockHistory, estimateHistory =
+			eft.round(ef, txHistory, blockHistory, estimateHistory,
+				txPerRound, txPerBlock, uint32(stepsBack))
+
+		for step := 0; step < stepsBack; step++ {
+			err := ef.rollback()
+			if err != nil {
+				t.Fatal("Could not rollback: ", err)
+			}
+
+			expected := estimateHistory[len(estimateHistory)-step-2]
+			estimates := eft.estimates(ef)
+
+			// Ensure that these are both the same.
+			for i := 0; i < estimateFeeDepth; i++ {
+				if expected[i] != estimates[i] {
+					t.Errorf("Rollback value mismatch. Expected %f, got %f. ",
+						expected[i], estimates[i])
+				}
+			}
+		}
+
+		// Remove last estries from estimateHistory
+		estimateHistory = estimateHistory[0 : len(estimateHistory)-stepsBack]
+
+		// replay the previous blocks.
+		for b := 0; b < stepsBack; b++ {
+			ef.RegisterBlock(blockHistory[b])
+			estimateHistory = append(estimateHistory, eft.estimates(ef))
+		}
+	}
+}

--- a/mempool/estimatefee_test.go
+++ b/mempool/estimatefee_test.go
@@ -19,19 +19,30 @@ import (
 func newTestFeeEstimator(binSize, maxReplacements, maxRollback uint32) *FeeEstimator {
 	return &FeeEstimator{
 		maxRollback:         maxRollback,
-		lastKnownHeight:     mining.UnminedHeight,
-		binSize:             int(binSize),
+		lastKnownHeight:     0,
+		binSize:             int32(binSize),
 		minRegisteredBlocks: 0,
-		maxReplacements:     int(maxReplacements),
-		observed:            make(map[chainhash.Hash]observedTransaction),
-		dropped:             make([]registeredBlock, 0, maxRollback),
+		maxReplacements:     int32(maxReplacements),
+		observed:            make(map[chainhash.Hash]*observedTransaction),
+		dropped:             make([]*registeredBlock, 0, maxRollback),
 	}
 }
 
+// lastBlock is a linked list of the block hashes which have been
+// processed by the test FeeEstimator.
+type lastBlock struct {
+	hash *chainhash.Hash
+	prev *lastBlock
+}
+
+// estimateFeeTester interacts with the FeeEstimator to keep track
+// of its expected state.
 type estimateFeeTester struct {
+	ef      *FeeEstimator
 	t       *testing.T
 	version int32
 	height  int32
+	last    *lastBlock
 }
 
 func (eft *estimateFeeTester) testTx(fee btcutil.Amount) *TxDesc {
@@ -48,30 +59,48 @@ func (eft *estimateFeeTester) testTx(fee btcutil.Amount) *TxDesc {
 	}
 }
 
-func expectedFeePerByte(t *TxDesc) SatoshiPerByte {
+func expectedFeePerKilobyte(t *TxDesc) BtcPerKilobyte {
 	size := float64(t.TxDesc.Tx.MsgTx().SerializeSize())
 	fee := float64(t.TxDesc.Fee)
 
-	return SatoshiPerByte(fee / size * 1E-8)
+	return SatoshiPerByte(fee / size).ToBtcPerKb()
 }
 
-func (eft *estimateFeeTester) testBlock(txs []*wire.MsgTx) *btcutil.Block {
-
+func (eft *estimateFeeTester) newBlock(txs []*wire.MsgTx) {
 	eft.height++
+
 	block := btcutil.NewBlock(&wire.MsgBlock{
 		Transactions: txs,
 	})
 	block.SetHeight(eft.height)
 
-	return block
+	eft.last = &lastBlock{block.Hash(), eft.last}
+
+	eft.ef.RegisterBlock(block)
 }
 
+func (eft *estimateFeeTester) rollback() {
+	if eft.last == nil {
+		return
+	}
+
+	err := eft.ef.Rollback(eft.last.hash)
+
+	if err != nil {
+		eft.t.Errorf("Could not rollback: %v", err)
+	}
+
+	eft.height--
+	eft.last = eft.last.prev
+}
+
+// TestEstimateFee tests basic functionality in the FeeEstimator.
 func TestEstimateFee(t *testing.T) {
-	ef := newTestFeeEstimator(5, 3, 0)
-	eft := estimateFeeTester{t: t}
+	ef := newTestFeeEstimator(5, 3, 1)
+	eft := estimateFeeTester{ef: ef, t: t}
 
 	// Try with no txs and get zero for all queries.
-	expected := SatoshiPerByte(0.0)
+	expected := BtcPerKilobyte(0.0)
 	for i := uint32(1); i <= estimateFeeDepth; i++ {
 		estimated, _ := ef.EstimateFee(i)
 
@@ -85,7 +114,7 @@ func TestEstimateFee(t *testing.T) {
 	ef.ObserveTransaction(tx)
 
 	// Expected should still be zero because this is still in the mempool.
-	expected = SatoshiPerByte(0.0)
+	expected = BtcPerKilobyte(0.0)
 	for i := uint32(1); i <= estimateFeeDepth; i++ {
 		estimated, _ := ef.EstimateFee(i)
 
@@ -97,7 +126,7 @@ func TestEstimateFee(t *testing.T) {
 	// Change minRegisteredBlocks to make sure that works. Error return
 	// value expected.
 	ef.minRegisteredBlocks = 1
-	expected = SatoshiPerByte(-1.0)
+	expected = BtcPerKilobyte(-1.0)
 	for i := uint32(1); i <= estimateFeeDepth; i++ {
 		estimated, _ := ef.EstimateFee(i)
 
@@ -106,9 +135,35 @@ func TestEstimateFee(t *testing.T) {
 		}
 	}
 
-	// Record a block.
-	ef.RegisterBlock(eft.testBlock([]*wire.MsgTx{tx.Tx.MsgTx()}))
-	expected = expectedFeePerByte(tx)
+	// Record a block with the new tx.
+	eft.newBlock([]*wire.MsgTx{tx.Tx.MsgTx()})
+	expected = expectedFeePerKilobyte(tx)
+	for i := uint32(1); i <= estimateFeeDepth; i++ {
+		estimated, _ := ef.EstimateFee(i)
+
+		if estimated != expected {
+			t.Errorf("Estimate fee error: expected %f when one tx is binned; got %f", expected, estimated)
+		}
+	}
+
+	// Roll back the last block; this was an orphan block.
+	ef.minRegisteredBlocks = 0
+	eft.rollback()
+	expected = BtcPerKilobyte(0.0)
+	for i := uint32(1); i <= estimateFeeDepth; i++ {
+		estimated, _ := ef.EstimateFee(i)
+
+		if estimated != expected {
+			t.Errorf("Estimate fee error: expected %f after rolling back block; got %f", expected, estimated)
+		}
+	}
+
+	// Record an empty block and then a block with the new tx.
+	// This test was made because of a bug that only appeared when there
+	// were no transactions in the first bin.
+	eft.newBlock([]*wire.MsgTx{})
+	eft.newBlock([]*wire.MsgTx{tx.Tx.MsgTx()})
+	expected = expectedFeePerKilobyte(tx)
 	for i := uint32(1); i <= estimateFeeDepth; i++ {
 		estimated, _ := ef.EstimateFee(i)
 
@@ -125,22 +180,22 @@ func TestEstimateFee(t *testing.T) {
 	ef.ObserveTransaction(txB)
 	ef.ObserveTransaction(txC)
 
-	// Record 8 empty blocks.
-	for i := 0; i < 8; i++ {
-		ef.RegisterBlock(eft.testBlock([]*wire.MsgTx{}))
+	// Record 7 empty blocks.
+	for i := 0; i < 7; i++ {
+		eft.newBlock([]*wire.MsgTx{})
 	}
 
 	// Mine the first tx.
-	ef.RegisterBlock(eft.testBlock([]*wire.MsgTx{txA.Tx.MsgTx()}))
+	eft.newBlock([]*wire.MsgTx{txA.Tx.MsgTx()})
 
 	// Now the estimated amount should depend on the value
 	// of the argument to estimate fee.
 	for i := uint32(1); i <= estimateFeeDepth; i++ {
 		estimated, _ := ef.EstimateFee(i)
-		if i > 8 {
-			expected = expectedFeePerByte(txA)
+		if i > 2 {
+			expected = expectedFeePerKilobyte(txA)
 		} else {
-			expected = expectedFeePerByte(tx)
+			expected = expectedFeePerKilobyte(tx)
 		}
 		if estimated != expected {
 			t.Errorf("Estimate fee error: expected %f on round %d; got %f", expected, i, estimated)
@@ -149,22 +204,22 @@ func TestEstimateFee(t *testing.T) {
 
 	// Record 5 more empty blocks.
 	for i := 0; i < 5; i++ {
-		ef.RegisterBlock(eft.testBlock([]*wire.MsgTx{}))
+		eft.newBlock([]*wire.MsgTx{})
 	}
 
 	// Mine the next tx.
-	ef.RegisterBlock(eft.testBlock([]*wire.MsgTx{txB.Tx.MsgTx()}))
+	eft.newBlock([]*wire.MsgTx{txB.Tx.MsgTx()})
 
 	// Now the estimated amount should depend on the value
 	// of the argument to estimate fee.
 	for i := uint32(1); i <= estimateFeeDepth; i++ {
 		estimated, _ := ef.EstimateFee(i)
-		if i <= 8 {
-			expected = expectedFeePerByte(txB)
-		} else if i <= 8+6 {
-			expected = expectedFeePerByte(tx)
+		if i <= 2 {
+			expected = expectedFeePerKilobyte(txB)
+		} else if i <= 8 {
+			expected = expectedFeePerKilobyte(tx)
 		} else {
-			expected = expectedFeePerByte(txA)
+			expected = expectedFeePerKilobyte(txA)
 		}
 
 		if estimated != expected {
@@ -174,22 +229,24 @@ func TestEstimateFee(t *testing.T) {
 
 	// Record 9 more empty blocks.
 	for i := 0; i < 10; i++ {
-		ef.RegisterBlock(eft.testBlock([]*wire.MsgTx{}))
+		eft.newBlock([]*wire.MsgTx{})
 	}
 
 	// Mine txC.
-	ef.RegisterBlock(eft.testBlock([]*wire.MsgTx{txC.Tx.MsgTx()}))
+	eft.newBlock([]*wire.MsgTx{txC.Tx.MsgTx()})
 
 	// This should have no effect on the outcome because too
 	// many blocks have been mined for txC to be recorded.
 	for i := uint32(1); i <= estimateFeeDepth; i++ {
 		estimated, _ := ef.EstimateFee(i)
-		if i <= 8 {
-			expected = expectedFeePerByte(txB)
+		if i <= 2 {
+			expected = expectedFeePerKilobyte(txC)
+		} else if i <= 8 {
+			expected = expectedFeePerKilobyte(txB)
 		} else if i <= 8+6 {
-			expected = expectedFeePerByte(tx)
+			expected = expectedFeePerKilobyte(tx)
 		} else {
-			expected = expectedFeePerByte(txA)
+			expected = expectedFeePerKilobyte(txA)
 		}
 
 		if estimated != expected {
@@ -198,133 +255,112 @@ func TestEstimateFee(t *testing.T) {
 	}
 }
 
-func (eft *estimateFeeTester) estimates(ef *FeeEstimator) [estimateFeeDepth]SatoshiPerByte {
+func (eft *estimateFeeTester) estimates() [estimateFeeDepth]BtcPerKilobyte {
 
 	// Generate estimates
-	var estimates [estimateFeeDepth]SatoshiPerByte
+	var estimates [estimateFeeDepth]BtcPerKilobyte
 	for i := 0; i < estimateFeeDepth; i++ {
-		estimates[i], _ = ef.EstimateFee(1)
+		estimates[i], _ = eft.ef.EstimateFee(uint32(i + 1))
 	}
 
 	// Check that all estimated fee results go in descending order.
 	for i := 1; i < estimateFeeDepth; i++ {
 		if estimates[i] > estimates[i-1] {
-			eft.t.Error("Estimates not in descending order.")
+			eft.t.Error("Estimates not in descending order; got ",
+				estimates[i], " for estimate ", i, " and ", estimates[i-1], " for ", (i - 1))
+			panic("invalid state.")
 		}
 	}
 
 	return estimates
 }
 
-func (eft *estimateFeeTester) round(ef *FeeEstimator,
-	txHistory [][]*TxDesc, blockHistory []*btcutil.Block,
-	estimateHistory [][estimateFeeDepth]SatoshiPerByte,
-	txPerRound, txPerBlock, maxRollback uint32) ([][]*TxDesc,
-	[]*btcutil.Block, [][estimateFeeDepth]SatoshiPerByte) {
+func (eft *estimateFeeTester) round(txHistory [][]*TxDesc,
+	estimateHistory [][estimateFeeDepth]BtcPerKilobyte,
+	txPerRound, txPerBlock uint32) ([][]*TxDesc, [][estimateFeeDepth]BtcPerKilobyte) {
 
 	// generate new txs.
 	var newTxs []*TxDesc
 	for i := uint32(0); i < txPerRound; i++ {
 		newTx := eft.testTx(btcutil.Amount(rand.Intn(1000000)))
-		ef.ObserveTransaction(newTx)
+		eft.ef.ObserveTransaction(newTx)
 		newTxs = append(newTxs, newTx)
 	}
 
-	// Construct new tx history.
-	txHistory = append(txHistory, newTxs)
-	if len(txHistory) > estimateFeeDepth {
-		txHistory = txHistory[1 : estimateFeeDepth+1]
+	// Generate mempool.
+	mempool := make(map[*observedTransaction]*TxDesc)
+	for _, h := range txHistory {
+		for _, t := range h {
+			if o, exists := eft.ef.observed[*t.Tx.Hash()]; exists && o.mined == mining.UnminedHeight {
+				mempool[o] = t
+			}
+		}
 	}
 
 	// generate new block, with no duplicates.
-	newBlockTxs := make(map[chainhash.Hash]*wire.MsgTx)
 	i := uint32(0)
-	for i < txPerBlock {
-		n := rand.Intn(len(txHistory))
-		m := rand.Intn(int(txPerRound))
-
-		tx := txHistory[n][m]
-		hash := *tx.Tx.Hash()
-
-		if _, ok := newBlockTxs[hash]; ok {
-			continue
-		}
-
-		newBlockTxs[hash] = tx.Tx.MsgTx()
+	newBlockList := make([]*wire.MsgTx, 0, txPerBlock)
+	for _, t := range mempool {
+		newBlockList = append(newBlockList, t.TxDesc.Tx.MsgTx())
 		i++
+
+		if i == txPerBlock {
+			break
+		}
 	}
 
-	var newBlockList []*wire.MsgTx
-	for _, tx := range newBlockTxs {
-		newBlockList = append(newBlockList, tx)
-	}
-
-	newBlock := eft.testBlock(newBlockList)
-	ef.RegisterBlock(newBlock)
+	// Register a new block.
+	eft.newBlock(newBlockList)
 
 	// return results.
-	estimates := eft.estimates(ef)
+	estimates := eft.estimates()
 
 	// Return results
-	blockHistory = append(blockHistory, newBlock)
-	if len(blockHistory) > int(maxRollback) {
-		blockHistory = blockHistory[1 : maxRollback+1]
-	}
-
-	return txHistory, blockHistory, append(estimateHistory, estimates)
+	return append(txHistory, newTxs), append(estimateHistory, estimates)
 }
 
+// TestEstimateFeeRollback tests the rollback function, which undoes the
+// effect of a adding a new block.
 func TestEstimateFeeRollback(t *testing.T) {
-	txPerRound := uint32(20)
-	txPerBlock := uint32(10)
-	binSize := uint32(5)
-	maxReplacements := uint32(3)
+	txPerRound := uint32(7)
+	txPerBlock := uint32(5)
+	binSize := uint32(6)
+	maxReplacements := uint32(4)
 	stepsBack := 2
 	rounds := 30
 
-	ef := newTestFeeEstimator(binSize, maxReplacements, uint32(stepsBack))
-	eft := estimateFeeTester{t: t}
+	eft := estimateFeeTester{ef: newTestFeeEstimator(binSize, maxReplacements, uint32(stepsBack)), t: t}
 	var txHistory [][]*TxDesc
-	var blockHistory []*btcutil.Block
-	estimateHistory := [][estimateFeeDepth]SatoshiPerByte{eft.estimates(ef)}
-
-	// Make some initial rounds so that we have room to step back.
-	for round := 0; round < stepsBack-1; round++ {
-		txHistory, blockHistory, estimateHistory =
-			eft.round(ef, txHistory, blockHistory, estimateHistory,
-				txPerRound, txPerBlock, uint32(stepsBack))
-	}
+	estimateHistory := [][estimateFeeDepth]BtcPerKilobyte{eft.estimates()}
 
 	for round := 0; round < rounds; round++ {
-		txHistory, blockHistory, estimateHistory =
-			eft.round(ef, txHistory, blockHistory, estimateHistory,
-				txPerRound, txPerBlock, uint32(stepsBack))
+		// Go forward a few rounds.
+		for step := 0; step <= stepsBack; step++ {
+			txHistory, estimateHistory =
+				eft.round(txHistory, estimateHistory, txPerRound, txPerBlock)
+		}
 
+		// Now go back.
 		for step := 0; step < stepsBack; step++ {
-			err := ef.rollback()
-			if err != nil {
-				t.Fatal("Could not rollback: ", err)
-			}
+			eft.rollback()
 
+			// After rolling back, we should have the same estimated
+			// fees as before.
 			expected := estimateHistory[len(estimateHistory)-step-2]
-			estimates := eft.estimates(ef)
+			estimates := eft.estimates()
 
 			// Ensure that these are both the same.
 			for i := 0; i < estimateFeeDepth; i++ {
 				if expected[i] != estimates[i] {
 					t.Errorf("Rollback value mismatch. Expected %f, got %f. ",
 						expected[i], estimates[i])
+					return
 				}
 			}
 		}
 
-		// Remove last estries from estimateHistory
+		// Erase history.
+		txHistory = txHistory[0 : len(txHistory)-stepsBack]
 		estimateHistory = estimateHistory[0 : len(estimateHistory)-stepsBack]
-
-		// replay the previous blocks.
-		for b := 0; b < stepsBack; b++ {
-			ef.RegisterBlock(blockHistory[b])
-			estimateHistory = append(estimateHistory, eft.estimates(ef))
-		}
 	}
 }

--- a/netsync/interface.go
+++ b/netsync/interface.go
@@ -36,4 +36,6 @@ type Config struct {
 
 	DisableCheckpoints bool
 	MaxPeers           int
+
+	FeeEstimator *mempool.FeeEstimator
 }

--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -557,6 +557,43 @@ func (c *Client) GetRawMempoolVerbose() (map[string]btcjson.GetRawMempoolVerbose
 	return c.GetRawMempoolVerboseAsync().Receive()
 }
 
+// FutureEstimateFeeResult is a future promise to deliver the result of a
+// EstimateFeeAsync RPC invocation (or an applicable error).
+type FutureEstimateFeeResult chan *response
+
+// Receive waits for the response promised by the future and returns the info
+// provided by the server.
+func (r FutureEstimateFeeResult) Receive() (float64, error) {
+	res, err := receiveFuture(r)
+	if err != nil {
+		return -1, err
+	}
+
+	// Unmarshal result as a getinfo result object.
+	var fee float64
+	err = json.Unmarshal(res, &fee)
+	if err != nil {
+		return -1, err
+	}
+
+	return fee, nil
+}
+
+// EstimateFeeAsync returns an instance of a type that can be used to get the result
+// of the RPC at some future time by invoking the Receive function on the
+// returned instance.
+//
+// See EstimateFee for the blocking version and more details.
+func (c *Client) EstimateFeeAsync(numBlocks int64) FutureEstimateFeeResult {
+	cmd := btcjson.NewEstimateFeeCmd(numBlocks)
+	return c.sendCmd(cmd)
+}
+
+// EstimateFee provides an estimated fee  in bitcoins per kilobyte.
+func (c *Client) EstimateFee(numBlocks int64) (float64, error) {
+	return c.EstimateFeeAsync(numBlocks).Receive()
+}
+
 // FutureVerifyChainResult is a future promise to deliver the result of a
 // VerifyChainAsync, VerifyChainLevelAsyncRPC, or VerifyChainBlocksAsync
 // invocation (or an applicable error).

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -132,6 +132,7 @@ var rpcHandlersBeforeInit = map[string]commandHandler{
 	"debuglevel":            handleDebugLevel,
 	"decoderawtransaction":  handleDecodeRawTransaction,
 	"decodescript":          handleDecodeScript,
+	"estimatefee":           handleEstimateFee,
 	"generate":              handleGenerate,
 	"getaddednodeinfo":      handleGetAddedNodeInfo,
 	"getbestblock":          handleGetBestBlock,
@@ -222,7 +223,6 @@ var rpcAskWallet = map[string]struct{}{
 
 // Commands that are currently unimplemented, but should ultimately be.
 var rpcUnimplemented = map[string]struct{}{
-	"estimatefee":      {},
 	"estimatepriority": {},
 	"getchaintips":     {},
 	"getmempoolentry":  {},
@@ -252,6 +252,7 @@ var rpcLimited = map[string]struct{}{
 	"createrawtransaction":  {},
 	"decoderawtransaction":  {},
 	"decodescript":          {},
+	"estimatefee":           {},
 	"getbestblock":          {},
 	"getbestblockhash":      {},
 	"getblock":              {},
@@ -847,6 +848,28 @@ func handleDecodeScript(s *rpcServer, cmd interface{}, closeChan <-chan struct{}
 		reply.P2sh = p2sh.EncodeAddress()
 	}
 	return reply, nil
+}
+
+// handleEstimateFee handles estimatefee commands.
+func handleEstimateFee(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
+	c := cmd.(*btcjson.EstimateFeeCmd)
+
+	if s.cfg.FeeEstimator == nil {
+		return nil, errors.New("Fee estimation disabled")
+	}
+
+	if c.NumBlocks <= 0 {
+		return -1.0, errors.New("Parameter NumBlocks must be positive")
+	}
+
+	feeRate, err := s.cfg.FeeEstimator.EstimateFee(uint32(c.NumBlocks))
+
+	if err != nil {
+		return -1.0, err
+	}
+
+	// Convert to satoshis per kb.
+	return float64(feeRate.ToSatoshiPerKb()), nil
 }
 
 // handleGenerate handles generate commands.
@@ -4182,6 +4205,10 @@ type rpcserverConfig struct {
 	// of to provide additional data when queried.
 	TxIndex   *indexers.TxIndex
 	AddrIndex *indexers.AddrIndex
+
+	// The fee estimator keeps track of how long transactions are left in
+	// the mempool before they are mined into blocks.
+	FeeEstimator *mempool.FeeEstimator
 }
 
 // newRPCServer returns a new instance of the rpcServer struct.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -869,7 +869,7 @@ func handleEstimateFee(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 	}
 
 	// Convert to satoshis per kb.
-	return float64(feeRate.ToSatoshiPerKb()), nil
+	return float64(feeRate), nil
 }
 
 // handleGenerate handles generate commands.

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -115,6 +115,15 @@ var helpDescsEnUS = map[string]string{
 	"decodescript--synopsis": "Returns a JSON object with information about the provided hex-encoded script.",
 	"decodescript-hexscript": "Hex-encoded script",
 
+	// EstimateFeeCmd help.
+	"estimatefee--synopsis": "Estimate the fee per kilobyte in satoshis " +
+		"required for a transaction to be mined before a certain number of " +
+		"blocks have been generated.",
+	"estimatefee-numblocks": "The maximum number of blocks which can be " +
+		"generated before the transaction is mined.",
+	"estimatefee--result0": "Estimated fee per kilobyte in satoshis for a block to " +
+		"be mined in the next NumBlocks blocks.",
+
 	// GenerateCmd help
 	"generate--synopsis": "Generates a set number of blocks (simnet or regtest only) and returns a JSON\n" +
 		" array of their hashes.",
@@ -658,6 +667,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"debuglevel":            {(*string)(nil), (*string)(nil)},
 	"decoderawtransaction":  {(*btcjson.TxRawDecodeResult)(nil)},
 	"decodescript":          {(*btcjson.DecodeScriptResult)(nil)},
+	"estimatefee":           {(*float64)(nil)},
 	"generate":              {(*[]string)(nil)},
 	"getaddednodeinfo":      {(*[]string)(nil), (*[]btcjson.GetAddedNodeInfoResult)(nil)},
 	"getbestblock":          {(*btcjson.GetBestBlockResult)(nil)},

--- a/server.go
+++ b/server.go
@@ -2410,19 +2410,20 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		}
 
 		s.rpcServer, err = newRPCServer(&rpcserverConfig{
-			Listeners:   rpcListeners,
-			StartupTime: s.startupTime,
-			ConnMgr:     &rpcConnManager{&s},
-			SyncMgr:     &rpcSyncMgr{&s, s.syncManager},
-			TimeSource:  s.timeSource,
-			Chain:       s.chain,
-			ChainParams: chainParams,
-			DB:          db,
-			TxMemPool:   s.txMemPool,
-			Generator:   blockTemplateGenerator,
-			CPUMiner:    s.cpuMiner,
-			TxIndex:     s.txIndex,
-			AddrIndex:   s.addrIndex,
+			Listeners:    rpcListeners,
+			StartupTime:  s.startupTime,
+			ConnMgr:      &rpcConnManager{&s},
+			SyncMgr:      &rpcSyncMgr{&s, s.syncManager},
+			TimeSource:   s.timeSource,
+			Chain:        s.chain,
+			ChainParams:  chainParams,
+			DB:           db,
+			TxMemPool:    s.txMemPool,
+			Generator:    blockTemplateGenerator,
+			CPUMiner:     s.cpuMiner,
+			TxIndex:      s.txIndex,
+			AddrIndex:    s.addrIndex,
+			FeeEstimator: feeEstimator,
 		})
 		if err != nil {
 			return nil, err

--- a/server.go
+++ b/server.go
@@ -228,6 +228,10 @@ type server struct {
 	// do not need to be protected for concurrent access.
 	txIndex   *indexers.TxIndex
 	addrIndex *indexers.AddrIndex
+
+	// The fee estimator keeps track of how long transactions are left in
+	// the mempool before they are mined into blocks.
+	feeEstimator *mempool.FeeEstimator
 }
 
 // serverPeer extends the peer to maintain state shared by the server and
@@ -1953,6 +1957,14 @@ func (s *server) Stop() error {
 		s.rpcServer.Stop()
 	}
 
+	// Save fee estimator state in the database.
+	s.db.Update(func(tx database.Tx) error {
+		metadata := tx.Metadata()
+		metadata.Put(mempool.EstimateFeeDatabaseKey, s.feeEstimator.Save())
+
+		return nil
+	})
+
 	// Signal the remaining goroutines to quit.
 	close(s.quit)
 	return nil
@@ -2249,9 +2261,35 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		return nil, err
 	}
 
-	feeEstimator := mempool.NewFeeEstimator(
-		mempool.DefaultEstimateFeeMaxRollback,
-		mempool.DefaultEstimateFeeMinRegisteredBlocks)
+	// Search for a FeeEstimator state in the database. If none can be found
+	// or if it cannot be loaded, create a new one.
+	db.Update(func(tx database.Tx) error {
+		metadata := tx.Metadata()
+		feeEstimationData := metadata.Get(mempool.EstimateFeeDatabaseKey)
+		if feeEstimationData != nil {
+			// delete it from the database so that we don't try to restore the
+			// same thing again somehow.
+			metadata.Delete(mempool.EstimateFeeDatabaseKey)
+
+			// If there is an error, log it and make a new fee estimator.
+			var err error
+			s.feeEstimator, err = mempool.RestoreFeeEstimator(feeEstimationData)
+
+			if err != nil {
+				peerLog.Errorf("Failed to restore fee estimator %v", err)
+			}
+		}
+
+		return nil
+	})
+
+	// If no feeEstimator has been found, or if the one that has been found
+	// is behind somehow, create a new one and start over.
+	if s.feeEstimator == nil || s.feeEstimator.LastKnownHeight() != s.chain.BestSnapshot().Height {
+		s.feeEstimator = mempool.NewFeeEstimator(
+			mempool.DefaultEstimateFeeMaxRollback,
+			mempool.DefaultEstimateFeeMinRegisteredBlocks)
+	}
 
 	txC := mempool.Config{
 		Policy: mempool.Policy{
@@ -2275,7 +2313,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		SigCache:           s.sigCache,
 		HashCache:          s.hashCache,
 		AddrIndex:          s.addrIndex,
-		FeeEstimator:       feeEstimator,
+		FeeEstimator:       s.feeEstimator,
 	}
 	s.txMemPool = mempool.New(&txC)
 
@@ -2423,7 +2461,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 			CPUMiner:     s.cpuMiner,
 			TxIndex:      s.txIndex,
 			AddrIndex:    s.addrIndex,
-			FeeEstimator: feeEstimator,
+			FeeEstimator: s.feeEstimator,
 		})
 		if err != nil {
 			return nil, err

--- a/server.go
+++ b/server.go
@@ -2249,6 +2249,10 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		return nil, err
 	}
 
+	feeEstimator := mempool.NewFeeEstimator(
+		mempool.DefaultEstimateFeeMaxRollback,
+		mempool.DefaultEstimateFeeMinRegisteredBlocks)
+
 	txC := mempool.Config{
 		Policy: mempool.Policy{
 			DisableRelayPriority: cfg.NoRelayPriority,
@@ -2271,6 +2275,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		SigCache:           s.sigCache,
 		HashCache:          s.hashCache,
 		AddrIndex:          s.addrIndex,
+		FeeEstimator:       feeEstimator,
 	}
 	s.txMemPool = mempool.New(&txC)
 


### PR DESCRIPTION
This pr implements estimatefee similar to the way it works in Bitcoin Core, as described [here](https://github.com/bitcoin/bitcoin/pull/3959). estimatefee allows for one parameter, NumBlocks. It attempts to provide an estimated fee / kb rate (in Bitcoins) for a transaction to be confirmed before at least NumBlocks (inclusive) have been mined. 

Every time a transaction is added to the mempool, it is registered with the fee estimator. Every time a new block is received, it is also registered with the fee estimator. The fee estimator keeps 25 bins containing information on transactions for which 1 to 25 blocks have been mined before being put in a block. Each bin contains information on up to 100 transactions. 

Let m be a bijective map from all sots in all bins to the set if indices from 1 to N, where N is the number of transactions in all bins. m maps the first slot in the first bin to 1, the second to 2, and so on, all the way through all the bins. The value returned by estimatefee is the fee / kb value of the transactions whose index in a sorted list of all transactions (with the highest value first) is the same as m[s], where s is the middle slot in bin NumBlocks. estimatefee therefore is a monotonically decreasing function of NumBlocks. 

It is also possible to rollback the effect of a limited number of blocks in case of orphans. Default number of rollbacks allowed is 2. 

Since it is very easy to store 25 values, all results for all values of NumBlocks are cached when estimatefee is first called. Each time a new block is registered or rolled back, the cache is deleted. 

~~In core, the set of observed transactions is saved between sessions in a file that also contains mempool transactions. btcd doesn't seem to have a similar file, so fee estimation starts over if the program restarts.~~

The server saves the state of the FeeEstimator on shutdown into the database and tries to restore it upon initialization. If it cannot, then it creates a new FeeEstimator. 

~~A corresponding pr to btcrpcclient has been made [here](https://github.com/btcsuite/btcrpcclient/pull/87).~~
