### PR TITLE
txscript: Add null data script creator

### DIFF
--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -358,12 +358,7 @@ func NullDataScript(data []byte) ([]byte, error) {
 		return nil, ErrStackLongScript
 	}
 
-	script := make([]byte, 3+len(data))
-	script[0] = OP_RETURN
-	script[1] = OP_PUSHDATA1
-	script[2] = byte(len(data))
-	copy(script[3:3+len(data)], data)
-	return script, nil
+	return NewScriptBuilder().AddOp(OP_RETURN).AddData(data).Script()
 }
 
 // MultiSigScript returns a valid script for a multisignature redemption where

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -351,6 +351,24 @@ func PayToAddrScript(addr btcutil.Address) ([]byte, error) {
 	return nil, ErrUnsupportedAddress
 }
 
+// NullDataScript creates a provably prunable script
+// containing OP_RETURN followed by the passed data.
+func NullDataScript(data []byte) ([]byte, error) {
+	if len(data) > MaxDataCarrierSize {
+		return nil, ErrStackLongScript
+	}
+
+	return unparseScript([]parsedOpcode{
+		parsedOpcode{
+			opcode: &opcodeArray[OP_RETURN],
+		},
+		parsedOpcode{
+			opcode: &opcodeArray[OP_PUSHDATA1],
+			data:   data,
+		},
+	})
+}
+
 // MultiSigScript returns a valid script for a multisignature redemption where
 // nrequired of the keys in pubkeys are required to have signed the transaction
 // for success.  An ErrBadNumRequired will be returned if nrequired is larger

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -358,15 +358,12 @@ func NullDataScript(data []byte) ([]byte, error) {
 		return nil, ErrStackLongScript
 	}
 
-	return unparseScript([]parsedOpcode{
-		parsedOpcode{
-			opcode: &opcodeArray[OP_RETURN],
-		},
-		parsedOpcode{
-			opcode: &opcodeArray[OP_PUSHDATA1],
-			data:   data,
-		},
-	})
+	script := make([]byte, 3+len(data))
+	script[0] = OP_RETURN
+	script[1] = OP_PUSHDATA1
+	script[2] = byte(len(data))
+	copy(script[3:3+len(data)], data)
+	return script, nil
 }
 
 // MultiSigScript returns a valid script for a multisignature redemption where

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -1028,3 +1028,28 @@ func TestStringifyClass(t *testing.T) {
 		}
 	}
 }
+
+// TestNullDataScript tests whether NullDataScript returns a valid script.
+func TestNullDataScript(t *testing.T) {
+	data := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+		17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
+		34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
+		51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
+		68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79}
+
+	tooLong := append(data, byte(80))
+
+	script, err := txscript.NullDataScript(data)
+	if err != nil {
+		t.Error("Error returned creating script: ", err)
+	}
+	scriptType := txscript.GetScriptClass(script)
+	if scriptType != txscript.NullDataTy {
+		t.Error("Expected a NullDataTy, got ", scriptType)
+	}
+
+	_, tooLongErr := txscript.NullDataScript(tooLong)
+	if tooLongErr == nil || tooLongErr != txscript.ErrStackLongScript {
+		t.Error("Expected ErrStackLongScript, got ", tooLongErr)
+	}
+}

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -1031,25 +1031,86 @@ func TestStringifyClass(t *testing.T) {
 
 // TestNullDataScript tests whether NullDataScript returns a valid script.
 func TestNullDataScript(t *testing.T) {
-	data := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
-		17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33,
-		34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50,
-		51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67,
-		68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79}
+	tiny := hexToBytes("01")
+	short := hexToBytes("0102030405060708090a0b0c0d0e0f1" +
+		"01112131415161718")
+	shortExp := hexToBytes("6a180102030405060708090a0b0c0d0e0f1" +
+		"01112131415161718")
+	justRight := hexToBytes("000102030405060708090a0b0c0d0e0f" +
+		"101112131415161718191a1b1c1d1e1f20212223242526272829" +
+		"2a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40414243" +
+		"4445464748494a4b4c4d4e4f")
+	tooLong := hexToBytes("000102030405060708090a0b0c0d0e0f" +
+		"101112131415161718191a1b1c1d1e1f20212223242526272829" +
+		"2a2b2c2d2e2f303132333435363738393a3b3c3d3e3f40414243" +
+		"4445464748494a4b4c4d4e4f50")
 
-	tooLong := append(data, byte(80))
-
-	script, err := txscript.NullDataScript(data)
-	if err != nil {
-		t.Error("Error returned creating script: ", err)
+	tests := []struct {
+		name     string
+		data     []byte
+		valid    bool
+		expected []byte
+	}{
+		{
+			name:     "small data",
+			data:     tiny,
+			valid:    true,
+			expected: []byte{0x6a, 0x51},
+		},
+		{
+			name:     "data of size before OP_PUSHDATA1 is needed",
+			data:     short,
+			valid:    true,
+			expected: shortExp,
+		},
+		{
+			name:  "just right",
+			data:  justRight,
+			valid: true,
+			expected: append([]byte{
+				OP_RETURN, OP_PUSHDATA1, 80},
+				justRight...),
+		},
+		{
+			name:     "too big",
+			data:     tooLong,
+			valid:    false,
+			expected: nil,
+		},
 	}
-	scriptType := txscript.GetScriptClass(script)
-	if scriptType != txscript.NullDataTy {
-		t.Error("Expected a NullDataTy, got ", scriptType)
-	}
 
-	_, tooLongErr := txscript.NullDataScript(tooLong)
-	if tooLongErr == nil || tooLongErr != txscript.ErrStackLongScript {
-		t.Error("Expected ErrStackLongScript, got ", tooLongErr)
+	for _, test := range tests {
+		script, err := NullDataScript(test.data)
+
+		if !test.valid {
+			if err == nil {
+				t.Errorf("NullDataScript test %v: expected error but none was returned. ",
+					test.name)
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("NullDataScript test %v: Unexpected error returned %v ",
+				test.name, err)
+
+			continue
+		}
+
+		// Check that the expected result was returned.
+		if !bytes.Equal(script, test.expected) {
+			t.Errorf("NullDataScript test %v: Expected %x, got %x",
+				test.name, test.expected, script)
+
+			continue
+		}
+
+		// Check that the script has the correct type.
+		scriptType := GetScriptClass(script)
+		if scriptType != NullDataTy {
+			t.Errorf("NullDataScript test %v: Expected NullDataTy, got %v",
+				test.name, scriptType)
+		}
 	}
 }


### PR DESCRIPTION
NullDataScript takes a byte array and constructs a null data output script. This is used for constructing transactions that contain extra data in provably prunable outputs. 

There is also a bug fix in isNullData. 