### PR TITLE
blockchain: Remove exported CalcPastTimeMedian func.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -134,7 +134,7 @@ type BestState struct {
 	BlockSize  uint64          // The size of the block.
 	NumTxns    uint64          // The number of txns in the block.
 	TotalTxns  uint64          // The total number of txns in the chain.
-	MedianTime time.Time       // Median time as per CalcPastMedianTime.
+	MedianTime time.Time       // Median time as per calcPastMedianTime.
 }
 
 // newBestState returns a new best stats instance for the given parameters.
@@ -680,18 +680,6 @@ func (b *BlockChain) calcPastMedianTime(startNode *blockNode) (time.Time, error)
 	// changed to an even number, this code will be wrong.
 	medianTimestamp := timestamps[numNodes/2]
 	return medianTimestamp, nil
-}
-
-// CalcPastMedianTime calculates the median time of the previous few blocks
-// prior to, and including, the end of the current best chain.  It is primarily
-// used to ensure new blocks have sane timestamps.
-//
-// This function is safe for concurrent access.
-func (b *BlockChain) CalcPastMedianTime() (time.Time, error) {
-	b.chainLock.Lock()
-	defer b.chainLock.Unlock()
-
-	return b.calcPastMedianTime(b.bestNode)
 }
 
 // getReorganizeNodes finds the fork point between the main chain and the passed

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -213,12 +213,8 @@ func (b *blockManager) updateChainState(newestHash *chainhash.Hash, newestHeight
 
 	b.chainState.newestHash = newestHash
 	b.chainState.newestHeight = newestHeight
-	medianTime, err := b.chain.CalcPastMedianTime()
-	if err != nil {
-		b.chainState.pastMedianTimeErr = err
-	} else {
-		b.chainState.pastMedianTime = medianTime
-	}
+	b.chainState.pastMedianTime = b.chain.BestSnapshot().MedianTime
+	b.chainState.pastMedianTimeErr = nil
 }
 
 // findNextHeaderCheckpoint returns the next checkpoint after the passed height.


### PR DESCRIPTION
This removes the exported `CalcPastTimeMedian` function from the `blockchain` package as it is no longer needed since the information is now available via the `BestState` snapshot.

Also, update the only known caller of this, which is the chain state in block manager, to use the snapshot instead.  In reality, now that everything the block manager chain state provides is available via the
`blockchain` `BestState` snapshot, the entire thing can be removed, however that will be done in a separate to commit to keep the changes targeted.