### PR TITLE
config: Add --whitelist support.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -35,10 +35,12 @@ Application Options:
                             (default all interfaces port: 8333, testnet: 18333)
       --maxpeers=           Max number of inbound and outbound peers (125)
       --nobanning           Disable banning of misbehaving peers
-      --banthreshold=       Maximum allowed ban score before disconnecting and
-                            banning misbehaving peers.
       --banduration=        How long to ban misbehaving peers.  Valid time units
                             are {s, m, h}.  Minimum 1 second (24h0m0s)
+      --banthreshold=       Maximum allowed ban score before disconnecting and
+                            banning misbehaving peers.
+      --whitelist=          Add an IP network or IP that will not be banned.
+                            (eg. 192.168.1.0/24 or ::1)
   -u, --rpcuser=            Username for RPC connections
   -P, --rpcpass=            Password for RPC connections
       --rpclimituser=       Username for limited RPC connections

--- a/sample-btcd.conf
+++ b/sample-btcd.conf
@@ -114,6 +114,13 @@
 ; banduration=24h
 ; banduration=11h30m15s
 
+; Add whitelisted IP networks and IPs. Connected peers whose IP matches a
+; whitelist will not have their ban score increased.
+; whitelist=127.0.0.1
+; whitelist=::1
+; whitelist=192.168.0.0/24
+; whitelist=fd00::/16
+
 ; Disable DNS seeding for peers.  By default, when btcd starts, it will use
 ; DNS to query for available peers to connect with.
 ; nodnsseed=1

--- a/server.go
+++ b/server.go
@@ -223,6 +223,7 @@ type serverPeer struct {
 	relayMtx       sync.Mutex
 	disableRelayTx bool
 	sentAddrs      bool
+	isWhitelisted  bool
 	filter         *bloom.Filter
 	knownAddresses map[string]struct{}
 	banScore       connmgr.DynamicBanScore
@@ -315,6 +316,11 @@ func (sp *serverPeer) addBanScore(persistent, transient uint32, reason string) {
 	if cfg.DisableBanning {
 		return
 	}
+	if sp.isWhitelisted {
+		peerLog.Debugf("Misbehaving whitelisted peer %s: %s", sp, reason)
+		return
+	}
+
 	warnThreshold := cfg.BanThreshold >> 1
 	if transient == 0 && persistent == 0 {
 		// The score is not being increased, but a warning message is still
@@ -1590,6 +1596,7 @@ func newPeerConfig(sp *serverPeer) *peer.Config {
 // for disconnection.
 func (s *server) inboundPeerConnected(conn net.Conn) {
 	sp := newServerPeer(s, false)
+	sp.isWhitelisted = isWhitelisted(conn.RemoteAddr())
 	sp.Peer = peer.NewInboundPeer(newPeerConfig(sp))
 	sp.AssociateConnection(conn)
 	go s.peerDoneHandler(sp)
@@ -1609,6 +1616,7 @@ func (s *server) outboundPeerConnected(c *connmgr.ConnReq, conn net.Conn) {
 	}
 	sp.Peer = p
 	sp.connReq = c
+	sp.isWhitelisted = isWhitelisted(conn.RemoteAddr())
 	sp.AssociateConnection(conn)
 	go s.peerDoneHandler(sp)
 	s.addrManager.Attempt(sp.NA())
@@ -2597,6 +2605,32 @@ func dynamicTickDuration(remaining time.Duration) time.Duration {
 		return time.Minute * 15
 	}
 	return time.Hour
+}
+
+// isWhitelisted returns whether the IP address is included in the whitelisted
+// networks and IPs.
+func isWhitelisted(addr net.Addr) bool {
+	if len(cfg.whitelists) == 0 {
+		return false
+	}
+
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		srvrLog.Warnf("Unable to SplitHostPort on '%s': %v", addr, err)
+		return false
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		srvrLog.Warnf("Unable to parse IP '%s'", addr)
+		return false
+	}
+
+	for _, ipnet := range cfg.whitelists {
+		if ipnet.Contains(ip) {
+			return true
+		}
+	}
+	return false
 }
 
 // checkpointSorter implements sort.Interface to allow a slice of checkpoints to


### PR DESCRIPTION
--whitelist specifies IP networks and IPs of remote peers that will not
be banned for misbehaving.
