### PR TITLE
config: introduce new flags to accept/reject non-std transactions

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -108,6 +108,10 @@ Application Options:
       --sigcachemaxsize=    The maximum number of entries in the signature
                             verification cache.
       --blocksonly          Do not accept transactions from remote peers.
+      --relaynonstd         Relay non-standard transactions regardless of the
+                            default settings for the active network.
+      --rejectnonstd        Reject non-standard transactions regardless of the
+                            default settings for the active network.
 
 Help Options:
   -h, --help           Show this help message

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -78,6 +78,12 @@ type Policy struct {
 	// transactions that do not have enough priority to be relayed.
 	DisableRelayPriority bool
 
+	// RelayNonStd defines whether to relay non-standard transactions. If
+	// true, non-standard transactions will be accepted into the mempool
+	// and relayed. Otherwise, all non-standard transactions will be
+	// rejected.
+	RelayNonStd bool
+
 	// FreeTxRelayLimit defines the given amount in thousands of bytes
 	// per minute that transactions with no fee are rate limited to.
 	FreeTxRelayLimit float64
@@ -537,7 +543,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *btcutil.Tx, isNew, rateLimit bool) 
 
 	// Don't allow non-standard transactions if the network parameters
 	// forbid their relaying.
-	if !mp.cfg.ChainParams.RelayNonStdTxs {
+	if !mp.cfg.Policy.RelayNonStd {
 		err := checkTransactionStandard(tx, nextBlockHeight,
 			mp.cfg.TimeSource, mp.cfg.Policy.MinRelayTxFee)
 		if err != nil {
@@ -622,7 +628,7 @@ func (mp *TxPool) maybeAcceptTransaction(tx *btcutil.Tx, isNew, rateLimit bool) 
 
 	// Don't allow transactions with non-standard inputs if the network
 	// parameters forbid their relaying.
-	if !mp.cfg.ChainParams.RelayNonStdTxs {
+	if !mp.cfg.Policy.RelayNonStd {
 		err := checkInputsStandard(tx, utxoView)
 		if err != nil {
 			// Attempt to extract a reject code from the error so

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -101,7 +101,12 @@ var primaryHarness *rpctest.Harness
 
 func TestMain(m *testing.M) {
 	var err error
-	primaryHarness, err = rpctest.New(&chaincfg.SimNetParams, nil, nil)
+
+	// In order to properly test scenarios on as if we were on mainnet,
+	// ensure that non-standard transactions aren't accepted into the
+	// mempool or relayed.
+	btcdCfg := []string{"--rejectnonstd"}
+	primaryHarness, err = rpctest.New(&chaincfg.SimNetParams, nil, btcdCfg)
 	if err != nil {
 		fmt.Println("unable to create primary harness: ", err)
 		os.Exit(1)

--- a/sample-btcd.conf
+++ b/sample-btcd.conf
@@ -238,6 +238,12 @@
 ; Do not accept transactions from remote peers.
 ; blocksonly=1
 
+; Relay non-standard transactions regardless of default network settings.
+; relaynonstd=1
+
+; Reject non-standard transactions regardless of default network settings.
+; rejectnonstd=1
+
 
 ; ------------------------------------------------------------------------------
 ; Optional Transaction Indexes

--- a/server.go
+++ b/server.go
@@ -2519,6 +2519,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	txC := mempool.Config{
 		Policy: mempool.Policy{
 			DisableRelayPriority: cfg.NoRelayPriority,
+			RelayNonStd:          chainParams.RelayNonStdTxs,
 			FreeTxRelayLimit:     cfg.FreeTxRelayLimit,
 			MaxOrphanTxs:         cfg.MaxOrphanTxs,
 			MaxOrphanTxSize:      defaultMaxOrphanTxSize,

--- a/server.go
+++ b/server.go
@@ -2519,7 +2519,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	txC := mempool.Config{
 		Policy: mempool.Policy{
 			DisableRelayPriority: cfg.NoRelayPriority,
-			RelayNonStd:          chainParams.RelayNonStdTxs,
+			RelayNonStd:          cfg.RelayNonStd,
 			FreeTxRelayLimit:     cfg.FreeTxRelayLimit,
 			MaxOrphanTxs:         cfg.MaxOrphanTxs,
 			MaxOrphanTxSize:      defaultMaxOrphanTxSize,


### PR DESCRIPTION
This PR adds two new cli flags: one for accepting non-std transactions, and the other for rejecting non-std transactions.

The two flag are rejected when used concurrently. Config parsing is set up such that, the desired policy expressed via the config always overrides the policy set by default for a particular chain.

The `mempool`'s `Policy` config has been modified to add a new `RelayNonStd` bool which is checked when validating transactions rather than the policy as dicated by the current `ChainParams` instance. 

Finally, the current set of integration tests has been modified to ensure the main harness always rejects non-standard transactions. With this change, although we're using `simnet` parameters, the harness' transaction validation/acceptance should reflect that policy on mainnet, 