### PR TITLE
blockchain: Expose main chain flag on ProcessBlock.

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -49,7 +49,7 @@ func TestHaveBlock(t *testing.T) {
 	chain.TstSetCoinbaseMaturity(1)
 
 	for i := 1; i < len(blocks); i++ {
-		isOrphan, err := chain.ProcessBlock(blocks[i], blockchain.BFNone)
+		_, isOrphan, err := chain.ProcessBlock(blocks[i], blockchain.BFNone)
 		if err != nil {
 			t.Errorf("ProcessBlock fail on block %v: %v\n", i, err)
 			return
@@ -62,7 +62,7 @@ func TestHaveBlock(t *testing.T) {
 	}
 
 	// Insert an orphan block.
-	isOrphan, err := chain.ProcessBlock(btcutil.NewBlock(&Block100000),
+	_, isOrphan, err := chain.ProcessBlock(btcutil.NewBlock(&Block100000),
 		blockchain.BFNone)
 	if err != nil {
 		t.Errorf("Unable to process block: %v", err)

--- a/blockchain/example_test.go
+++ b/blockchain/example_test.go
@@ -59,11 +59,13 @@ func ExampleBlockChain_ProcessBlock() {
 	// cause an error by trying to process the genesis block which already
 	// exists.
 	genesisBlock := btcutil.NewBlock(chaincfg.MainNetParams.GenesisBlock)
-	isOrphan, err := chain.ProcessBlock(genesisBlock, blockchain.BFNone)
+	isMainChain, isOrphan, err := chain.ProcessBlock(genesisBlock,
+		blockchain.BFNone)
 	if err != nil {
 		fmt.Printf("Failed to process block: %v\n", err)
 		return
 	}
+	fmt.Printf("Block accepted. Is it on the main chain?: %v", isMainChain)
 	fmt.Printf("Block accepted. Is it an orphan?: %v", isOrphan)
 
 	// Output:

--- a/blockchain/reorganization_test.go
+++ b/blockchain/reorganization_test.go
@@ -60,7 +60,7 @@ func TestReorganization(t *testing.T) {
 
 	expectedOrphans := map[int]struct{}{5: {}, 6: {}}
 	for i := 1; i < len(blocks); i++ {
-		isOrphan, err := chain.ProcessBlock(blocks[i], blockchain.BFNone)
+		_, isOrphan, err := chain.ProcessBlock(blocks[i], blockchain.BFNone)
 		if err != nil {
 			t.Errorf("ProcessBlock fail on block %v: %v\n", i, err)
 			return

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -566,7 +566,7 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 
 	// Process the block to include validation, best chain selection, orphan
 	// handling, etc.
-	isOrphan, err := b.chain.ProcessBlock(bmsg.block, behaviorFlags)
+	_, isOrphan, err := b.chain.ProcessBlock(bmsg.block, behaviorFlags)
 	if err != nil {
 		// When the error is a rule error, it means the block was simply
 		// rejected as opposed to something actually going wrong, so log
@@ -1121,8 +1121,8 @@ out:
 				msg.reply <- b.syncPeer
 
 			case processBlockMsg:
-				isOrphan, err := b.chain.ProcessBlock(msg.block,
-					msg.flags)
+				_, isOrphan, err := b.chain.ProcessBlock(
+					msg.block, msg.flags)
 				if err != nil {
 					msg.reply <- processBlockResponse{
 						isOrphan: false,

--- a/cmd/addblock/import.go
+++ b/cmd/addblock/import.go
@@ -129,9 +129,14 @@ func (bi *blockImporter) processBlock(serializedBlock []byte) (bool, error) {
 
 	// Ensure the blocks follows all of the chain rules and match up to the
 	// known checkpoints.
-	isOrphan, err := bi.chain.ProcessBlock(block, blockchain.BFFastAdd)
+	isMainChain, isOrphan, err := bi.chain.ProcessBlock(block,
+		blockchain.BFFastAdd)
 	if err != nil {
 		return false, err
+	}
+	if !isMainChain {
+		return false, fmt.Errorf("import file contains an block that "+
+			"does not extend the main chain: %v", blockHash)
 	}
 	if isOrphan {
 		return false, fmt.Errorf("import file contains an orphan "+


### PR DESCRIPTION
This modifies the `blockchain.ProcessBlock` function to return an additional boolean as the first parameter which indicates whether or not the block ended up on the main chain.

This is primarily useful for upcoming test code that needs to be able to tell the difference between a block accepted to a side chain and a block that either extends the main chain or triggers a reorganize that causes it to become the main chain.  However, it is also useful for the `addblock` utility since it allows a better error in the case a file with out of order blocks is provided and will also be useful for the eventual multi-peer code.