### PR TITLE
Implement the CSV-Package soft-fork via BIP0009 VersionBits

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -351,17 +351,15 @@ func (b *BlockChain) CalcSequenceLock(tx *btcutil.Tx, utxoView *UtxoViewpoint,
 	b.chainLock.Lock()
 	defer b.chainLock.Unlock()
 
-	return b.calcSequenceLock(tx, utxoView, mempool)
+	return b.calcSequenceLock(b.bestNode, tx, utxoView, mempool)
 }
 
 // calcSequenceLock computes the relative lock-times for the passed
 // transaction. See the exported version, CalcSequenceLock for further details.
 //
 // This function MUST be called with the chain state lock held (for writes).
-func (b *BlockChain) calcSequenceLock(tx *btcutil.Tx, utxoView *UtxoViewpoint,
-	mempool bool) (*SequenceLock, error) {
-
-	mTx := tx.MsgTx()
+func (b *BlockChain) calcSequenceLock(node *blockNode, tx *btcutil.Tx,
+	utxoView *UtxoViewpoint, mempool bool) (*SequenceLock, error) {
 
 	// A value of -1 for each relative lock type represents a relative time
 	// lock value that will allow a transaction to be included in a block
@@ -370,20 +368,42 @@ func (b *BlockChain) calcSequenceLock(tx *btcutil.Tx, utxoView *UtxoViewpoint,
 	// activated.
 	sequenceLock := &SequenceLock{Seconds: -1, BlockHeight: -1}
 
+	// The sequence locks semantics are always active for transactions
+	// within the mempool.
+	csvSoftforkActive := mempool
+
+	// If we're performing block validation, then we need to query the BIP9
+	// state.
+	if !csvSoftforkActive {
+		prevNode, err := b.index.PrevNodeFromNode(node)
+		if err != nil {
+			return nil, err
+		}
+
+		// Obtain the latest BIP9 version bits state for the
+		// CSV-package soft-fork deployment. The adherence of sequence
+		// locks depends on the current soft-fork state.
+		csvState, err := b.deploymentState(prevNode, chaincfg.DeploymentCSV)
+		if err != nil {
+			return nil, err
+		}
+		csvSoftforkActive = csvState == ThresholdActive
+	}
+
 	// If the transaction's version is less than 2, and BIP 68 has not yet
 	// been activated then sequence locks are disabled. Additionally,
 	// sequence locks don't apply to coinbase transactions Therefore, we
 	// return sequence lock values of -1 indicating that this transaction
 	// can be included within a block at any given height or time.
-	// TODO(roasbeef): check version bits state or pass as param
-	// * true should be replaced with a version bits state check
-	sequenceLockActive := mTx.Version >= 2 && (mempool || true)
+	mTx := tx.MsgTx()
+	sequenceLockActive := mTx.Version >= 2 && csvSoftforkActive
 	if !sequenceLockActive || IsCoinBase(tx) {
 		return sequenceLock, nil
 	}
 
-	// Grab the next height to use for inputs present in the mempool.
-	nextHeight := b.BestSnapshot().Height + 1
+	// Grab the next height from the PoV of the passed blockNode to use for
+	// inputs present in the mempool.
+	nextHeight := node.height + 1
 
 	for txInIndex, txIn := range mTx.TxIn {
 		utxo := utxoView.LookupEntry(&txIn.PreviousOutPoint.Hash)
@@ -421,9 +441,8 @@ func (b *BlockChain) calcSequenceLock(tx *btcutil.Tx, utxoView *UtxoViewpoint,
 			// compute the past median time for the block prior to
 			// the one which included this referenced output.
 			// TODO: caching should be added to keep this speedy
-			inputDepth := uint32(b.bestNode.height-inputHeight) + 1
-			blockNode, err := b.index.RelativeNode(b.bestNode,
-				inputDepth)
+			inputDepth := uint32(node.height-inputHeight) + 1
+			blockNode, err := b.index.RelativeNode(node, inputDepth)
 			if err != nil {
 				return sequenceLock, err
 			}

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -122,7 +122,7 @@ func TestCalcSequenceLock(t *testing.T) {
 	netParams := &chaincfg.SimNetParams
 
 	// Create a new database and chain instance to run tests against.
-	chain, teardownFunc, err := chainSetup("haveblock", netParams)
+	chain, teardownFunc, err := chainSetup("calcseqlock", netParams)
 	if err != nil {
 		t.Errorf("Failed to setup chain instance: %v", err)
 		return
@@ -190,7 +190,8 @@ func TestCalcSequenceLock(t *testing.T) {
 		prevBlock = block
 	}
 
-	// Create with all the utxos within the create created above.
+	// Create a utxo view with all the utxos within the blocks created
+	// above.
 	utxoView := blockchain.NewUtxoViewpoint()
 	for blockHeight, blockWithMTP := range blocksWithMTP {
 		for _, tx := range blockWithMTP.block.Transactions() {
@@ -200,8 +201,9 @@ func TestCalcSequenceLock(t *testing.T) {
 	utxoView.SetBestHash(blocksWithMTP[len(blocksWithMTP)-1].block.Hash())
 
 	// The median time calculated from the PoV of the best block in our
-	// test chain. For unconfirmed inputs, this value will be used since th
-	// MTP will be calculated from the PoV of the yet-to-be-mined block.
+	// test chain. For unconfirmed inputs, this value will be used since
+	// the MTP will be calculated from the PoV of the yet-to-be-mined
+	// block.
 	nextMedianTime := int64(1401292712)
 
 	// We'll refer to this utxo within each input in the transactions

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -5,11 +5,15 @@
 package blockchain_test
 
 import (
+	"bytes"
 	"testing"
+	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/rpctest"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 )
@@ -115,15 +119,10 @@ func TestHaveBlock(t *testing.T) {
 // combinations of inputs to the CalcSequenceLock function in order to ensure
 // the returned SequenceLocks are correct for each test instance.
 func TestCalcSequenceLock(t *testing.T) {
-	fileName := "blk_0_to_4.dat.bz2"
-	blocks, err := loadBlocks(fileName)
-	if err != nil {
-		t.Errorf("Error loading file: %v\n", err)
-		return
-	}
+	netParams := &chaincfg.SimNetParams
 
 	// Create a new database and chain instance to run tests against.
-	chain, teardownFunc, err := chainSetup("haveblock", &chaincfg.MainNetParams)
+	chain, teardownFunc, err := chainSetup("haveblock", netParams)
 	if err != nil {
 		t.Errorf("Failed to setup chain instance: %v", err)
 		return
@@ -134,45 +133,90 @@ func TestCalcSequenceLock(t *testing.T) {
 	// maturity to 1.
 	chain.TstSetCoinbaseMaturity(1)
 
-	// Load all the blocks into our test chain.
-	for i := 1; i < len(blocks); i++ {
-		_, isOrphan, err := chain.ProcessBlock(blocks[i], blockchain.BFNone)
+	// Create a test mining address to use for the blocks we'll generate
+	// shortly below.
+	k := bytes.Repeat([]byte{1}, 32)
+	_, miningPub := btcec.PrivKeyFromBytes(btcec.S256(), k)
+	miningAddr, err := btcutil.NewAddressPubKey(miningPub.SerializeCompressed(),
+		netParams)
+	if err != nil {
+		t.Fatalf("unable to generate mining addr: %v", err)
+	}
+
+	// We'll keep track of the previous block for back pointers in blocks
+	// we generated, and also the generated blocks along with the MTP from
+	// their PoV to aide with our relative time lock calculations.
+	var prevBlock *btcutil.Block
+	var blocksWithMTP []struct {
+		block *btcutil.Block
+		mtp   time.Time
+	}
+
+	// We need to activate CSV in order to test the processing logic, so
+	// manually craft the block version that's used to signal the soft-fork
+	// activation.
+	csvBit := netParams.Deployments[chaincfg.DeploymentCSV].BitNumber
+	blockVersion := int32(0x20000000 | (uint32(1) << csvBit))
+
+	// Generate enough blocks to activate CSV, collecting each of the
+	// blocks into a slice for later use.
+	numBlocksToActivate := (netParams.MinerConfirmationWindow * 3)
+	for i := uint32(0); i < numBlocksToActivate; i++ {
+		block, err := rpctest.CreateBlock(prevBlock, nil, blockVersion,
+			time.Time{}, miningAddr, netParams)
 		if err != nil {
-			t.Errorf("ProcessBlock fail on block %v: %v\n", i, err)
-			return
+			t.Fatalf("unable to generate block: %v", err)
+		}
+
+		mtp := chain.BestSnapshot().MedianTime
+
+		_, isOrphan, err := chain.ProcessBlock(block, blockchain.BFNone)
+		if err != nil {
+			t.Fatalf("ProcessBlock fail on block %v: %v\n", i, err)
 		}
 		if isOrphan {
-			t.Errorf("ProcessBlock incorrectly returned block %v "+
+			t.Fatalf("ProcessBlock incorrectly returned block %v "+
 				"is an orphan\n", i)
-			return
 		}
+
+		blocksWithMTP = append(blocksWithMTP, struct {
+			block *btcutil.Block
+			mtp   time.Time
+		}{
+			block: block,
+			mtp:   mtp,
+		})
+
+		prevBlock = block
 	}
 
 	// Create with all the utxos within the create created above.
 	utxoView := blockchain.NewUtxoViewpoint()
-	for blockHeight, block := range blocks {
-		for _, tx := range block.Transactions() {
+	for blockHeight, blockWithMTP := range blocksWithMTP {
+		for _, tx := range blockWithMTP.block.Transactions() {
 			utxoView.AddTxOuts(tx, int32(blockHeight))
 		}
 	}
-	utxoView.SetBestHash(blocks[len(blocks)-1].Hash())
+	utxoView.SetBestHash(blocksWithMTP[len(blocksWithMTP)-1].block.Hash())
 
-	// The median past time from the point of view of the second to last
-	// block in the chain.
-	medianTime := blocks[2].MsgBlock().Header.Timestamp.Unix()
-
-	// The median past time of the *next* block will be the timestamp of
-	// the 2nd block due to the way MTP is calculated in order to be
-	// compatible with Bitcoin Core.
-	nextMedianTime := blocks[2].MsgBlock().Header.Timestamp.Unix()
+	// The median time calculated from the PoV of the best block in our
+	// test chain. For unconfirmed inputs, this value will be used since th
+	// MTP will be calculated from the PoV of the yet-to-be-mined block.
+	nextMedianTime := int64(1401292712)
 
 	// We'll refer to this utxo within each input in the transactions
-	// created below. This block that includes this UTXO has a height of 4.
-	targetTx := blocks[4].Transactions()[0]
+	// created below. This utxo has an age of 4 blocks and was mined within
+	// block 297
+	targetTx := blocksWithMTP[len(blocksWithMTP)-4].block.Transactions()[0]
 	utxo := wire.OutPoint{
 		Hash:  *targetTx.Hash(),
 		Index: 0,
 	}
+
+	// Obtain the median time past from the PoV of the input created above.
+	// The MTP for the input is the MTP from the PoV of the block *prior*
+	// to the one that included it.
+	medianTime := blocksWithMTP[len(blocksWithMTP)-5].mtp.Unix()
 
 	// Add an additional transaction which will serve as our unconfirmed
 	// output.
@@ -187,6 +231,7 @@ func TestCalcSequenceLock(t *testing.T) {
 		Hash:  unConfTx.TxHash(),
 		Index: 0,
 	}
+
 	// Adding a utxo with a height of 0x7fffffff indicates that the output
 	// is currently unmined.
 	utxoView.AddTxOuts(btcutil.NewTx(unConfTx), 0x7fffffff)
@@ -283,24 +328,24 @@ func TestCalcSequenceLock(t *testing.T) {
 					Sequence:         blockchain.LockTimeToSequence(true, 2560),
 				}, {
 					PreviousOutPoint: utxo,
-					Sequence: blockchain.LockTimeToSequence(false, 3) |
+					Sequence: blockchain.LockTimeToSequence(false, 5) |
 						wire.SequenceLockTimeDisabled,
 				}, {
 					PreviousOutPoint: utxo,
-					Sequence:         blockchain.LockTimeToSequence(false, 3),
+					Sequence:         blockchain.LockTimeToSequence(false, 4),
 				}},
 			}),
 			view: utxoView,
 			want: &blockchain.SequenceLock{
 				Seconds:     medianTime + (5 << wire.SequenceLockTimeGranularity) - 1,
-				BlockHeight: 6,
+				BlockHeight: 299,
 			},
 		},
 		// Transaction has a single input spending the genesis block
 		// transaction. The input's sequence number is encodes a
 		// relative lock-time in blocks (3 blocks). The sequence lock
 		// should have a value of -1 for seconds, but a block height of
-		// 6 meaning it can be included at height 7.
+		// 298 meaning it can be included at height 299.
 		{
 			tx: btcutil.NewTx(&wire.MsgTx{
 				Version: 2,
@@ -312,7 +357,7 @@ func TestCalcSequenceLock(t *testing.T) {
 			view: utxoView,
 			want: &blockchain.SequenceLock{
 				Seconds:     -1,
-				BlockHeight: 6,
+				BlockHeight: 298,
 			},
 		},
 		// A transaction with two inputs with lock times expressed in
@@ -337,8 +382,9 @@ func TestCalcSequenceLock(t *testing.T) {
 		},
 		// A transaction with two inputs with lock times expressed in
 		// seconds. The selected sequence lock value for blocks should
-		// be the height further in the future, so a height of 10
-		// indicating in can be included at height 7.
+		// be the height further in the future. The converted absolute
+		// block height should be 302, meaning it can be included in
+		// block 303.
 		{
 			tx: btcutil.NewTx(&wire.MsgTx{
 				Version: 2,
@@ -353,7 +399,7 @@ func TestCalcSequenceLock(t *testing.T) {
 			view: utxoView,
 			want: &blockchain.SequenceLock{
 				Seconds:     -1,
-				BlockHeight: 10,
+				BlockHeight: 302,
 			},
 		},
 		// A transaction with multiple inputs. Two inputs are time
@@ -380,14 +426,15 @@ func TestCalcSequenceLock(t *testing.T) {
 			view: utxoView,
 			want: &blockchain.SequenceLock{
 				Seconds:     medianTime + (13 << wire.SequenceLockTimeGranularity) - 1,
-				BlockHeight: 12,
+				BlockHeight: 304,
 			},
 		},
 		// A transaction with a single unconfirmed input. As the input
 		// is confirmed, the height of the input should be interpreted
-		// as the height of the *next* block. So the relative block
-		// lock should be based from a height of 5 rather than a height
-		// of 4.
+		// as the height of the *next* block. The current block height
+		// is 300, so the lock time should be calculated using height
+		// 301 as a base. A 2 block relative lock means the transaction
+		// can be included after block 302, so in 303.
 		{
 			tx: btcutil.NewTx(&wire.MsgTx{
 				Version: 2,
@@ -399,7 +446,7 @@ func TestCalcSequenceLock(t *testing.T) {
 			view: utxoView,
 			want: &blockchain.SequenceLock{
 				Seconds:     -1,
-				BlockHeight: 6,
+				BlockHeight: 302,
 			},
 		},
 		// A transaction with a single unconfirmed input. The input has

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -309,14 +309,33 @@ func (b *BlockChain) thresholdState(prevNode *blockNode, checker thresholdCondit
 //
 // This function is safe for concurrent access.
 func (b *BlockChain) ThresholdState(deploymentID uint32) (ThresholdState, error) {
+	b.chainLock.Lock()
+	state, err := b.deploymentState(b.bestNode, deploymentID)
+	b.chainLock.Unlock()
+
+	return state, err
+}
+
+// deploymentState returns the current rule change threshold for a given
+// deploymentID. The threshold is evaluated from the point of view of the block
+// node passed in as the first argument to this method.
+//
+// It is important to note that, as the variable name indicates, this function
+// expects the block node prior to the block for which the deployment state is
+// desired.  In other words, the returned deployment state is for the block
+// AFTER the passed node.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (b *BlockChain) deploymentState(prevNode *blockNode,
+	deploymentID uint32) (ThresholdState, error) {
+
 	if deploymentID > uint32(len(b.chainParams.Deployments)) {
 		return ThresholdFailed, DeploymentError(deploymentID)
 	}
+
 	deployment := &b.chainParams.Deployments[deploymentID]
 	checker := deploymentChecker{deployment: deployment, chain: b}
 	cache := &b.deploymentCaches[deploymentID]
-	b.chainLock.Lock()
-	state, err := b.thresholdState(b.bestNode, checker, cache)
-	b.chainLock.Unlock()
-	return state, err
+
+	return b.thresholdState(prevNode, checker, cache)
 }

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -752,6 +752,27 @@ func (b *BlockChain) checkBlockContext(block *btcutil.Block, prevNode *blockNode
 
 	fastAdd := flags&BFFastAdd == BFFastAdd
 	if !fastAdd {
+		// Obtain the latest state of the deployed CSV soft-fork in
+		// order to properly guard the new validation behavior based on
+		// the current BIP 9 version bits state.
+		csvState, err := b.deploymentState(prevNode, chaincfg.DeploymentCSV)
+		if err != nil {
+			return err
+		}
+
+		// Once the CSV soft-fork is fully active, we'll switch to
+		// using the current median time past of the past block's
+		// timestamps for all lock-time based checks.
+		blockTime := header.Timestamp
+		if csvState == ThresholdActive {
+			medianTime, err := b.index.CalcPastMedianTime(prevNode)
+			if err != nil {
+				return err
+			}
+
+			blockTime = medianTime
+		}
+
 		// The height of this block is one more than the referenced
 		// previous block.
 		blockHeight := prevNode.height + 1
@@ -759,7 +780,7 @@ func (b *BlockChain) checkBlockContext(block *btcutil.Block, prevNode *blockNode
 		// Ensure all transactions in the block are finalized.
 		for _, tx := range block.Transactions() {
 			if !IsFinalizedTransaction(tx, blockHeight,
-				header.Timestamp) {
+				blockTime) {
 
 				str := fmt.Sprintf("block contains unfinalized "+
 					"transaction %v", tx.Hash())
@@ -1131,6 +1152,48 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *btcutil.Block, vi
 	// activation threshold has been reached.  This is part of BIP0065.
 	if blockHeader.Version >= 4 && node.height >= b.chainParams.BIP0065Height {
 		scriptFlags |= txscript.ScriptVerifyCheckLockTimeVerify
+	}
+
+	// Enforce CHECKSEQUENCEVERIFY during all block validation checks once
+	// the soft-fork deployment is fully active.
+	csvState, err := b.deploymentState(node.parent, chaincfg.DeploymentCSV)
+	if err != nil {
+		return err
+	}
+	if csvState == ThresholdActive {
+		// If the CSV soft-fork is now active, then modify the
+		// scriptFlags to ensure that the CSV op code is properly
+		// validated during the script checks bleow.
+		scriptFlags |= txscript.ScriptVerifyCheckSequenceVerify
+
+		// We obtain the MTP of the *previous* block in order to
+		// determine if transactions in the current block are final.
+		medianTime, err := b.index.CalcPastMedianTime(node.parent)
+		if err != nil {
+			return err
+		}
+
+		// Additionally, if the CSV soft-fork package is now active,
+		// then we also enforce the relative sequence number based
+		// lock-times within the inputs of all transactions in this
+		// candidate block.
+		for _, tx := range block.Transactions() {
+			// A transaction can only be included within a block
+			// once the sequence locks of *all* its inputs are
+			// active.
+			sequenceLock, err := b.calcSequenceLock(node, tx, view,
+				false)
+			if err != nil {
+				return err
+			}
+			if !SequenceLockActive(sequenceLock, node.height,
+				medianTime) {
+				str := fmt.Sprintf("block contains " +
+					"transaction whose input sequence " +
+					"locks are not met")
+				return ruleError(ErrUnfinalizedTx, str)
+			}
+		}
 	}
 
 	// Now that the inexpensive checks are done and have passed, verify the

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -85,6 +85,11 @@ const (
 	// purposes.
 	DeploymentTestDummy = iota
 
+	// DeploymentCSV defines the rule change deployment ID for the CSV
+	// soft-fork package. The CSV package includes the depolyment of BIPS
+	// 68, 112, and 113.
+	DeploymentCSV
+
 	// NOTE: DefinedDeployments must always come last since it is used to
 	// determine how many defined deployments there currently are.
 
@@ -270,6 +275,11 @@ var MainNetParams = Params{
 			StartTime:  1199145601, // January 1, 2008 UTC
 			ExpireTime: 1230767999, // December 31, 2008 UTC
 		},
+		DeploymentCSV: {
+			BitNumber:  0,
+			StartTime:  1462060800, // May 1st, 2016
+			ExpireTime: 1493596800, // May 1st, 2017
+		},
 	},
 
 	// Mempool parameters
@@ -327,6 +337,11 @@ var RegressionNetParams = Params{
 	Deployments: [DefinedDeployments]ConsensusDeployment{
 		DeploymentTestDummy: {
 			BitNumber:  28,
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		},
+		DeploymentCSV: {
+			BitNumber:  0,
 			StartTime:  0,             // Always available for vote
 			ExpireTime: math.MaxInt64, // Never expires
 		},
@@ -407,6 +422,11 @@ var TestNet3Params = Params{
 			StartTime:  1199145601, // January 1, 2008 UTC
 			ExpireTime: 1230767999, // December 31, 2008 UTC
 		},
+		DeploymentCSV: {
+			BitNumber:  0,
+			StartTime:  1456790400, // March 1st, 2016
+			ExpireTime: 1493596800, // May 1st, 2017
+		},
 	},
 
 	// Mempool parameters
@@ -468,6 +488,11 @@ var SimNetParams = Params{
 	Deployments: [DefinedDeployments]ConsensusDeployment{
 		DeploymentTestDummy: {
 			BitNumber:  28,
+			StartTime:  0,             // Always available for vote
+			ExpireTime: math.MaxInt64, // Never expires
+		},
+		DeploymentCSV: {
+			BitNumber:  0,
 			StartTime:  0,             // Always available for vote
 			ExpireTime: math.MaxInt64, // Never expires
 		},

--- a/integration/csv_fork_test.go
+++ b/integration/csv_fork_test.go
@@ -1,0 +1,695 @@
+// Copyright (c) 2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+// This file is ignored during the regular tests due to the following build tag.
+// +build rpctest
+
+package integration
+
+import (
+	"bytes"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/rpctest"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+)
+
+const (
+	csvKey = "csv"
+)
+
+// makeTestOutput creates an on-chain output paying to a freshly generated
+// p2pkh output with the specified amount.
+func makeTestOutput(r *rpctest.Harness, t *testing.T,
+	amt btcutil.Amount) (*btcec.PrivateKey, *wire.OutPoint, []byte, error) {
+
+	// Create a fresh key, then send some coins to an address spendable by
+	// that key.
+	key, err := btcec.NewPrivateKey(btcec.S256())
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Using the key created above, generate a pkScript which it's able to
+	// spend.
+	a, err := btcutil.NewAddressPubKey(key.PubKey().SerializeCompressed(), r.ActiveNet)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	selfAddrScript, err := txscript.PayToAddrScript(a.AddressPubKeyHash())
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	output := &wire.TxOut{PkScript: selfAddrScript, Value: 1e8}
+
+	// Next, create and broadcast a transaction paying to the output.
+	fundTx, err := r.CreateTransaction([]*wire.TxOut{output}, 10)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	txHash, err := r.Node.SendRawTransaction(fundTx, true)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// The transaction created above should be included within the next
+	// generated block.
+	blockHash, err := r.Node.Generate(1)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	assertTxInBlock(r, t, blockHash[0], txHash)
+
+	// Locate the output index of the coins spendable by the key we
+	// generated above, this is needed in order to create a proper utxo for
+	// this output.
+	var outputIndex uint32
+	if bytes.Equal(fundTx.TxOut[0].PkScript, selfAddrScript) {
+		outputIndex = 0
+	} else {
+		outputIndex = 1
+	}
+
+	utxo := &wire.OutPoint{
+		Hash:  fundTx.TxHash(),
+		Index: outputIndex,
+	}
+
+	return key, utxo, selfAddrScript, nil
+}
+
+// TestBIP0113Activation tests for proper adherance of the BIP 113 rule
+// constraint which requires all transaction finality tests to use the MTP of
+// the last 11 blocks, rather than the timestamp of the block which includes
+// them.
+//
+// Overview:
+//  - Pre soft-fork:
+//    - Transactions with non-final lock-times from the PoV of MTP should be
+//      rejected from the mempool.
+//    - Transactions within non-final MTP based lock-times should be accepted
+//      in valid blocks.
+//
+//  - Post soft-fork:
+//    - Transactions with non-final lock-times from the PoV of MTP should be
+//      rejected from the mempool and when found within otherwise valid blocks.
+//    - Transactions with final lock-times from the PoV of MTP should be
+//      accepted to the mempool and mined in future block.
+func TestBIP0113Activation(t *testing.T) {
+	t.Parallel()
+
+	btcdCfg := []string{"--rejectnonstd"}
+	r, err := rpctest.New(&chaincfg.SimNetParams, nil, btcdCfg)
+	if err != nil {
+		t.Fatal("unable to create primary harness: ", err)
+	}
+	if err := r.SetUp(true, 1); err != nil {
+		t.Fatalf("unable to setup test chain: %v", err)
+	}
+	defer r.TearDown()
+
+	// Create a fresh output for usage within the test below.
+	const outputValue = btcutil.SatoshiPerBitcoin
+	outputKey, testOutput, testPkScript, err := makeTestOutput(r, t,
+		outputValue)
+	if err != nil {
+		t.Fatalf("unable to create test output: %v", err)
+	}
+
+	// Fetch a fresh address from the harness, we'll use this address to
+	// send funds back into the Harness.
+	addr, err := r.NewAddress()
+	if err != nil {
+		t.Fatalf("unable to generate address: %v", err)
+	}
+	addrScript, err := txscript.PayToAddrScript(addr)
+	if err != nil {
+		t.Fatalf("unable to generate addr script: %v", err)
+	}
+
+	// Now create a transaction with a lock time which is "final" according
+	// to the latest block, but not according to the current median time
+	// past.
+	tx := wire.NewMsgTx(1)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: *testOutput,
+	})
+	tx.AddTxOut(&wire.TxOut{
+		PkScript: addrScript,
+		Value:    outputValue - 1000,
+	})
+
+	// We set the lock-time of the transaction to just one minute after the
+	// current MTP of the chain.
+	chainInfo, err := r.Node.GetBlockChainInfo()
+	if err != nil {
+		t.Fatalf("unable to query for chain info: %v", err)
+	}
+	tx.LockTime = uint32(chainInfo.MedianTime) + 1
+
+	sigScript, err := txscript.SignatureScript(tx, 0, testPkScript,
+		txscript.SigHashAll, outputKey, true)
+	if err != nil {
+		t.Fatalf("unable to generate sig: %v", err)
+	}
+	tx.TxIn[0].SignatureScript = sigScript
+
+	// This transaction should be rejected from the mempool as using MTP
+	// for transactions finality is now a policy rule. Additionally, the
+	// exact error should be the rejection of a non-final transaction.
+	_, err = r.Node.SendRawTransaction(tx, true)
+	if err == nil {
+		t.Fatalf("transaction accepted, but should be non-final")
+	} else if !strings.Contains(err.Error(), "not finalized") {
+		t.Fatalf("transaction should be rejected due to being "+
+			"non-final, instead: %v", err)
+	}
+
+	// However, since the block validation consensus rules haven't yet
+	// activated, a block including the transaction should be accepted.
+	txns := []*btcutil.Tx{btcutil.NewTx(tx)}
+	block, err := r.GenerateAndSubmitBlock(txns, -1, time.Time{})
+	if err != nil {
+		t.Fatalf("unable to submit block: %v", err)
+	}
+	txid := tx.TxHash()
+	assertTxInBlock(r, t, block.Hash(), &txid)
+
+	// At this point, the block height should be 103: we mined 101 blocks
+	// to create a single mature output, then an additional block to create
+	// a new output, and then mined a single block above to include our
+	// transation.
+	assertChainHeight(r, t, 103)
+
+	// Next, mine enough blocks to ensure that the soft-fork becomes
+	// activated. Assert that the block version of the second-to-last block
+	// in the final range is active.
+
+	// Next, mine ensure blocks to ensure that the soft-fork becomes
+	// active. We're at height 103 and we need 200 blocks to be mined after
+	// the genesis target period, so we mine 196 blocks. This'll put us at
+	// height 299. The getblockchaininfo call checks the state for the
+	// block AFTER the current height.
+	numBlocks := (r.ActiveNet.MinerConfirmationWindow * 2) - 4
+	if _, err := r.Node.Generate(numBlocks); err != nil {
+		t.Fatalf("unable to generate blocks: %v", err)
+	}
+
+	assertChainHeight(r, t, 299)
+	assertSoftForkStatus(r, t, csvKey, blockchain.ThresholdActive)
+
+	// The timeLockDeltas slice represents a series of deviations from the
+	// current MTP which will be used to test border conditions w.r.t
+	// transaction finality. -1 indicates 1 second prior to the MTP, 0
+	// indicates the current MTP, and 1 indicates 1 second after the
+	// current MTP.
+	//
+	// This time, all transactions which are final according to the MTP
+	// *should* be accepted to both the mempool and within a valid block.
+	// While transactions with lock-times *after* the current MTP should be
+	// rejected.
+	timeLockDeltas := []int64{-1, 0, 1}
+	for _, timeLockDelta := range timeLockDeltas {
+		chainInfo, err = r.Node.GetBlockChainInfo()
+		if err != nil {
+			t.Fatalf("unable to query for chain info: %v", err)
+		}
+		medianTimePast := chainInfo.MedianTime
+
+		// Create another test output to be spent shortly below.
+		outputKey, testOutput, testPkScript, err = makeTestOutput(r, t,
+			outputValue)
+		if err != nil {
+			t.Fatalf("unable to create test output: %v", err)
+		}
+
+		// Create a new transaction with a lock-time past the current known
+		// MTP.
+		tx = wire.NewMsgTx(1)
+		tx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: *testOutput,
+		})
+		tx.AddTxOut(&wire.TxOut{
+			PkScript: addrScript,
+			Value:    outputValue - 1000,
+		})
+		tx.LockTime = uint32(medianTimePast + timeLockDelta)
+		sigScript, err = txscript.SignatureScript(tx, 0, testPkScript,
+			txscript.SigHashAll, outputKey, true)
+		if err != nil {
+			t.Fatalf("unable to generate sig: %v", err)
+		}
+		tx.TxIn[0].SignatureScript = sigScript
+
+		// If the time-lock delta is greater than -1, then the
+		// transaction should be rejected from the mempool and when
+		// included within a block. A time-lock delta of -1 should be
+		// accepted as it has a lock-time of one
+		// second _before_ the current MTP.
+
+		_, err = r.Node.SendRawTransaction(tx, true)
+		if err == nil && timeLockDelta >= 0 {
+			t.Fatal("transaction was accepted into the mempool " +
+				"but should be rejected!")
+		} else if err != nil && !strings.Contains(err.Error(), "not finalized") {
+			t.Fatalf("transaction should be rejected from mempool "+
+				"due to being  non-final, instead: %v", err)
+		}
+
+		txns = []*btcutil.Tx{btcutil.NewTx(tx)}
+		_, err := r.GenerateAndSubmitBlock(txns, -1, time.Time{})
+		if err == nil && timeLockDelta >= 0 {
+			t.Fatal("block should be rejected due to non-final " +
+				"txn, but was accepted")
+		} else if err != nil && !strings.Contains(err.Error(), "unfinalized") {
+			t.Fatalf("block should be rejected due to non-final "+
+				"tx, instead: %v", err)
+		}
+	}
+}
+
+// createCSVOutput creates an output paying to a trivially redeemable CSV
+// pkScript with the specified time-lock.
+func createCSVOutput(r *rpctest.Harness, t *testing.T,
+	numSatoshis btcutil.Amount, timeLock int32,
+	isSeconds bool) ([]byte, *wire.OutPoint, *wire.MsgTx, error) {
+
+	// Convert the time-lock to the proper sequence lock based according to
+	// if the lock is seconds or time based.
+	sequenceLock := blockchain.LockTimeToSequence(isSeconds,
+		uint32(timeLock))
+
+	// Our CSV script is simply: <sequenceLock> OP_CSV OP_DROP
+	b := txscript.NewScriptBuilder().
+		AddInt64(int64(sequenceLock)).
+		AddOp(txscript.OP_CHECKSEQUENCEVERIFY).
+		AddOp(txscript.OP_DROP)
+	csvScript, err := b.Script()
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// Using the script generated above, create a P2SH output which will be
+	// accepted into the mempool.
+	p2shAddr, err := btcutil.NewAddressScriptHash(csvScript, r.ActiveNet)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	p2shScript, err := txscript.PayToAddrScript(p2shAddr)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	output := &wire.TxOut{
+		PkScript: p2shScript,
+		Value:    int64(numSatoshis),
+	}
+
+	// Finally create a valid transaction which creates the output crafted
+	// above.
+	tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var outputIndex uint32
+	if !bytes.Equal(tx.TxOut[0].PkScript, p2shScript) {
+		outputIndex = 1
+	}
+
+	utxo := &wire.OutPoint{
+		Hash:  tx.TxHash(),
+		Index: outputIndex,
+	}
+
+	return csvScript, utxo, tx, nil
+}
+
+// spendCSVOutput spends an output previously created by the createCSVOutput
+// function. The sigScript is a trivial push of OP_TRUE followed by the
+// redeemScript to pass P2SH evaluation.
+func spendCSVOutput(redeemScript []byte, csvUTXO *wire.OutPoint,
+	sequence uint32, targetOutput *wire.TxOut,
+	txVersion int32) (*wire.MsgTx, error) {
+
+	tx := wire.NewMsgTx(txVersion)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: *csvUTXO,
+		Sequence:         sequence,
+	})
+	tx.AddTxOut(targetOutput)
+
+	b := txscript.NewScriptBuilder().
+		AddOp(txscript.OP_TRUE).
+		AddData(redeemScript)
+
+	sigScript, err := b.Script()
+	if err != nil {
+		return nil, err
+	}
+	tx.TxIn[0].SignatureScript = sigScript
+
+	return tx, nil
+}
+
+// assertTxInBlock asserts a transaction with the specified txid is found
+// within the block with the passed block hash.
+func assertTxInBlock(r *rpctest.Harness, t *testing.T, blockHash *chainhash.Hash,
+	txid *chainhash.Hash) {
+
+	block, err := r.Node.GetBlock(blockHash)
+	if err != nil {
+		t.Fatalf("unable to get block: %v", err)
+	}
+	if len(block.Transactions) < 2 {
+		t.Fatal("target transaction was not mined")
+	}
+
+	for _, txn := range block.Transactions {
+		txHash := txn.TxHash()
+		if txn.TxHash() == txHash {
+			return
+		}
+	}
+
+	_, _, line, _ := runtime.Caller(1)
+	t.Fatalf("assertion failed at line %v: txid %v was not found in "+
+		"block %v", line, txid, blockHash)
+}
+
+// TestBIP0068AndBIP0112Activation tests for the proper adherence to the BIP
+// 112 and BIP 68 rule-set after the activation of the CSV-package soft-fork.
+//
+// Overview:
+//  - Pre soft-fork:
+//    - A transaction spending a CSV output validly should be rejected from the
+//    mempool, but accepted in a valid generated block including the
+//    transaction.
+//  - Post soft-fork:
+//    - See the cases exercised within the table driven tests towards the end
+//    of this test.
+func TestBIP0068AndBIP0112Activation(t *testing.T) {
+	t.Parallel()
+
+	// We'd like the test proper evaluation and validation of the BIP 68
+	// (sequence locks) and BIP 112 rule-sets which add input-age based
+	// relative lock times.
+
+	btcdCfg := []string{"--rejectnonstd"}
+	r, err := rpctest.New(&chaincfg.SimNetParams, nil, btcdCfg)
+	if err != nil {
+		t.Fatal("unable to create primary harness: ", err)
+	}
+	if err := r.SetUp(true, 1); err != nil {
+		t.Fatalf("unable to setup test chain: %v", err)
+	}
+	defer r.TearDown()
+
+	assertSoftForkStatus(r, t, csvKey, blockchain.ThresholdStarted)
+
+	harnessAddr, err := r.NewAddress()
+	if err != nil {
+		t.Fatalf("unable to obtain harness address: %v", err)
+	}
+	harnessScript, err := txscript.PayToAddrScript(harnessAddr)
+	if err != nil {
+		t.Fatalf("unable to generate pkScript: %v", err)
+	}
+
+	const (
+		outputAmt         = btcutil.SatoshiPerBitcoin
+		relativeBlockLock = 10
+	)
+
+	sweepOutput := &wire.TxOut{
+		Value:    outputAmt - 5000,
+		PkScript: harnessScript,
+	}
+
+	// As the soft-fork hasn't yet activated _any_ transaction version
+	// which uses the CSV opcode should be accepted. Since at this point,
+	// CSV doesn't actually exist, it's just a NOP.
+	for txVersion := int32(0); txVersion < 3; txVersion++ {
+		// Create a trivially spendable output with a CSV lock-time of
+		// 10 relative blocks.
+		redeemScript, testUTXO, tx, err := createCSVOutput(r, t, outputAmt,
+			relativeBlockLock, false)
+		if err != nil {
+			t.Fatalf("unable to create CSV encumbered output: %v", err)
+		}
+
+		// As the transaction is p2sh it should be accepted into the
+		// mempool and found within the next generated block.
+		if _, err := r.Node.SendRawTransaction(tx, true); err != nil {
+			t.Fatalf("unable to broadcast tx: %v", err)
+		}
+		blocks, err := r.Node.Generate(1)
+		if err != nil {
+			t.Fatalf("unable to generate blocks: %v", err)
+		}
+		txid := tx.TxHash()
+		assertTxInBlock(r, t, blocks[0], &txid)
+
+		// Generate a custom transaction which spends the CSV output.
+		sequenceNum := blockchain.LockTimeToSequence(false, 10)
+		spendingTx, err := spendCSVOutput(redeemScript, testUTXO,
+			sequenceNum, sweepOutput, txVersion)
+		if err != nil {
+			t.Fatalf("unable to spend csv output: %v", err)
+		}
+
+		// This transaction should be rejected from the mempool since
+		// CSV validation is already mempool policy pre-fork.
+		_, err = r.Node.SendRawTransaction(spendingTx, true)
+		if err == nil {
+			t.Fatalf("transaction should have been rejected, but was " +
+				"instead accepted")
+		}
+
+		// However, this transaction should be accepted in a custom
+		// generated block as CSV validation for scripts within blocks
+		// shouldn't yet be active.
+		txns := []*btcutil.Tx{btcutil.NewTx(spendingTx)}
+		block, err := r.GenerateAndSubmitBlock(txns, -1, time.Time{})
+		if err != nil {
+			t.Fatalf("unable to submit block: %v", err)
+		}
+		txid = spendingTx.TxHash()
+		assertTxInBlock(r, t, block.Hash(), &txid)
+	}
+
+	// At this point, the block height should be 107: we started at height
+	// 101, then generated 2 blocks in each loop iteration above.
+	assertChainHeight(r, t, 107)
+
+	// With the height at 107 we need 200 blocks to be mined after the
+	// genesis target period, so we mine 192 blocks. This'll put us at
+	// height 299. The getblockchaininfo call checks the state for the
+	// block AFTER the current height.
+	numBlocks := (r.ActiveNet.MinerConfirmationWindow * 2) - 8
+	if _, err := r.Node.Generate(numBlocks); err != nil {
+		t.Fatalf("unable to generate blocks: %v", err)
+	}
+
+	assertChainHeight(r, t, 299)
+	assertSoftForkStatus(r, t, csvKey, blockchain.ThresholdActive)
+
+	// Knowing the number of outputs needed for the tests below, create a
+	// fresh output for use within each of the test-cases below.
+	const relativeTimeLock = 512
+	const numTests = 8
+	type csvOutput struct {
+		RedeemScript []byte
+		Utxo         *wire.OutPoint
+		Timelock     int32
+	}
+	var spendableInputs [numTests]csvOutput
+
+	// Create three outputs which have a block-based sequence locks, and
+	// three outputs which use the above time based sequence lock.
+	for i := 0; i < numTests; i++ {
+		timeLock := relativeTimeLock
+		isSeconds := true
+		if i < 7 {
+			timeLock = relativeBlockLock
+			isSeconds = false
+		}
+
+		redeemScript, utxo, tx, err := createCSVOutput(r, t, outputAmt,
+			int32(timeLock), isSeconds)
+		if err != nil {
+			t.Fatalf("unable to create CSV output: %v", err)
+		}
+
+		if _, err := r.Node.SendRawTransaction(tx, true); err != nil {
+			t.Fatalf("unable to broadcast transaction: %v", err)
+		}
+
+		spendableInputs[i] = csvOutput{
+			RedeemScript: redeemScript,
+			Utxo:         utxo,
+			Timelock:     int32(timeLock),
+		}
+	}
+
+	// Mine a single block including all the transactions generated above.
+	if _, err := r.Node.Generate(1); err != nil {
+		t.Fatalf("unable to generate block: %v", err)
+	}
+
+	// Now mine 10 additional blocks giving the inputs generated above a
+	// age of 11. Space out each block 10 minutes after the previous block.
+	prevBlockHash, err := r.Node.GetBestBlockHash()
+	if err != nil {
+		t.Fatalf("unable to get prior block hash: %v", err)
+	}
+	prevBlock, err := r.Node.GetBlock(prevBlockHash)
+	if err != nil {
+		t.Fatalf("unable to get block: %v", err)
+	}
+	for i := 0; i < relativeBlockLock; i++ {
+		timeStamp := prevBlock.Header.Timestamp.Add(time.Minute * 10)
+		b, err := r.GenerateAndSubmitBlock(nil, -1, timeStamp)
+		if err != nil {
+			t.Fatalf("unable to generate block: %v", err)
+		}
+
+		prevBlock = b.MsgBlock()
+	}
+
+	// A helper function to create fully signed transactions in-line during
+	// the array initialization below.
+	var inputIndex uint32
+	makeTxCase := func(sequenceNum uint32, txVersion int32) *wire.MsgTx {
+		csvInput := spendableInputs[inputIndex]
+
+		tx, err := spendCSVOutput(csvInput.RedeemScript, csvInput.Utxo,
+			sequenceNum, sweepOutput, txVersion)
+		if err != nil {
+			t.Fatalf("unable to spend CSV output: %v", err)
+		}
+
+		inputIndex++
+		return tx
+	}
+
+	tests := [numTests]struct {
+		tx     *wire.MsgTx
+		accept bool
+	}{
+		// A valid transaction with a single input a sequence number
+		// creating a 100 block relative time-lock. This transaction
+		// should be rejected as its version number is 1, and only tx
+		// of version > 2 will trigger the CSV behavior.
+		{
+			tx:     makeTxCase(blockchain.LockTimeToSequence(false, 100), 1),
+			accept: false,
+		},
+		// A transaction of version 2 spending a single input. The
+		// input has a relative time-lock of 1 block, but the disable
+		// bit it set. The transaction should be rejected as a result.
+		{
+			tx: makeTxCase(
+				blockchain.LockTimeToSequence(false, 1)|wire.SequenceLockTimeDisabled,
+				2,
+			),
+			accept: false,
+		},
+		// A v2 transaction with a single input having a 9 block
+		// relative time lock. The referenced input is 11 blocks old,
+		// but the CSV output requires a 10 block relative lock-time.
+		// Therefore, the transaction should be rejected.
+		{
+			tx:     makeTxCase(blockchain.LockTimeToSequence(false, 9), 2),
+			accept: false,
+		},
+		// A v2 transaction with a single input having a 10 block
+		// relative time lock. The referenced input is 11 blocks old so
+		// the transaction should be accepted.
+		{
+			tx:     makeTxCase(blockchain.LockTimeToSequence(false, 10), 2),
+			accept: true,
+		},
+		// A v2 transaction with a single input having a 11 block
+		// relative time lock. The input referenced has an input age of
+		// 11 and the CSV op-code requires 10 blocks to have passed, so
+		// this transaction should be accepted.
+		{
+			tx:     makeTxCase(blockchain.LockTimeToSequence(false, 11), 2),
+			accept: true,
+		},
+		// A v2 transaction whose input has a 1000 blck relative time
+		// lock.  This should be rejected as the input's age is only 11
+		// blocks.
+		{
+			tx:     makeTxCase(blockchain.LockTimeToSequence(false, 1000), 2),
+			accept: false,
+		},
+		// A v2 transaction with a single input having a 512,000 second
+		// relative time-lock. This transaction should be rejected as 6
+		// days worth of blocks haven't yet been mined. The referenced
+		// input doesn't have sufficient age.
+		{
+			tx:     makeTxCase(blockchain.LockTimeToSequence(true, 512000), 2),
+			accept: false,
+		},
+		// A v2 transaction whose single input has a 512 second
+		// relative time-lock. This transaction should be accepted as
+		// finalized.
+		{
+			tx:     makeTxCase(blockchain.LockTimeToSequence(true, 512), 2),
+			accept: true,
+		},
+	}
+
+	for i, test := range tests {
+		txid, err := r.Node.SendRawTransaction(test.tx, true)
+		switch {
+		// Test case passes, nothing further to report.
+		case test.accept && err == nil:
+
+		// Transaction should have been accepted but we have a non-nil
+		// error.
+		case test.accept && err != nil:
+			t.Fatalf("test #%d, transaction should be accepted, "+
+				"but was rejected: %v", i, err)
+
+		// Transaction should have been rejected, but it was accepted.
+		case !test.accept && err == nil:
+			t.Fatalf("test #%d, transaction should be rejected, "+
+				"but was accepted", i)
+
+		// Transaction was rejected as wanted, nothing more to do.
+		case !test.accept && err != nil:
+		}
+
+		// If the transaction should be rejected, manually mine a block
+		// with the non-final transaction. It should be rejected.
+		if !test.accept {
+			txns := []*btcutil.Tx{btcutil.NewTx(test.tx)}
+			_, err := r.GenerateAndSubmitBlock(txns, -1, time.Time{})
+			if err == nil {
+				t.Fatalf("test #%d, invalid block accepted", i)
+			}
+
+			continue
+		}
+
+		// Generate a block, the transaction should be included within
+		// the newly mined block.
+		blockHashes, err := r.Node.Generate(1)
+		if err != nil {
+			t.Fatalf("unable to mine block: %v", err)
+		}
+		assertTxInBlock(r, t, blockHashes[0], txid)
+	}
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1179,6 +1179,8 @@ func handleGetBlockChainInfo(s *rpcServer, cmd interface{}, closeChan <-chan str
 		switch deployment {
 		case chaincfg.DeploymentTestDummy:
 			forkName = "dummy"
+		case chaincfg.DeploymentCSV:
+			forkName = "csv"
 		default:
 			return nil, &btcjson.RPCError{
 				Code: btcjson.ErrRPCInternal.Code,

--- a/rpctest/rpc_harness.go
+++ b/rpctest/rpc_harness.go
@@ -421,7 +421,7 @@ func (h *Harness) GenerateAndSubmitBlock(txns []*btcutil.Tx, blockVersion int32,
 	prevBlock.SetHeight(prevBlockHeight)
 
 	// Create a new block including the specified transactions
-	newBlock, err := createBlock(prevBlock, txns, blockVersion,
+	newBlock, err := CreateBlock(prevBlock, txns, blockVersion,
 		blockTime, h.wallet.coinbaseAddr, h.ActiveNet)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This commit fully implements the CSV-package soft-fork. The CSV-package soft-fork bundles the deployment of the following BIPs: [68](https://github.com/bitcoin/bips/blob/master/bip-0068.mediawiki), [112](https://github.com/bitcoin/bips/blob/master/bip-0112.mediawiki), and [113](https://github.com/bitcoin/bips/blob/master/bip-0113.mediawiki). The activation logic of the soft-fork is governed by [BIP 9](https://github.com/bitcoin/bips/blob/master/bip-0009.mediawiki), VersionBits. 

This PR currently is built upon a combined branch includes #713, #628, #712, and #755. Therefore, **only the last 3 commits** should be examined during code-review. As the aforementioned pending PR's re merged into master, this PR will be updated accordingly to increasingly reflect the final diff. 

A summary of the proposed changes follows: 
- A new `ConsensusDeployment` has been added to the chain parameters for mainnet, testnet, simnet, and regtestnet. This new deployment defines the BIP0009 parameters (bit #, start time, end time) for the CSV-package soft-fork. A new constant, `DeploymentCSV` has been added which uniquely identifies the new deployment within the `Deployments` array for each of the target networks. 
- During non-contextual, and contextual block validation, we now examine the `ThresholdState` for the `CSV` deployment, activating the observance of the new consensus rules once the soft-fork switches to the `ThresholdActive` state. 
  - If the soft-fork is active, then MTP is used for transaction finality checks, the CSV op-code is recognized and validated during Script execution, and a transaction can only be included within a block if the sequence locks for _all_ its inputs have been met. 
- Finally, when selecting transactions for inclusion into the current block template, the version bits state is again checked in order to guard the observance of the new consensus rules. If the soft-fork is active, then transactions can only be included into the to-be-constructed block iff they don't violate any of the new consensus rules. 
