### PR TITLE
Implement infrastructure for BIP0009.

### DIFF
--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -8,11 +8,21 @@ import (
 	"fmt"
 )
 
+// DeploymentError identifies an error that indicates a deployment ID was
+// specified that does not exist.
+type DeploymentError uint32
+
+// Error returns the assertion error as a human-readable string and satisfies
+// the error interface.
+func (e DeploymentError) Error() string {
+	return fmt.Sprintf("deployment ID %d does not exist", uint32(e))
+}
+
 // AssertError identifies an error that indicates an internal code consistency
 // issue and should be treated as a critical and unrecoverable error.
 type AssertError string
 
-// Error returns the assertion error as a huma-readable string and satisfies
+// Error returns the assertion error as a human-readable string and satisfies
 // the error interface.
 func (e AssertError) Error() string {
 	return "assertion failed: " + string(e)

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -95,3 +95,37 @@ func TestRuleError(t *testing.T) {
 		}
 	}
 }
+
+// TestDeploymentError tests the stringized output for the DeploymentError type.
+func TestDeploymentError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   blockchain.DeploymentError
+		want string
+	}{
+		{
+			blockchain.DeploymentError(0),
+			"deployment ID 0 does not exist",
+		},
+		{
+			blockchain.DeploymentError(10),
+			"deployment ID 10 does not exist",
+		},
+		{
+			blockchain.DeploymentError(123),
+			"deployment ID 123 does not exist",
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		result := test.in.Error()
+		if result != test.want {
+			t.Errorf("Error #%d\n got: %s want: %s", i, result,
+				test.want)
+			continue
+		}
+	}
+
+}

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -1,0 +1,322 @@
+// Copyright (c) 2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+// ThresholdState define the various threshold states used when voting on
+// consensus changes.
+type ThresholdState byte
+
+// These constants are used to identify specific threshold states.
+//
+// NOTE: This section specifically does not use iota for the individual states
+// since these values are serialized and must be stable for long-term storage.
+const (
+	// ThresholdDefined is the first state for each deployment and is the
+	// state for the genesis block has by defintion for all deployments.
+	ThresholdDefined ThresholdState = 0
+
+	// ThresholdStarted is the state for a deployment once its start time
+	// has been reached.
+	ThresholdStarted ThresholdState = 1
+
+	// ThresholdLockedIn is the state for a deployment during the retarget
+	// period which is after the ThresholdStarted state period and the
+	// number of blocks that have voted for the deployment equal or exceed
+	// the required number of votes for the deployment.
+	ThresholdLockedIn ThresholdState = 2
+
+	// ThresholdActive is the state for a deployment for all blocks after a
+	// retarget period in which the deployment was in the ThresholdLockedIn
+	// state.
+	ThresholdActive ThresholdState = 3
+
+	// ThresholdFailed is the state for a deployment once its expiration
+	// time has been reached and it did not reach the ThresholdLockedIn
+	// state.
+	ThresholdFailed ThresholdState = 4
+
+	// numThresholdsStates is the maximum number of threshold states used in
+	// tests.
+	numThresholdsStates = iota
+)
+
+// thresholdStateStrings is a map of ThresholdState values back to their
+// constant names for pretty printing.
+var thresholdStateStrings = map[ThresholdState]string{
+	ThresholdDefined:  "ThresholdDefined",
+	ThresholdStarted:  "ThresholdStarted",
+	ThresholdLockedIn: "ThresholdLockedIn",
+	ThresholdActive:   "ThresholdActive",
+	ThresholdFailed:   "ThresholdFailed",
+}
+
+// String returns the ThresholdState as a human-readable name.
+func (t ThresholdState) String() string {
+	if s := thresholdStateStrings[t]; s != "" {
+		return s
+	}
+	return fmt.Sprintf("Unknown ThresholdState (%d)", int(t))
+}
+
+// thresholdConditionChecker provides a generic interface that is invoked to
+// determine when a consensus rule change threshold should be changed.
+type thresholdConditionChecker interface {
+	// BeginTime returns the unix timestamp for the median block time after
+	// which voting on a rule change starts (at the next window).
+	BeginTime() uint64
+
+	// EndTime returns the unix timestamp for the median block time after
+	// which an attempted rule change fails if it has not already been
+	// locked in or activated.
+	EndTime() uint64
+
+	// RuleChangeActivationThreshold is the number of blocks for which the
+	// condition must be true in order to lock in a rule change.
+	RuleChangeActivationThreshold() uint32
+
+	// MinerConfirmationWindow is the number of blocks in each threshold
+	// state retarget window.
+	MinerConfirmationWindow() uint32
+
+	// Condition returns whether or not the rule change activation condition
+	// has been met.  This typically involves checking whether or not the
+	// bit assocaited with the condition is set, but can be more complex as
+	// needed.
+	Condition(*blockNode) (bool, error)
+}
+
+// thresholdStateCache provides a type to cache the threshold states of each
+// threshold window for a set of IDs.  It also keeps track of which entries have
+// been modified and therefore need to be written to the database.
+type thresholdStateCache struct {
+	dbUpdates map[chainhash.Hash]ThresholdState
+	entries   map[chainhash.Hash]ThresholdState
+}
+
+// Lookup returns the threshold state associated with the given hash along with
+// a boolean that indicates whether or not it is valid.
+func (c *thresholdStateCache) Lookup(hash chainhash.Hash) (ThresholdState, bool) {
+	state, ok := c.entries[hash]
+	return state, ok
+}
+
+// Update updates the cache to contain the provided hash to threshold state
+// mapping while properly tracking needed updates flush changes to the database.
+func (c *thresholdStateCache) Update(hash chainhash.Hash, state ThresholdState) {
+	if existing, ok := c.entries[hash]; ok && existing == state {
+		return
+	}
+
+	c.dbUpdates[hash] = state
+	c.entries[hash] = state
+}
+
+// MarkFlushed marks all of the current udpates as flushed to the database.
+// This is useful so the caller can ensure the needed database updates are not
+// lost until they have successfully been written to the database.
+func (c *thresholdStateCache) MarkFlushed() {
+	for hash := range c.dbUpdates {
+		delete(c.dbUpdates, hash)
+	}
+}
+
+// newThresholdCaches returns a new array of caches to be used when calculating
+// threshold states.
+func newThresholdCaches(numCaches uint32) []thresholdStateCache {
+	caches := make([]thresholdStateCache, numCaches)
+	for i := 0; i < len(caches); i++ {
+		caches[i] = thresholdStateCache{
+			entries:   make(map[chainhash.Hash]ThresholdState),
+			dbUpdates: make(map[chainhash.Hash]ThresholdState),
+		}
+	}
+	return caches
+}
+
+// thresholdState returns the current rule change threshold state for the given
+// node and deployment ID.  The cache is used to ensure the threshold states for
+// previous windows are only calculated once.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) thresholdState(prevNode *blockNode, checker thresholdConditionChecker, cache *thresholdStateCache) (ThresholdState, error) {
+	// The threshold state for the window that contains the genesis block is
+	// defined by definition.
+	confirmationWindow := int32(checker.MinerConfirmationWindow())
+	if prevNode == nil || (prevNode.height+1) < confirmationWindow {
+		return ThresholdDefined, nil
+	}
+
+	// Get the ancestor that is the last block of the previous confirmation
+	// window in order to get its threshold state.  This can be done because
+	// the state is the same for all blocks within a given window.
+	var err error
+	prevNode, err = b.ancestorNode(prevNode, prevNode.height-
+		(prevNode.height+1)%confirmationWindow)
+	if err != nil {
+		return ThresholdFailed, err
+	}
+
+	// Iterate backwards through each of the previous confirmation windows
+	// to find the most recently cached threshold state.
+	var neededStates []*blockNode
+	for prevNode != nil {
+		// Nothing more to do if the state of the block is already
+		// cached.
+		if _, ok := cache.Lookup(*prevNode.hash); ok {
+			break
+		}
+
+		// The start and expiration times are based on the median block
+		// time, so calculate it now.
+		medianTime, err := b.calcPastMedianTime(prevNode)
+		if err != nil {
+			return ThresholdFailed, err
+		}
+
+		// The state is simply defined if the start time hasn't been
+		// been reached yet.
+		if uint64(medianTime.Unix()) < checker.BeginTime() {
+			cache.Update(*prevNode.hash, ThresholdDefined)
+			break
+		}
+
+		// Add this node to the list of nodes that need the state
+		// calculated and cached.
+		neededStates = append(neededStates, prevNode)
+
+		// Get the ancestor that is the last block of the previous
+		// confirmation window.
+		prevNode, err = b.ancestorNode(prevNode, prevNode.height-
+			confirmationWindow)
+		if err != nil {
+			return ThresholdFailed, err
+		}
+	}
+
+	// Start with the threshold state for the most recent confirmation
+	// window that has a cached state.
+	state := ThresholdDefined
+	if prevNode != nil {
+		var ok bool
+		state, ok = cache.Lookup(*prevNode.hash)
+		if !ok {
+			return ThresholdFailed, AssertError(fmt.Sprintf(
+				"thresholdState: cache lookup failed for %v",
+				prevNode.hash))
+		}
+	}
+
+	// Since each threshold state depends on the state of the previous
+	// window, iterate starting from the oldest unknown window.
+	for neededNum := len(neededStates) - 1; neededNum >= 0; neededNum-- {
+		prevNode := neededStates[neededNum]
+
+		switch state {
+		case ThresholdDefined:
+			// The deployment of the rule change fails if it expires
+			// before it is accepted and locked in.
+			medianTime, err := b.calcPastMedianTime(prevNode)
+			if err != nil {
+				return ThresholdFailed, err
+			}
+			medianTimeUnix := uint64(medianTime.Unix())
+			if medianTimeUnix >= checker.EndTime() {
+				state = ThresholdFailed
+				break
+			}
+
+			// The state for the rule moves to the started state
+			// once its start time has been reached (and it hasn't
+			// already expired per the above).
+			if medianTimeUnix >= checker.BeginTime() {
+				state = ThresholdStarted
+			}
+
+		case ThresholdStarted:
+			// The deployment of the rule change fails if it expires
+			// before it is accepted and locked in.
+			medianTime, err := b.calcPastMedianTime(prevNode)
+			if err != nil {
+				return ThresholdFailed, err
+			}
+			if uint64(medianTime.Unix()) >= checker.EndTime() {
+				state = ThresholdFailed
+				break
+			}
+
+			// At this point, the rule change is still being voted
+			// on by the miners, so iterate backwards through the
+			// confirmation window to count all of the votes in it.
+			var count uint32
+			countNode := prevNode
+			for i := int32(0); i < confirmationWindow; i++ {
+				condition, err := checker.Condition(countNode)
+				if err != nil {
+					return ThresholdFailed, err
+				}
+				if condition {
+					count++
+				}
+
+				// Get the previous block node.  This function
+				// is used over simply accessing countNode.parent
+				// directly as it will dynamically create
+				// previous block nodes as needed.  This helps
+				// allow only the pieces of the chain that are
+				// needed to remain in memory.
+				countNode, err = b.getPrevNodeFromNode(countNode)
+				if err != nil {
+					return ThresholdFailed, err
+				}
+			}
+
+			// The state is locked in if the number of blocks in the
+			// period that voted for the rule change meets the
+			// activation threshold.
+			if count >= checker.RuleChangeActivationThreshold() {
+				state = ThresholdLockedIn
+			}
+
+		case ThresholdLockedIn:
+			// The new rule becomes active when its previous state
+			// was locked in.
+			state = ThresholdActive
+
+		// Nothing to do if the previous state is active or failed since
+		// they are both terminal states.
+		case ThresholdActive:
+		case ThresholdFailed:
+		}
+
+		// Update the cache to avoid recalculating the state in the
+		// future.
+		cache.Update(*prevNode.hash, state)
+	}
+
+	return state, nil
+}
+
+// ThresholdState returns the current rule change threshold state of the given
+// deployment ID for the end of the current best chain.
+//
+// This function is safe for concurrent access.
+func (b *BlockChain) ThresholdState(deploymentID uint32) (ThresholdState, error) {
+	if deploymentID > uint32(len(b.chainParams.Deployments)) {
+		return ThresholdFailed, DeploymentError(deploymentID)
+	}
+	deployment := &b.chainParams.Deployments[deploymentID]
+	checker := deploymentChecker{deployment: deployment, chain: b}
+	cache := &b.deploymentCaches[deploymentID]
+	b.chainLock.Lock()
+	state, err := b.thresholdState(b.bestNode, checker, cache)
+	b.chainLock.Unlock()
+	return state, err
+}

