### PR TITLE
server: Remove superfluous check in OnMemPool.

### DIFF
--- a/server.go
+++ b/server.go
@@ -426,18 +426,11 @@ func (sp *serverPeer) OnMemPool(p *peer.Peer, msg *wire.MsgMemPool) {
 	invMsg := wire.NewMsgInvSizeHint(uint(len(txDescs)))
 
 	for i, txDesc := range txDescs {
-		// Another thread might have removed the transaction from the
-		// pool since the initial query.
-		hash := txDesc.Tx.Hash()
-		if !txMemPool.IsTransactionInPool(hash) {
-			continue
-		}
-
 		// Either add all transactions when there is no bloom filter,
 		// or only the transactions that match the filter when there is
 		// one.
 		if !sp.filter.IsLoaded() || sp.filter.MatchTxAndUpdate(txDesc.Tx) {
-			iv := wire.NewInvVect(wire.InvTypeTx, hash)
+			iv := wire.NewInvVect(wire.InvTypeTx, txDesc.Tx.Hash())
 			invMsg.AddInvVect(iv)
 			if i+1 >= wire.MaxInvPerMsg {
 				break


### PR DESCRIPTION
This reduces the mempool lock contention by removing an unnecessary check when responding to a `mempool` request.

In particular, the code first gets a list of all transactions from the mempool and then iterates them in order to construct the inventory vectors and apply bloom filtering if it is enabled.  Since it is possible that the transaction was removed from the mempool by another thread while that list is being iterated, the code was checking if each transaction was still in the mempool.  This is a pointless check because the transaction might still be removed at any point after the check anyways.  For example, it might be removed after the mempool response has been sent to the remote peer or even while the loop is still iterating.