### PR TITLE
mempool: Refactor mempool code to its own package.

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/database"
+	"github.com/btcsuite/btcd/mempool"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 )
@@ -475,7 +476,7 @@ func (b *blockManager) handleTxMsg(tmsg *txMsg) {
 		// simply rejected as opposed to something actually going wrong,
 		// so log it as such.  Otherwise, something really did go wrong,
 		// so log it as an actual error.
-		if _, ok := err.(RuleError); ok {
+		if _, ok := err.(mempool.RuleError); ok {
 			bmgrLog.Debugf("Rejected transaction %v from %s: %v",
 				txHash, tmsg.peer, err)
 		} else {
@@ -485,7 +486,7 @@ func (b *blockManager) handleTxMsg(tmsg *txMsg) {
 
 		// Convert the error into an appropriate reject message and
 		// send it.
-		code, reason := errToRejectErr(err)
+		code, reason := mempool.ErrToRejectErr(err)
 		tmsg.peer.PushRejectMsg(wire.CmdTx, code, reason, txHash,
 			false)
 		return
@@ -585,7 +586,7 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 
 		// Convert the error into an appropriate reject message and
 		// send it.
-		code, reason := errToRejectErr(err)
+		code, reason := mempool.ErrToRejectErr(err)
 		bmsg.peer.PushRejectMsg(wire.CmdBlock, code, reason,
 			blockHash, false)
 		return

--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/btcsuite/btcd/database"
 	_ "github.com/btcsuite/btcd/database/ffldb"
+	"github.com/btcsuite/btcd/mempool"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 	flags "github.com/btcsuite/go-flags"
@@ -46,7 +47,6 @@ const (
 	defaultBlockMaxSize          = 750000
 	blockMaxSizeMin              = 1000
 	blockMaxSizeMax              = wire.MaxBlockPayload - 1000
-	defaultBlockPrioritySize     = 50000
 	defaultGenerate              = false
 	defaultMaxOrphanTransactions = 1000
 	defaultMaxOrphanTxSize       = 5000
@@ -344,11 +344,11 @@ func loadConfig() (*config, []string, error) {
 		DbType:            defaultDbType,
 		RPCKey:            defaultRPCKeyFile,
 		RPCCert:           defaultRPCCertFile,
-		MinRelayTxFee:     defaultMinRelayTxFee.ToBTC(),
+		MinRelayTxFee:     mempool.DefaultMinRelayTxFee.ToBTC(),
 		FreeTxRelayLimit:  defaultFreeTxRelayLimit,
 		BlockMinSize:      defaultBlockMinSize,
 		BlockMaxSize:      defaultBlockMaxSize,
-		BlockPrioritySize: defaultBlockPrioritySize,
+		BlockPrioritySize: mempool.DefaultBlockPrioritySize,
 		MaxOrphanTxs:      defaultMaxOrphanTransactions,
 		SigCacheMaxSize:   defaultSigCacheMaxSize,
 		Generate:          defaultGenerate,

--- a/log.go
+++ b/log.go
@@ -12,6 +12,7 @@ import (
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/blockchain/indexers"
 	"github.com/btcsuite/btcd/database"
+	"github.com/btcsuite/btcd/mempool"
 	"github.com/btcsuite/btcd/peer"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btclog"
@@ -136,6 +137,7 @@ func useLogger(subsystemID string, logger btclog.Logger) {
 
 	case "TXMP":
 		txmpLog = logger
+		mempool.UseLogger(logger)
 	}
 }
 

--- a/mempool/README.md
+++ b/mempool/README.md
@@ -1,0 +1,23 @@
+mempool
+=======
+
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
+(https://travis-ci.org/btcsuite/btcd) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcd/mempool)
+
+## Overview
+
+This package is currently a work in progress.
+
+## Installation and Updating
+
+```bash
+$ go get -u github.com/btcsuite/btcd/mempool
+```
+
+## License
+
+Package mempool is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/mempool/error.go
+++ b/mempool/error.go
@@ -1,8 +1,8 @@
-// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2014-2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package main
+package mempool
 
 import (
 	"github.com/btcsuite/btcd/blockchain"
@@ -109,9 +109,9 @@ func extractRejectCode(err error) (wire.RejectCode, bool) {
 	return wire.RejectInvalid, false
 }
 
-// errToRejectErr examines the underlying type of the error and returns a reject
+// ErrToRejectErr examines the underlying type of the error and returns a reject
 // code and string appropriate to be sent in a wire.MsgReject message.
-func errToRejectErr(err error) (wire.RejectCode, string) {
+func ErrToRejectErr(err error) (wire.RejectCode, string) {
 	// Return the reject code along with the error text if it can be
 	// extracted from the error.
 	rejectCode, found := extractRejectCode(err)

--- a/mempool/log.go
+++ b/mempool/log.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2013-2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package mempool
+
+import (
+	"github.com/btcsuite/btclog"
+)
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	DisableLog()
+}
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until either UseLogger or SetLogWriter are called.
+func DisableLog() {
+	log = btclog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package main
+package mempool
 
 import (
 	"fmt"
@@ -38,12 +38,12 @@ const (
 	// (1 + 15*74 + 3) + (15*34 + 3) + 23 = 1650
 	maxStandardSigScriptSize = 1650
 
-	// defaultMinRelayTxFee is the minimum fee in satoshi that is required
+	// DefaultMinRelayTxFee is the minimum fee in satoshi that is required
 	// for a transaction to be treated as free for relay and mining
 	// purposes.  It is also used to help determine if a transaction is
 	// considered dust and as a base for calculating minimum required fees
 	// for larger transactions.  This value is in Satoshi/1000 bytes.
-	defaultMinRelayTxFee = btcutil.Amount(1000)
+	DefaultMinRelayTxFee = btcutil.Amount(1000)
 
 	// maxStandardMultiSigKeys is the maximum number of public keys allowed
 	// in a multi-signature transaction output script for it to be
@@ -75,11 +75,11 @@ func calcMinRequiredTxRelayFee(serializedSize int64, minRelayTxFee btcutil.Amoun
 	return minFee
 }
 
-// calcPriority returns a transaction priority given a transaction and the sum
+// CalcPriority returns a transaction priority given a transaction and the sum
 // of each of its input values multiplied by their age (# of confirmations).
 // Thus, the final formula for the priority is:
 // sum(inputValue * inputAge) / adjustedTxSize
-func calcPriority(tx *wire.MsgTx, utxoView *blockchain.UtxoViewpoint, nextBlockHeight int32) float64 {
+func CalcPriority(tx *wire.MsgTx, utxoView *blockchain.UtxoViewpoint, nextBlockHeight int32) float64 {
 	// In order to encourage spending multiple old unspent transaction
 	// outputs thereby reducing the total set, don't count the constant
 	// overhead for each input as well as enough bytes of the signature

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package main
+package mempool
 
 import (
 	"bytes"
@@ -36,13 +36,13 @@ func TestCalcMinRequiredTxRelayFee(t *testing.T) {
 		{
 			"100 bytes with default minimum relay fee",
 			100,
-			defaultMinRelayTxFee,
+			DefaultMinRelayTxFee,
 			100,
 		},
 		{
 			"max standard tx size with default minimum relay fee",
 			maxStandardTxSize,
-			defaultMinRelayTxFee,
+			DefaultMinRelayTxFee,
 			100000,
 		},
 		{
@@ -470,7 +470,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 	for _, test := range tests {
 		// Ensure standardness is as expected.
 		err := checkTransactionStandard(btcutil.NewTx(&test.tx),
-			test.height, timeSource, defaultMinRelayTxFee)
+			test.height, timeSource, DefaultMinRelayTxFee)
 		if err == nil && test.isStandard {
 			// Test passes since function returned standard for a
 			// transaction which is intended to be standard.


### PR DESCRIPTION
This does the minimum work necessary to refactor the mempool code into its own package.  The idea is that separating this code into its own package will greatly improve its testability, allow independent
benchmarking and profiling, and open up some interesting opportunities for future development related to the memory pool.

There are likely some areas related to policy that could be further refactored, however it is better to do that in future commits in order to keep the changeset as small as possible during this refactor.

Overview of the major changes:

- Create the new package
- Move several files into the new package:
  - `mempool.go` -> `mempool/mempool.go`
  - `mempoolerror.go` -> `mempool/error.go`
  - `policy.go` -> `mempool/policy.go`
  - `policy_test.go` -> `mempool/policy_test.go`
- Update mempool logging to use the new mempool package logger
- Rename `mempoolPolicy` to `Policy` (so it's now `mempool.Policy`)
- Rename `mempoolConfig` to `Config` (so it's now `mempool.Config`)
- Rename `mempoolTxDesc` to `TxDesc` (so it's now `mempool.TxDesc`)
- Rename `txMemPool` to `TxPool` (so it's now `mempool.TxPool`)
- Move `defaultBlockPrioritySize` to the new package and export it
- Export `DefaultMinRelayTxFee` from the `mempool` package
- Export the `CalcPriority` function from the `mempool` package
- Introduce a new `RawMempoolVerbose` function on the `TxPool` and update
  the RPC server to use it
- Update all references to the `mempool` to use the package
- Add a skeleton `README.md`