### PR TITLE
mempool: Break dependency on chain instance.

### DIFF
--- a/server.go
+++ b/server.go
@@ -2527,7 +2527,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		},
 		ChainParams:   chainParams,
 		FetchUtxoView: s.blockManager.chain.FetchUtxoView,
-		Chain:         s.blockManager.chain,
+		BestHeight:    func() int32 { return bm.chain.BestSnapshot().Height },
 		SigCache:      s.sigCache,
 		TimeSource:    s.timeSource,
 		AddrIndex:     s.addrIndex,


### PR DESCRIPTION
This modifies the config for the new `mempool` package such that it takes a callback function to obtain the best chain height instead of requiring a fully initialized `blockchain.BlockChain` instance.

This will make it much easier to test the `mempool` since the tests will be able to provide their own height function to test various functionality without having create and manipulate full blocks and chain instances.