### PR TITLE
peer: rename peer.Connect to AssociateConnection

### DIFF
--- a/peer/example_test.go
+++ b/peer/example_test.go
@@ -39,7 +39,7 @@ func mockRemotePeer() error {
 
 		// Create and start the inbound peer.
 		p := peer.NewInboundPeer(peerCfg)
-		p.Connect(conn)
+		p.AssociateConnection(conn)
 	}()
 
 	return nil
@@ -90,7 +90,7 @@ func Example_newOutboundPeer() {
 		fmt.Printf("net.Dial: error %v\n", err)
 		return
 	}
-	p.Connect(conn)
+	p.AssociateConnection(conn)
 
 	// Wait for the verack message or timeout in case of failure.
 	select {

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1860,9 +1860,9 @@ func (p *Peer) QueueInventory(invVect *wire.InvVect) {
 	p.outputInvChan <- invVect
 }
 
-// Connect uses the given conn to connect to the peer. Calling this function when
-// the peer is already connected  will have no effect.
-func (p *Peer) Connect(conn net.Conn) {
+// AssociateConnection associates the given conn to the peer. Calling this
+// function when the peer is already connected will have no effect.
+func (p *Peer) AssociateConnection(conn net.Conn) {
 	// Already connected?
 	if !atomic.CompareAndSwapInt32(&p.connected, 0, 1) {
 		return

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -249,13 +249,13 @@ func TestPeerConnection(t *testing.T) {
 					&conn{raddr: "10.0.0.2:8333"},
 				)
 				inPeer := peer.NewInboundPeer(peerCfg)
-				inPeer.Connect(inConn)
+				inPeer.AssociateConnection(inConn)
 
 				outPeer, err := peer.NewOutboundPeer(peerCfg, "10.0.0.2:8333")
 				if err != nil {
 					return nil, nil, err
 				}
-				outPeer.Connect(outConn)
+				outPeer.AssociateConnection(outConn)
 
 				for i := 0; i < 4; i++ {
 					select {
@@ -275,13 +275,13 @@ func TestPeerConnection(t *testing.T) {
 					&conn{raddr: "10.0.0.2:8333"},
 				)
 				inPeer := peer.NewInboundPeer(peerCfg)
-				inPeer.Connect(inConn)
+				inPeer.AssociateConnection(inConn)
 
 				outPeer, err := peer.NewOutboundPeer(peerCfg, "10.0.0.2:8333")
 				if err != nil {
 					return nil, nil, err
 				}
-				outPeer.Connect(outConn)
+				outPeer.AssociateConnection(outConn)
 
 				for i := 0; i < 4; i++ {
 					select {
@@ -397,7 +397,7 @@ func TestPeerListeners(t *testing.T) {
 		&conn{raddr: "10.0.0.2:8333"},
 	)
 	inPeer := peer.NewInboundPeer(peerCfg)
-	inPeer.Connect(inConn)
+	inPeer.AssociateConnection(inConn)
 
 	peerCfg.Listeners = peer.MessageListeners{
 		OnVerAck: func(p *peer.Peer, msg *wire.MsgVerAck) {
@@ -409,7 +409,7 @@ func TestPeerListeners(t *testing.T) {
 		t.Errorf("NewOutboundPeer: unexpected err %v\n", err)
 		return
 	}
-	outPeer.Connect(outConn)
+	outPeer.AssociateConnection(outConn)
 
 	for i := 0; i < 2; i++ {
 		select {
@@ -549,8 +549,8 @@ func TestOutboundPeer(t *testing.T) {
 	}
 
 	// Test trying to connect twice.
-	p.Connect(c)
-	p.Connect(c)
+	p.AssociateConnection(c)
+	p.AssociateConnection(c)
 
 	disconnected := make(chan struct{})
 	go func() {
@@ -603,7 +603,7 @@ func TestOutboundPeer(t *testing.T) {
 		t.Errorf("NewOutboundPeer: unexpected err - %v\n", err)
 		return
 	}
-	p1.Connect(c1)
+	p1.AssociateConnection(c1)
 
 	// Test update latest block
 	latestBlockHash, err := chainhash.NewHashFromStr("1a63f9cdff1752e6375c8c76e543a71d239e1a2e5c6db1aa679")
@@ -633,7 +633,7 @@ func TestOutboundPeer(t *testing.T) {
 		t.Errorf("NewOutboundPeer: unexpected err - %v\n", err)
 		return
 	}
-	p2.Connect(c2)
+	p2.AssociateConnection(c2)
 
 	// Test PushXXX
 	var addrs []*wire.NetAddress

--- a/server.go
+++ b/server.go
@@ -1624,7 +1624,7 @@ func (s *server) listenHandler(listener net.Listener) {
 		sp := newServerPeer(s, false)
 		sp.Peer = peer.NewInboundPeer(newPeerConfig(sp))
 		go s.peerDoneHandler(sp)
-		sp.Connect(conn)
+		sp.AssociateConnection(conn)
 	}
 	s.wg.Done()
 	srvrLog.Tracef("Listener handler done for %s", listener.Addr())
@@ -1720,7 +1720,7 @@ func (s *server) establishConn(sp *serverPeer) error {
 	if err != nil {
 		return err
 	}
-	sp.Connect(conn)
+	sp.AssociateConnection(conn)
 	s.addrManager.Attempt(sp.NA())
 	return nil
 }


### PR DESCRIPTION
As mentioned in #653 the renamed the method which associates the connection to the peer as `AssociateConnection` rather than `Connect` for clarity.