--- a/blockchain/thresholdstate_test.go
+++ b/blockchain/thresholdstate_test.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+// TestThresholdStateStringer tests the stringized output for the
+// ThresholdState type.
+func TestThresholdStateStringer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		in   ThresholdState
+		want string
+	}{
+		{ThresholdDefined, "ThresholdDefined"},
+		{ThresholdStarted, "ThresholdStarted"},
+		{ThresholdLockedIn, "ThresholdLockedIn"},
+		{ThresholdActive, "ThresholdActive"},
+		{ThresholdFailed, "ThresholdFailed"},
+		{0xff, "Unknown ThresholdState (255)"},
+	}
+
+	// Detect additional threshold states that don't have the stringer added.
+	if len(tests)-1 != int(numThresholdsStates) {
+		t.Errorf("It appears a threshold statewas added without " +
+			"adding an associated stringer test")
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		result := test.in.String()
+		if result != test.want {
+			t.Errorf("String #%d\n got: %s want: %s", i, result,
+				test.want)
+			continue
+		}
+	}
+}
+
+// TestThresholdStateCache ensure the threshold state cache works as intended
+// including adding entries, updating existing entries, and flushing.
+func TestThresholdStateCache(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		numEntries int
+		state      ThresholdState
+	}{
+		{name: "2 entries defined", numEntries: 2, state: ThresholdDefined},
+		{name: "7 entries started", numEntries: 7, state: ThresholdStarted},
+		{name: "10 entries active", numEntries: 10, state: ThresholdActive},
+		{name: "5 entries locked in", numEntries: 5, state: ThresholdLockedIn},
+		{name: "3 entries failed", numEntries: 3, state: ThresholdFailed},
+	}
+
+nextTest:
+	for _, test := range tests {
+		cache := &newThresholdCaches(1)[0]
+		for i := 0; i < test.numEntries; i++ {
+			var hash chainhash.Hash
+			hash[0] = uint8(i + 1)
+
+			// Ensure the hash isn't available in the cache already.
+			_, ok := cache.Lookup(hash)
+			if ok {
+				t.Errorf("Lookup (%s): has entry for hash %v",
+					test.name, hash)
+				continue nextTest
+			}
+
+			// Ensure hash that was added to the cache reports it's
+			// available and the state is the expected value.
+			cache.Update(hash, test.state)
+			state, ok := cache.Lookup(hash)
+			if !ok {
+				t.Errorf("Lookup (%s): missing entry for hash "+
+					"%v", test.name, hash)
+				continue nextTest
+			}
+			if state != test.state {
+				t.Errorf("Lookup (%s): state mismatch - got "+
+					"%v, want %v", test.name, state,
+					test.state)
+				continue nextTest
+			}
+
+			// Ensure the update is also added to the internal
+			// database updates map and its state matches.
+			state, ok = cache.dbUpdates[hash]
+			if !ok {
+				t.Errorf("dbUpdates (%s): missing entry for "+
+					"hash %v", test.name, hash)
+				continue nextTest
+			}
+			if state != test.state {
+				t.Errorf("dbUpdates (%s): state mismatch - "+
+					"got %v, want %v", test.name, state,
+					test.state)
+				continue nextTest
+			}
+
+			// Ensure flushing the cache removes all entries from
+			// the internal database updates map.
+			cache.MarkFlushed()
+			if len(cache.dbUpdates) != 0 {
+				t.Errorf("dbUpdates (%s): unflushed entries",
+					test.name)
+				continue nextTest
+			}
+
+			// Ensure hash is still available in the cache and the
+			// state is the expected value.
+			state, ok = cache.Lookup(hash)
+			if !ok {
+				t.Errorf("Lookup (%s): missing entry after "+
+					"flush for hash %v", test.name, hash)
+				continue nextTest
+			}
+			if state != test.state {
+				t.Errorf("Lookup (%s): state mismatch after "+
+					"flush - got %v, want %v", test.name,
+					state, test.state)
+				continue nextTest
+			}
+
+			// Ensure adding an existing hash with the same state
+			// doesn't break the existing entry and it is NOT added
+			// to the database updates map.
+			cache.Update(hash, test.state)
+			state, ok = cache.Lookup(hash)
+			if !ok {
+				t.Errorf("Lookup (%s): missing entry after "+
+					"second add for hash %v", test.name,
+					hash)
+				continue nextTest
+			}
+			if state != test.state {
+				t.Errorf("Lookup (%s): state mismatch after "+
+					"second add - got %v, want %v",
+					test.name, state, test.state)
+				continue nextTest
+			}
+			if len(cache.dbUpdates) != 0 {
+				t.Errorf("dbUpdates (%s): unflushed entries "+
+					"after duplicate add", test.name)
+				continue nextTest
+			}
+
+			// Ensure adding an existing hash with a different state
+			// updates the existing entry.
+			newState := ThresholdFailed
+			if newState == test.state {
+				newState = ThresholdStarted
+			}
+			cache.Update(hash, newState)
+			state, ok = cache.Lookup(hash)
+			if !ok {
+				t.Errorf("Lookup (%s): missing entry after "+
+					"state change for hash %v", test.name,
+					hash)
+				continue nextTest
+			}
+			if state != newState {
+				t.Errorf("Lookup (%s): state mismatch after "+
+					"state change - got %v, want %v",
+					test.name, state, newState)
+				continue nextTest
+			}
+
+			// Ensure the update is also added to the internal
+			// database updates map and its state matches.
+			state, ok = cache.dbUpdates[hash]
+			if !ok {
+				t.Errorf("dbUpdates (%s): missing entry after "+
+					"state change for hash %v", test.name,
+					hash)
+				continue nextTest
+			}
+			if state != newState {
+				t.Errorf("dbUpdates (%s): state mismatch "+
+					"after state change - got %v, want %v",
+					test.name, state, newState)
+				continue nextTest
+			}
+		}
+	}
+}

