### PR TITLE
config: Replace log outputs with fmt.Fprintln.

### DIFF
--- a/config.go
+++ b/config.go
@@ -834,8 +834,8 @@ func loadConfig() (*config, []string, error) {
 
 		if cfg.TorIsolation &&
 			(cfg.ProxyUser != "" || cfg.ProxyPass != "") {
-			btcdLog.Warn("Tor isolation set -- overriding " +
-				"specified proxy user credentials")
+			fmt.Fprintln(os.Stderr, "Tor isolation set -- "+
+				"overriding specified proxy user credentials")
 		}
 
 		proxy := &socks.Proxy{
@@ -872,8 +872,9 @@ func loadConfig() (*config, []string, error) {
 
 		if cfg.TorIsolation &&
 			(cfg.OnionProxyUser != "" || cfg.OnionProxyPass != "") {
-			btcdLog.Warn("Tor isolation set -- overriding " +
-				"specified onionproxy user credentials ")
+			fmt.Fprintln(os.Stderr, "Tor isolation set -- "+
+				"overriding specified onionproxy user "+
+				"credentials ")
 		}
 
 		cfg.oniondial = func(a, b string) (net.Conn, error) {

--- a/config.go
+++ b/config.go
@@ -404,8 +404,8 @@ func loadConfig() (*config, []string, error) {
 		if _, err := os.Stat(preCfg.ConfigFile); os.IsNotExist(err) {
 			err := createDefaultConfigFile(preCfg.ConfigFile)
 			if err != nil {
-				fmt.Fprintln(os.Stderr, "Error creating a "+
-					"default config file: %v", err)
+				fmt.Fprintf(os.Stderr, "Error creating a "+
+					"default config file: %v\n", err)
 			}
 		}
 

--- a/config.go
+++ b/config.go
@@ -404,7 +404,8 @@ func loadConfig() (*config, []string, error) {
 		if _, err := os.Stat(preCfg.ConfigFile); os.IsNotExist(err) {
 			err := createDefaultConfigFile(preCfg.ConfigFile)
 			if err != nil {
-				btcdLog.Warnf("Error creating a default config file: %v", err)
+				fmt.Fprintln(os.Stderr, "Error creating a "+
+					"default config file: %v", err)
 			}
 		}
 


### PR DESCRIPTION
Fixes #757.