### PR TITLE
blockchain: make scriptval_test fail more nicely

### DIFF
--- a/blockchain/scriptval_test.go
+++ b/blockchain/scriptval_test.go
@@ -27,6 +27,11 @@ func TestCheckBlockScripts(t *testing.T) {
 	}
 	if len(blocks) > 1 {
 		t.Errorf("The test block file must only have one block in it")
+		return
+	}
+	if len(blocks) == 0 {
+		t.Errorf("The test block file may not be empty")
+		return
 	}
 
 	storeDataFile := fmt.Sprintf("%d.utxostore.bz2", testBlockNum)


### PR DESCRIPTION
1. Return early when failing on `len(blocks) > 1`.
2. Check for `len(blocks) == 0` so we can fail on that condition with an error message instead of a panic.