--- a/blockchain/versionbits.go
+++ b/blockchain/versionbits.go
@@ -1,0 +1,316 @@
+// Copyright (c) 2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"math"
+
+	"github.com/btcsuite/btcd/chaincfg"
+)
+
+const (
+	// vbLegacyBlockVersion is the highest legacy block version before the
+	// version bits scheme became active.
+	vbLegacyBlockVersion = 4
+
+	// vbTopBits defines the bits to set in the version to signal that the
+	// version bits scheme is being used.
+	vbTopBits = 0x20000000
+
+	// vbTopMask is the bitmask to use to determine whether or not the
+	// version bits scheme is in use.
+	vbTopMask = 0xe0000000
+
+	// vbNumBits is the total number of bits available for use with the
+	// version bits scheme.
+	vbNumBits = 29
+
+	// unknownVerNumToCheck is the number of previous blocks to consider
+	// when checking for a threshold of unknown block versions for the
+	// purposes of warning the user.
+	unknownVerNumToCheck = 100
+
+	// unknownVerWarnNum is the threshold of previous blocks that have an
+	// unknown version to use for the purposes of warning the user.
+	unknownVerWarnNum = unknownVerNumToCheck / 2
+)
+
+// bitConditionChecker provides a thresholdConditionChecker which can be used to
+// test whether or not a specific bit is set when it's not supposed to be
+// according to the expected version based on the known deployments and the
+// current state of the chain.  This is useful for detecting and warning about
+// unknown rule activations.
+type bitConditionChecker struct {
+	bit   uint32
+	chain *BlockChain
+}
+
+// Ensure the bitConditionChecker type implements the thresholdConditionChecker
+// interface.
+var _ thresholdConditionChecker = bitConditionChecker{}
+
+// BeginTime returns the unix timestamp for the median block time after which
+// voting on a rule change starts (at the next window).
+//
+// Since this implementation checks for unknown rules, it returns 0 so the rule
+// is always treated as active.
+//
+// This is part of the thresholdConditionChecker interface implementation.
+func (c bitConditionChecker) BeginTime() uint64 {
+	return 0
+}
+
+// EndTime returns the unix timestamp for the median block time after which an
+// attempted rule change fails if it has not already been locked in or
+// activated.
+//
+// Since this implementation checks for unknown rules, it returns the maximum
+// possible timestamp so the rule is always treated as active.
+//
+// This is part of the thresholdConditionChecker interface implementation.
+func (c bitConditionChecker) EndTime() uint64 {
+	return math.MaxUint64
+}
+
+// RuleChangeActivationThreshold is the number of blocks for which the condition
+// must be true in order to lock in a rule change.
+//
+// This implementation returns the value defined by the chain params the checker
+// is associated with.
+//
+// This is part of the thresholdConditionChecker interface implementation.
+func (c bitConditionChecker) RuleChangeActivationThreshold() uint32 {
+	return c.chain.chainParams.RuleChangeActivationThreshold
+}
+
+// MinerConfirmationWindow is the number of blocks in each threshold state
+// retarget window.
+//
+// This implementation returns the value defined by the chain params the checker
+// is associated with.
+//
+// This is part of the thresholdConditionChecker interface implementation.
+func (c bitConditionChecker) MinerConfirmationWindow() uint32 {
+	return c.chain.chainParams.MinerConfirmationWindow
+}
+
+// Condition returns true when the specific bit associated with the checker is
+// set and it's not supposed to be according to the expected version based on
+// the known deployments and the current state of the chain.
+//
+// This function MUST be called with the chain state lock held (for writes).
+//
+// This is part of the thresholdConditionChecker interface implementation.
+func (c bitConditionChecker) Condition(node *blockNode) (bool, error) {
+	conditionMask := uint32(1) << c.bit
+	version := uint32(node.version)
+	if version&vbTopMask != vbTopBits {
+		return false, nil
+	}
+	if version&conditionMask == 0 {
+		return false, nil
+	}
+
+	// Get the previous block node.  This function is used over simply
+	// accessing node.parent directly as it will dynamically create previous
+	// block nodes as needed.  This helps allow only the pieces of the chain
+	// that are needed to remain in memory.
+	prevNode, err := c.chain.getPrevNodeFromNode(node)
+	if err != nil {
+		return false, err
+	}
+	expectedVersion, err := c.chain.calcNextBlockVersion(prevNode)
+	if err != nil {
+		return false, err
+	}
+	return uint32(expectedVersion)&conditionMask == 0, nil
+}
+
+// deploymentChecker provides a thresholdConditionChecker which can be used to
+// test a specific deployment rule.  This is required for properly detecting
+// and activating consensus rule changes.
+type deploymentChecker struct {
+	deployment *chaincfg.ConsensusDeployment
+	chain      *BlockChain
+}
+
+// Ensure the deploymentChecker type implements the thresholdConditionChecker
+// interface.
+var _ thresholdConditionChecker = deploymentChecker{}
+
+// BeginTime returns the unix timestamp for the median block time after which
+// voting on a rule change starts (at the next window).
+//
+// This implementation returns the value defined by the specific deployment the
+// checker is associated with.
+//
+// This is part of the thresholdConditionChecker interface implementation.
+func (c deploymentChecker) BeginTime() uint64 {
+	return c.deployment.StartTime
+}
+
+// EndTime returns the unix timestamp for the median block time after which an
+// attempted rule change fails if it has not already been locked in or
+// activated.
+//
+// This implementation returns the value defined by the specific deployment the
+// checker is associated with.
+//
+// This is part of the thresholdConditionChecker interface implementation.
+func (c deploymentChecker) EndTime() uint64 {
+	return c.deployment.ExpireTime
+}
+
+// RuleChangeActivationThreshold is the number of blocks for which the condition
+// must be true in order to lock in a rule change.
+//
+// This implementation returns the value defined by the chain params the checker
+// is associated with.
+//
+// This is part of the thresholdConditionChecker interface implementation.
+func (c deploymentChecker) RuleChangeActivationThreshold() uint32 {
+	return c.chain.chainParams.RuleChangeActivationThreshold
+}
+
+// MinerConfirmationWindow is the number of blocks in each threshold state
+// retarget window.
+//
+// This implementation returns the value defined by the chain params the checker
+// is associated with.
+//
+// This is part of the thresholdConditionChecker interface implementation.
+func (c deploymentChecker) MinerConfirmationWindow() uint32 {
+	return c.chain.chainParams.MinerConfirmationWindow
+}
+
+// Condition returns true when the specific bit defined by the deployment
+// associated with the checker is set.
+//
+// This is part of the thresholdConditionChecker interface implementation.
+func (c deploymentChecker) Condition(node *blockNode) (bool, error) {
+	conditionMask := uint32(1) << c.deployment.BitNumber
+	version := uint32(node.version)
+	return (version&vbTopMask == vbTopBits) && (version&conditionMask != 0),
+		nil
+}
+
+// calcNextBlockVersion calculates the expected version of the block after the
+// passed previous block node based on the state of started and locked in
+// rule change deployments.
+//
+// This function differs from the exported CalcNextBlockVersion in that the
+// exported version uses the current best chain as the previous block node
+// while this function accepts any block node.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) calcNextBlockVersion(prevNode *blockNode) (int32, error) {
+	// Set the appropriate bits for each actively defined rule deployment
+	// that is either in the process of being voted on, or locked in for the
+	// activation at the next threshold window change.
+	expectedVersion := uint32(vbTopBits)
+	for id := 0; id < len(b.chainParams.Deployments); id++ {
+		deployment := &b.chainParams.Deployments[id]
+		cache := &b.deploymentCaches[id]
+		checker := deploymentChecker{deployment: deployment, chain: b}
+		state, err := b.thresholdState(prevNode, checker, cache)
+		if err != nil {
+			return 0, err
+		}
+		if state == ThresholdStarted || state == ThresholdLockedIn {
+			expectedVersion |= uint32(1) << deployment.BitNumber
+		}
+	}
+	return int32(expectedVersion), nil
+}
+
+// CalcNextBlockVersion calculates the expected version of the block after the
+// end of the current best chain based on the state of started and locked in
+// rule change deployments.
+//
+// This function is safe for concurrent access.
+func (b *BlockChain) CalcNextBlockVersion() (int32, error) {
+	b.chainLock.Lock()
+	version, err := b.calcNextBlockVersion(b.bestNode)
+	b.chainLock.Unlock()
+	return version, err
+}
+
+// warnUnknownRuleActivations displays a warning when any unknown new rules are
+// either about to activate or have been activated.  This will only happen once
+// when new rules have been activated and every block for those about to be
+// activated.
+//
+// This function MUST be called with the chain state lock held (for writes)
+func (b *BlockChain) warnUnknownRuleActivations(node *blockNode) error {
+	// Warn if any unknown new rules are either about to activate or have
+	// already been activated.
+	for bit := uint32(0); bit < vbNumBits; bit++ {
+		checker := bitConditionChecker{bit: bit, chain: b}
+		cache := &b.warningCaches[bit]
+		state, err := b.thresholdState(node, checker, cache)
+		if err != nil {
+			return err
+		}
+
+		switch state {
+		case ThresholdActive:
+			if !b.unknownRulesWarned {
+				log.Warnf("Unknown new rules activated (bit %d)",
+					bit)
+				b.unknownRulesWarned = true
+			}
+
+		case ThresholdLockedIn:
+			window := int32(checker.MinerConfirmationWindow())
+			activationHeight := window - (node.height % window)
+			log.Warnf("Unknown new rules are about to activate in "+
+				"%d blocks (bit %d)", bit, activationHeight)
+		}
+	}
+
+	return nil
+}
+
+// warnUnknownVersions logs a warning if a high enough percentage of the last
+// blocks have unexpected versions.
+//
+// This function MUST be called with the chain state lock held (for writes)
+func (b *BlockChain) warnUnknownVersions(node *blockNode) error {
+	// Nothing to do if already warned.
+	if b.unknownVersionsWarned {
+		return nil
+	}
+
+	// Warn if enough previous blocks have unexpected versions.
+	numUpgraded := uint32(0)
+	for i := uint32(0); i < unknownVerNumToCheck && node != nil; i++ {
+		expectedVersion, err := b.calcNextBlockVersion(node.parent)
+		if err != nil {
+			return err
+		}
+		if expectedVersion > vbLegacyBlockVersion &&
+			(node.version & ^expectedVersion) != 0 {
+
+			numUpgraded++
+		}
+
+		// Get the previous block node.  This function is used over
+		// simply accessing node.parent directly as it will dynamically
+		// create previous block nodes as needed.  This helps allow only
+		// the pieces of the chain that are needed to remain in memory.
+		node, err = b.getPrevNodeFromNode(node)
+		if err != nil {
+			return err
+		}
+	}
+	if numUpgraded > unknownVerWarnNum {
+		log.Warn("Unknown block versions are being mined, so new " +
+			"rules might be in effect.  Are you running the " +
+			"latest version of the software?")
+		b.unknownVersionsWarned = true
+	}
+
+	return nil
+}

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -6,6 +6,7 @@ package chaincfg
 
 import (
 	"errors"
+	"math"
 	"math/big"
 	"time"
 
@@ -59,6 +60,37 @@ type DNSSeed struct {
 	// by service flags (wire.ServiceFlag).
 	HasFiltering bool
 }
+
+// ConsensusDeployment defines details related to a specific consensus rule
+// change that is voted in.  This is part of BIP0009.
+type ConsensusDeployment struct {
+	// BitNumber defines the specific bit number within the block version
+	// this particular soft-fork deployment refers to.
+	BitNumber uint8
+
+	// StartTime is the median block time after which voting on the
+	// deployment starts.
+	StartTime uint64
+
+	// ExpireTime is the median block time after which the attempted
+	// deployment expires.
+	ExpireTime uint64
+}
+
+// Constants that define the deployment offset in the deployments field of the
+// parameters for each deployment.  This is useful to be able to get the details
+// of a specific deployment by name.
+const (
+	// DeploymentTestDummy defines the rule change deployment ID for testing
+	// purposes.
+	DeploymentTestDummy = iota
+
+	// NOTE: DefinedDeployments must always come last since it is used to
+	// determine how many defined deployments there currently are.
+
+	// DefinedDeployments is the number of currently defined deployments.
+	DefinedDeployments
+)
 
 // Params defines a Bitcoin network by its parameters.  These parameters may be
 // used by Bitcoin applications to differentiate networks as well as addresses
@@ -143,6 +175,23 @@ type Params struct {
 	// The number of nodes to check.  This is part of BIP0034.
 	BlockUpgradeNumToCheck uint64
 
+	// These fields are related to voting on consensus rule changes as
+	// defined by BIP0009.
+	//
+	// RuleChangeActivationThreshold is the number of blocks in a threshold
+	// state retarget window for which a positive vote for a rule change
+	// must be cast in order to lock in a rule change. It should typically
+	// be 95% for the main network and 75% for test networks.
+	//
+	// MinerConfirmationWindow is the number of blocks in each threshold
+	// state retarget window.
+	//
+	// Deployments define the specific consensus rule changes to be voted
+	// on.
+	RuleChangeActivationThreshold uint32
+	MinerConfirmationWindow       uint32
+	Deployments                   [DefinedDeployments]ConsensusDeployment
+
 	// Mempool parameters
 	RelayNonStdTxs bool
 
@@ -221,6 +270,20 @@ var MainNetParams = Params{
 	BlockRejectNumRequired:  950,
 	BlockUpgradeNumToCheck:  1000,
 
+	// Consensus rule change deployments.
+	//
+	// The miner confirmation window is defined as:
+	//   target proof of work timespan / target proof of work spacing
+	RuleChangeActivationThreshold: 1916, // 95% of MinerConfirmationWindow
+	MinerConfirmationWindow:       2016, //
+	Deployments: [DefinedDeployments]ConsensusDeployment{
+		DeploymentTestDummy: {
+			BitNumber:  28,
+			StartTime:  1199145601, // January 1, 2008 UTC
+			ExpireTime: 1230767999, // December 31, 2008 UTC
+		},
+	},
+
 	// Mempool parameters
 	RelayNonStdTxs: false,
 
@@ -273,6 +336,20 @@ var RegressionNetParams = Params{
 	BlockEnforceNumRequired: 750,
 	BlockRejectNumRequired:  950,
 	BlockUpgradeNumToCheck:  1000,
+
+	// Consensus rule change deployments.
+	//
+	// The miner confirmation window is defined as:
+	//   target proof of work timespan / target proof of work spacing
+	RuleChangeActivationThreshold: 108, // 75%  of MinerConfirmationWindow
+	MinerConfirmationWindow:       144,
+	Deployments: [DefinedDeployments]ConsensusDeployment{
+		DeploymentTestDummy: {
+			BitNumber:  28,
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		},
+	},
 
 	// Mempool parameters
 	RelayNonStdTxs: true,
@@ -334,6 +411,20 @@ var TestNet3Params = Params{
 	BlockRejectNumRequired:  75,
 	BlockUpgradeNumToCheck:  100,
 
+	// Consensus rule change deployments.
+	//
+	// The miner confirmation window is defined as:
+	//   target proof of work timespan / target proof of work spacing
+	RuleChangeActivationThreshold: 1512, // 75% of MinerConfirmationWindow
+	MinerConfirmationWindow:       2016,
+	Deployments: [DefinedDeployments]ConsensusDeployment{
+		DeploymentTestDummy: {
+			BitNumber:  28,
+			StartTime:  1199145601, // January 1, 2008 UTC
+			ExpireTime: 1230767999, // December 31, 2008 UTC
+		},
+	},
+
 	// Mempool parameters
 	RelayNonStdTxs: true,
 
@@ -390,6 +481,20 @@ var SimNetParams = Params{
 	BlockEnforceNumRequired: 51,
 	BlockRejectNumRequired:  75,
 	BlockUpgradeNumToCheck:  100,
+
+	// Consensus rule change deployments.
+	//
+	// The miner confirmation window is defined as:
+	//   target proof of work timespan / target proof of work spacing
+	RuleChangeActivationThreshold: 75, // 75% of MinerConfirmationWindow
+	MinerConfirmationWindow:       100,
+	Deployments: [DefinedDeployments]ConsensusDeployment{
+		DeploymentTestDummy: {
+			BitNumber:  28,
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		},
+	},
 
 	// Mempool parameters
 	RelayNonStdTxs: true,

--- a/integration/bip0009_test.go
+++ b/integration/bip0009_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// This file is ignored during the regular tests due to the following build tag.
+// +build rpctest
+
+package integration
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/rpctest"
+)
+
+// assertVersionBit gets the passed block hash from the given test harness and
+// ensures its version either has the provided bit set or unset per the set
+// flag.
+func assertVersionBit(r *rpctest.Harness, t *testing.T, hash *chainhash.Hash, bit uint8, set bool) {
+	block, err := r.Node.GetBlock(hash)
+	if err != nil {
+		t.Fatalf("failed to retrieve block %v: %v", hash, err)
+	}
+	switch {
+	case set && block.Header.Version&(1<<bit) == 0:
+		_, _, line, _ := runtime.Caller(1)
+		t.Fatalf("assertion failed at line %d: block %s, version 0x%x "+
+			"does not have bit %d set", line, hash,
+			block.Header.Version, bit)
+	case !set && block.Header.Version&(1<<bit) != 0:
+		_, _, line, _ := runtime.Caller(1)
+		t.Fatalf("assertion failed at line %d: block %s, version 0x%x "+
+			"has bit %d set", line, hash, block.Header.Version, bit)
+	}
+}
+
+// TestBIP0009Mining ensures blocks built via btcd's CPU miner follow the rules
+// set forth by BIP0009 by using the test dummy deployment.
+//
+// Overview:
+// - Generate block 1
+//   - Assert bit is NOT set (ThresholdDefined)
+// - Generate enough blocks to reach first state transition
+//   - Assert bit is NOT set for block prior to state transition
+//   - Assert bit is set for block at state transition (ThresholdStarted)
+// - Generate enough blocks to reach second state transition
+//   - Assert bit is set for block at state transition (ThresholdLockedIn)
+// - Generate enough blocks to reach third state transition
+//   - Assert bit is set for block prior to state transition (ThresholdLockedIn)
+//   - Assert bit is NOT set for block at state transition (ThresholdActive)
+func TestBIP0009Mining(t *testing.T) {
+	t.Parallel()
+
+	// Initialize the primary mining node with only the genesis block.
+	r, err := rpctest.New(&chaincfg.SimNetParams, nil, nil)
+	if err != nil {
+		t.Fatalf("unable to create primary harness: %v", err)
+	}
+	if err := r.SetUp(true, 0); err != nil {
+		t.Fatalf("unable to setup test chain: %v", err)
+	}
+	defer r.TearDown()
+
+	// *** ThresholdDefined ***
+	//
+	// Generate a block that extends the genesis block.  It should not have
+	// the test dummy bit set in the version since the first window is
+	// in the defined threshold state.
+	deployment := &r.ActiveNet.Deployments[chaincfg.DeploymentTestDummy]
+	testDummyBitNum := deployment.BitNumber
+	hashes, err := r.Node.Generate(1)
+	if err != nil {
+		t.Fatalf("unable to generate blocks: %v", err)
+	}
+	assertVersionBit(r, t, hashes[0], testDummyBitNum, false)
+
+	// *** ThresholdStarted ***
+	//
+	// Generate enough blocks to reach the first state transition.
+	//
+	// The second to last generated block should not have the test bit set
+	// in the version.
+	//
+	// The last generated block should now have the test bit set in the
+	// version since the btcd mining code will have recognized the test
+	// dummy deployment as started.
+	confirmationWindow := r.ActiveNet.MinerConfirmationWindow
+	numNeeded := confirmationWindow - 1
+	hashes, err = r.Node.Generate(numNeeded)
+	if err != nil {
+		t.Fatalf("failed to generated %d blocks: %v", numNeeded, err)
+	}
+	assertVersionBit(r, t, hashes[len(hashes)-2], testDummyBitNum, false)
+	assertVersionBit(r, t, hashes[len(hashes)-1], testDummyBitNum, true)
+
+	// *** ThresholdLockedIn ***
+	//
+	// Generate enough blocks to reach the next state transition.
+	//
+	// The last generated block should still have the test bit set in the
+	// version since the btcd mining code will have recognized the test
+	// dummy deployment as locked in.
+	hashes, err = r.Node.Generate(confirmationWindow)
+	if err != nil {
+		t.Fatalf("failed to generated %d blocks: %v", confirmationWindow,
+			err)
+	}
+	assertVersionBit(r, t, hashes[len(hashes)-1], testDummyBitNum, true)
+
+	// *** ThresholdActivated ***
+	//
+	// Generate enough blocks to reach the next state transition.
+	//
+	// The second to last generated block should still have the test bit set
+	// in the version since it is still locked in.
+	//
+	// The last generated block should NOT have the test bit set in the
+	// version since the btcd mining code will have recognized the test
+	// dummy deployment as activated and thus there is no longer any need
+	// to set the bit.
+	hashes, err = r.Node.Generate(confirmationWindow)
+	if err != nil {
+		t.Fatalf("failed to generated %d blocks: %v", confirmationWindow,
+			err)
+	}
+	assertVersionBit(r, t, hashes[len(hashes)-2], testDummyBitNum, true)
+	assertVersionBit(r, t, hashes[len(hashes)-1], testDummyBitNum, false)
+}

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -454,7 +454,8 @@ func TestPeerListeners(t *testing.T) {
 		},
 		{
 			"OnBlock",
-			wire.NewMsgBlock(wire.NewBlockHeader(&chainhash.Hash{}, &chainhash.Hash{}, 1, 1)),
+			wire.NewMsgBlock(wire.NewBlockHeader(1,
+				&chainhash.Hash{}, &chainhash.Hash{}, 1, 1)),
 		},
 		{
 			"OnInv",
@@ -498,7 +499,8 @@ func TestPeerListeners(t *testing.T) {
 		},
 		{
 			"OnMerkleBlock",
-			wire.NewMsgMerkleBlock(wire.NewBlockHeader(&chainhash.Hash{}, &chainhash.Hash{}, 1, 1)),
+			wire.NewMsgMerkleBlock(wire.NewBlockHeader(1,
+				&chainhash.Hash{}, &chainhash.Hash{}, 1, 1)),
 		},
 		// only one version message is allowed
 		// only one verack message is allowed

--- a/rpctest/rpc_harness.go
+++ b/rpctest/rpc_harness.go
@@ -30,6 +30,10 @@ const (
 	maxPeerPort = 35000
 	minRPCPort  = maxPeerPort
 	maxRPCPort  = 60000
+
+	// BlockVersion is the default block version used when generating
+	// blocks.
+	BlockVersion = 4
 )
 
 var (
@@ -377,7 +381,7 @@ func (h *Harness) GenerateAndSubmitBlock(txns []*btcutil.Tx, blockVersion int32,
 	defer h.Unlock()
 
 	if blockVersion == -1 {
-		blockVersion = wire.BlockVersion
+		blockVersion = BlockVersion
 	}
 
 	prevBlockHash, prevBlockHeight, err := h.Node.GetBestBlock()

--- a/rpctest/rpc_harness_test.go
+++ b/rpctest/rpc_harness_test.go
@@ -363,9 +363,9 @@ func testGenerateAndSubmitBlock(r *Harness, t *testing.T) {
 			"expected %v, got %v", numTxns+1, numBlocksTxns)
 	}
 	blockVersion := block.MsgBlock().Header.Version
-	if blockVersion != wire.BlockVersion {
+	if blockVersion != BlockVersion {
 		t.Fatalf("block version is not default: expected %v, got %v",
-			wire.BlockVersion, blockVersion)
+			BlockVersion, blockVersion)
 	}
 
 	// Next generate a block with a "non-standard" block version along with

--- a/wire/bench_test.go
+++ b/wire/bench_test.go
@@ -419,7 +419,7 @@ func BenchmarkDecodeHeaders(b *testing.B) {
 		if err != nil {
 			b.Fatalf("NewHashFromStr: unexpected error: %v", err)
 		}
-		m.AddBlockHeader(NewBlockHeader(hash, hash, 0, uint32(i)))
+		m.AddBlockHeader(NewBlockHeader(1, hash, hash, 0, uint32(i)))
 	}
 
 	// Serialize it so the bytes are available to test the decode below.
@@ -565,7 +565,7 @@ func BenchmarkDecodeMerkleBlock(b *testing.B) {
 	if err != nil {
 		b.Fatalf("NewHashFromStr: unexpected error: %v", err)
 	}
-	m.Header = *NewBlockHeader(hash, hash, 0, uint32(10000))
+	m.Header = *NewBlockHeader(1, hash, hash, 0, uint32(10000))
 	for i := 0; i < 105; i++ {
 		hash, err := chainhash.NewHashFromStr(fmt.Sprintf("%x", i))
 		if err != nil {

--- a/wire/blockheader.go
+++ b/wire/blockheader.go
@@ -12,9 +12,6 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
 
-// BlockVersion is the current latest supported block version.
-const BlockVersion = 4
-
 // MaxBlockHeaderPayload is the maximum number of bytes a block header can be.
 // Version 4 bytes + Timestamp 4 bytes + Bits 4 bytes + Nonce 4 bytes +
 // PrevBlock and MerkleRoot hashes.
@@ -95,16 +92,16 @@ func (h *BlockHeader) Serialize(w io.Writer) error {
 	return writeBlockHeader(w, 0, h)
 }
 
-// NewBlockHeader returns a new BlockHeader using the provided previous block
-// hash, merkle root hash, difficulty bits, and nonce used to generate the
+// NewBlockHeader returns a new BlockHeader using the provided version, previous
+// block hash, merkle root hash, difficulty bits, and nonce used to generate the
 // block with defaults for the remaining fields.
-func NewBlockHeader(prevHash *chainhash.Hash, merkleRootHash *chainhash.Hash,
+func NewBlockHeader(version int32, prevHash, merkleRootHash *chainhash.Hash,
 	bits uint32, nonce uint32) *BlockHeader {
 
 	// Limit the timestamp to one second precision since the protocol
 	// doesn't support better.
 	return &BlockHeader{
-		Version:    BlockVersion,
+		Version:    version,
 		PrevBlock:  *prevHash,
 		MerkleRoot: *merkleRootHash,
 		Timestamp:  time.Unix(time.Now().Unix(), 0),

--- a/wire/blockheader_test.go
+++ b/wire/blockheader_test.go
@@ -24,7 +24,7 @@ func TestBlockHeader(t *testing.T) {
 	hash := mainNetGenesisHash
 	merkleHash := mainNetGenesisMerkleRoot
 	bits := uint32(0x1d00ffff)
-	bh := NewBlockHeader(&hash, &merkleHash, bits, nonce)
+	bh := NewBlockHeader(1, &hash, &merkleHash, bits, nonce)
 
 	// Ensure we get the same data back out.
 	if !bh.PrevBlock.IsEqual(&hash) {

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -66,7 +66,7 @@ func TestMessage(t *testing.T) {
 	msgFilterAdd := NewMsgFilterAdd([]byte{0x01})
 	msgFilterClear := NewMsgFilterClear()
 	msgFilterLoad := NewMsgFilterLoad([]byte{0x01}, 10, 0, BloomUpdateNone)
-	bh := NewBlockHeader(&chainhash.Hash{}, &chainhash.Hash{}, 0, 0)
+	bh := NewBlockHeader(1, &chainhash.Hash{}, &chainhash.Hash{}, 0, 0)
 	msgMerkleBlock := NewMsgMerkleBlock(bh)
 	msgReject := NewMsgReject("block", RejectDuplicate, "duplicate block")
 

--- a/wire/msgblock_test.go
+++ b/wire/msgblock_test.go
@@ -24,7 +24,7 @@ func TestBlock(t *testing.T) {
 	merkleHash := &blockOne.Header.MerkleRoot
 	bits := blockOne.Header.Bits
 	nonce := blockOne.Header.Nonce
-	bh := NewBlockHeader(prevHash, merkleHash, bits, nonce)
+	bh := NewBlockHeader(1, prevHash, merkleHash, bits, nonce)
 
 	// Ensure the command is expected value.
 	wantCmd := "block"

--- a/wire/msgheaders_test.go
+++ b/wire/msgheaders_test.go
@@ -66,7 +66,7 @@ func TestHeadersWire(t *testing.T) {
 	merkleHash := blockOne.Header.MerkleRoot
 	bits := uint32(0x1d00ffff)
 	nonce := uint32(0x9962e301)
-	bh := NewBlockHeader(&hash, &merkleHash, bits, nonce)
+	bh := NewBlockHeader(1, &hash, &merkleHash, bits, nonce)
 	bh.Version = blockOne.Header.Version
 	bh.Timestamp = blockOne.Header.Timestamp
 
@@ -223,7 +223,7 @@ func TestHeadersWireErrors(t *testing.T) {
 	merkleHash := blockOne.Header.MerkleRoot
 	bits := uint32(0x1d00ffff)
 	nonce := uint32(0x9962e301)
-	bh := NewBlockHeader(&hash, &merkleHash, bits, nonce)
+	bh := NewBlockHeader(1, &hash, &merkleHash, bits, nonce)
 	bh.Version = blockOne.Header.Version
 	bh.Timestamp = blockOne.Header.Timestamp
 
@@ -260,7 +260,7 @@ func TestHeadersWireErrors(t *testing.T) {
 
 	// Intentionally invalid block header that has a transaction count used
 	// to force errors.
-	bhTrans := NewBlockHeader(&hash, &merkleHash, bits, nonce)
+	bhTrans := NewBlockHeader(1, &hash, &merkleHash, bits, nonce)
 	bhTrans.Version = blockOne.Header.Version
 	bhTrans.Timestamp = blockOne.Header.Timestamp
 

--- a/wire/msgmerkleblock_test.go
+++ b/wire/msgmerkleblock_test.go
@@ -25,7 +25,7 @@ func TestMerkleBlock(t *testing.T) {
 	merkleHash := &blockOne.Header.MerkleRoot
 	bits := blockOne.Header.Bits
 	nonce := blockOne.Header.Nonce
-	bh := NewBlockHeader(prevHash, merkleHash, bits, nonce)
+	bh := NewBlockHeader(1, prevHash, merkleHash, bits, nonce)
 
 	// Ensure the command is expected value.
 	wantCmd := "merkleblock"
@@ -117,7 +117,7 @@ func TestMerkleBlockCrossProtocol(t *testing.T) {
 	merkleHash := &blockOne.Header.MerkleRoot
 	bits := blockOne.Header.Bits
 	nonce := blockOne.Header.Nonce
-	bh := NewBlockHeader(prevHash, merkleHash, bits, nonce)
+	bh := NewBlockHeader(1, prevHash, merkleHash, bits, nonce)
 
 	msg := NewMsgMerkleBlock(bh)
 


### PR DESCRIPTION
This adds all of the infrastructure needed to support BIP0009 soft forks.

The following is an overview of the changes:
- Add new configuration options to the chaincfg package which allows the rule deployments to be defined per chain
- Implement code to calculate the threshold state as required by BIP0009
  - Use threshold state caches that are stored to the database in order to accelerate startup time
  - Remove caches that are invalid due to definition changes in the params including additions, deletions, and changes to existing entries
- Detect and warn when a new unknown rule is about to activate or has been activated in the block connection code
- Detect and warn when 50% of the last 100 blocks have unexpected versions.
- Remove the latest block version from wire since it no longer applies
- Add a version parameter to the `wire.NewBlockHeader` function since the default is no longer available
- Update the miner block template generation code to use the calculated block version based on the currently defined rule deployments and their threshold states as of the previous block
- Add tests for new error type
- Add tests for threshold state cache
- Modify the `rpctest` package to provide its own constant for the block version since it is no longer available via the wire package
- Add integration tests to ensure the miner generates blocks according to the BIP0009 rules.

Outstanding items:
- [x] Implement integration tests to ensure the state transitions work as expected using the `rpctest` framework.
