### PR TITLE
rpctest: Gate rpctest-based behind a build tag.

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -12,7 +12,7 @@ set -ex
 test -z "$(go fmt $(glide novendor) | tee /dev/stderr)"
 test -z "$(for package in $(glide novendor); do golint $package; done | grep -v 'ALL_CAPS\|OP_\|NewFieldVal' | tee /dev/stderr)"
 test -z "$(go vet $(glide novendor) 2>&1 | tee /dev/stderr)"
-env GORACE="halt_on_error=1" go test -v -race $(glide novendor)
+env GORACE="halt_on_error=1" go test -v -race -tags rpctest $(glide novendor)
 
 # Run test coverage on each subdirectories and merge the coverage profile.
 

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -2,6 +2,9 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
+// This file is ignored during the regular tests due to the following build tag.
+// +build rpctest
+
 package main
 
 import (

--- a/rpctest/rpc_harness_test.go
+++ b/rpctest/rpc_harness_test.go
@@ -1,6 +1,10 @@
 // Copyright (c) 2016 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
+
+// This file is ignored during the regular tests due to the following build tag.
+// +build rpctest
+
 package rpctest
 
 import (


### PR DESCRIPTION
This adds a new build tag named `rpctest` which must be set in order for `rpctest`-based tests to be executed.  The new build tag is also added to the `goclean.sh` script which is executed by Travis during continuous integration builds.

This change is being made because the `rpctest` framework requires additional careful user configuration to ensure the version of `btcd` under test can be programmatically launched from the system path with
all of the necessary ports open whereas all of the other tests are self-contained within the test binary itself.

Since said additional configuration is typically not done, it leads to a lot of false positives.  Putting the tests behind a build tag allows them to remain to be available and run during continuous integration without imposing the additional configuration requirements on users.

Closes #772