### PR TITLE
rpctest: Cleanup resources on failed setup.

### DIFF
--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -117,6 +117,13 @@ func TestMain(m *testing.M) {
 	// purposes.
 	if err := primaryHarness.SetUp(true, 25); err != nil {
 		fmt.Println("unable to setup test chain: ", err)
+
+		// Even though the harness was not fully setup, it still needs
+		// to be torn down to ensure all resources such as temp
+		// directories are cleaned up.  The error is intentionally
+		// ignored since this is already an error path and nothing else
+		// could be done about it anyways.
+		_ = primaryHarness.TearDown()
 		os.Exit(1)
 	}
 

--- a/rpctest/rpc_harness_test.go
+++ b/rpctest/rpc_harness_test.go
@@ -501,6 +501,13 @@ func TestMain(m *testing.M) {
 	// purposes.
 	if err = mainHarness.SetUp(true, numMatureOutputs); err != nil {
 		fmt.Println("unable to setup test chain: ", err)
+
+		// Even though the harness was not fully setup, it still needs
+		// to be torn down to ensure all resources such as temp
+		// directories are cleaned up.  The error is intentionally
+		// ignored since this is already an error path and nothing else
+		// could be done about it anyways.
+		_ = mainHarness.TearDown()
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
This modifies the `rpctest` harness to call the `TearDown` function in the `SetUp` error path.  This ensures any resources, such as temp directories, that were created during setup before whatever the failure that caused the error are properly cleaned up.

Fixes #762.