### PR TITLE
build: execute tests across all packages serially

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -12,7 +12,7 @@ set -ex
 test -z "$(go fmt $(glide novendor) | tee /dev/stderr)"
 test -z "$(for package in $(glide novendor); do golint $package; done | grep -v 'ALL_CAPS\|OP_\|NewFieldVal' | tee /dev/stderr)"
 test -z "$(go vet $(glide novendor) 2>&1 | tee /dev/stderr)"
-env GORACE="halt_on_error=1" go test -v -race $(glide novendor)
+env GORACE="halt_on_error=1" go test -p 1 -v -race $(glide novendor)
 
 # Run test coverage on each subdirectories and merge the coverage profile.
 


### PR DESCRIPTION
This commit modifies the goclean.sh to execute all the tests amongst
the packages serially. The default behavior of the `go test` command is
to execute all tests in parallel amongst the listed packages. This
behavior can at times cause tests which use the `rpctest` package to
fail due to multiple `btcd` nodes attempting to bind to the same port
simultaneously. As only one node can successfully bind to the port, the
btcd processes for the other concurrent harness instances exit silently
causing the RPC clients to fail with connection timeouts as their
target process no longer exists. Executing all tests serially
eliminates such a race condition which can cause non-deterministic test
failures.

Fixes #766.