### PR TITLE
rpctest: Choose flags based on provided params.

### DIFF
--- a/rpctest/node.go
+++ b/rpctest/node.go
@@ -12,10 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
 	"time"
-
-	"github.com/btcsuite/btcd/wire"
 
 	rpc "github.com/btcsuite/btcrpcclient"
 	"github.com/btcsuite/btcutil"
@@ -90,8 +87,6 @@ func (n *nodeConfig) setDefaults() error {
 // process.
 func (n *nodeConfig) arguments() []string {
 	args := []string{}
-	// --simnet
-	args = append(args, fmt.Sprintf("--%s", strings.ToLower(wire.SimNet.String())))
 	if n.rpcUser != "" {
 		// --rpcuser
 		args = append(args, fmt.Sprintf("--rpcuser=%s", n.rpcUser))

--- a/rpctest/rpc_harness.go
+++ b/rpctest/rpc_harness.go
@@ -99,6 +99,22 @@ func New(activeNet *chaincfg.Params, handlers *btcrpcclient.NotificationHandlers
 	harnessStateMtx.Lock()
 	defer harnessStateMtx.Unlock()
 
+	// Add a flag for the appropriate network type based on the provided
+	// chain params.
+	switch activeNet.Net {
+	case wire.MainNet:
+		// No extra flags since mainnet is the default
+	case wire.TestNet3:
+		extraArgs = append(extraArgs, "--testnet")
+	case wire.TestNet:
+		extraArgs = append(extraArgs, "--regtest")
+	case wire.SimNet:
+		extraArgs = append(extraArgs, "--simnet")
+	default:
+		return nil, fmt.Errorf("rpctest.New must be called with one " +
+			"of the supported chain networks")
+	}
+
 	harnessID := strconv.Itoa(int(numTestInstances))
 	nodeTestData, err := ioutil.TempDir("", "rpctest-"+harnessID)
 	if err != nil {


### PR DESCRIPTION
This modifies the `rpctest` framework to start `btcd` with the appropriate network flags depending on the provided parameters.

Previously, it always started `btcd` with `--simnet` even if other parameters, such as those for the regression test network, were provided.