### PR TITLE
wire: Lower MaxUserAgentLen to 256.

### DIFF
--- a/wire/msgversion.go
+++ b/wire/msgversion.go
@@ -15,10 +15,10 @@ import (
 
 // MaxUserAgentLen is the maximum allowed length for the user agent field in a
 // version message (MsgVersion).
-const MaxUserAgentLen = 2000
+const MaxUserAgentLen = 256
 
 // DefaultUserAgent for wire in the stack
-const DefaultUserAgent = "/btcwire:0.4.0/"
+const DefaultUserAgent = "/btcwire:0.4.1/"
 
 // MsgVersion implements the Message interface and represents a bitcoin version
 // message.  It is used for a peer to advertise itself as soon as an outbound

--- a/wire/msgversion_test.go
+++ b/wire/msgversion_test.go
@@ -113,7 +113,7 @@ func TestVersion(t *testing.T) {
 	// remote and local net addresses + nonce 8 bytes + length of user agent
 	// (varInt) + max allowed user agent length + last block 4 bytes +
 	// relay transactions flag 1 byte.
-	wantPayload := uint32(2102)
+	wantPayload := uint32(358)
 	maxPayload := msg.MaxPayloadLength(pver)
 	if maxPayload != wantPayload {
 		t.Errorf("MaxPayloadLength: wrong max payload length for "+


### PR DESCRIPTION
The protocol was silently upgrade in Core some time ago to enforce a limit of 256 for the user agent in version messages.  This updates wire to coincide with that change and consequently includes a wire version bump to 0.4.1.

Fixes #743.