### PR TITLE
peer: Implement feefilter p2p message (bip0133)

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	// MaxProtocolVersion is the max protocol version the peer supports.
-	MaxProtocolVersion = wire.SendHeadersVersion
+	MaxProtocolVersion = wire.FeeFilterVersion
 
 	// outputBufferSize is the number of elements the output channels use.
 	outputBufferSize = 50
@@ -139,6 +139,9 @@ type MessageListeners struct {
 	// OnGetHeaders is invoked when a peer receives a getheaders bitcoin
 	// message.
 	OnGetHeaders func(p *Peer, msg *wire.MsgGetHeaders)
+
+	// OnFeeFilter is invoked when a peer receives a feefilter bitcoin message.
+	OnFeeFilter func(p *Peer, msg *wire.MsgFeeFilter)
 
 	// OnFilterAdd is invoked when a peer receives a filteradd bitcoin message.
 	OnFilterAdd func(p *Peer, msg *wire.MsgFilterAdd)
@@ -1498,6 +1501,11 @@ out:
 		case *wire.MsgGetHeaders:
 			if p.cfg.Listeners.OnGetHeaders != nil {
 				p.cfg.Listeners.OnGetHeaders(p, msg)
+			}
+
+		case *wire.MsgFeeFilter:
+			if p.cfg.Listeners.OnFeeFilter != nil {
+				p.cfg.Listeners.OnFeeFilter(p, msg)
 			}
 
 		case *wire.MsgFilterAdd:

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -359,6 +359,9 @@ func TestPeerListeners(t *testing.T) {
 			OnGetHeaders: func(p *peer.Peer, msg *wire.MsgGetHeaders) {
 				ok <- msg
 			},
+			OnFeeFilter: func(p *peer.Peer, msg *wire.MsgFeeFilter) {
+				ok <- msg
+			},
 			OnFilterAdd: func(p *peer.Peer, msg *wire.MsgFilterAdd) {
 				ok <- msg
 			},
@@ -476,6 +479,10 @@ func TestPeerListeners(t *testing.T) {
 		{
 			"OnGetHeaders",
 			wire.NewMsgGetHeaders(),
+		},
+		{
+			"OnFeeFilter",
+			wire.NewMsgFeeFilter(15000),
 		},
 		{
 			"OnFilterAdd",
@@ -656,6 +663,7 @@ func TestOutboundPeer(t *testing.T) {
 	p2.QueueMessage(wire.NewMsgMemPool(), nil)
 	p2.QueueMessage(wire.NewMsgGetData(), nil)
 	p2.QueueMessage(wire.NewMsgGetHeaders(), nil)
+	p2.QueueMessage(wire.NewMsgFeeFilter(20000), nil)
 
 	p2.Disconnect()
 }


### PR DESCRIPTION
Requires #753 

NOTE: This only implements the new message type in the `peer` package. Further PRs will be needed to btcd itself to implement and respond to the message.