### PR TITLE
mempool: Rename RelayNonStd config option.

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -80,11 +80,10 @@ type Policy struct {
 	// transactions that do not have enough priority to be relayed.
 	DisableRelayPriority bool
 
-	// RelayNonStd defines whether to relay non-standard transactions. If
-	// true, non-standard transactions will be accepted into the mempool
-	// and relayed. Otherwise, all non-standard transactions will be
-	// rejected.
-	RelayNonStd bool
+	// AcceptNonStd defines whether to accept non-standard transactions. If
+	// true, non-standard transactions will be accepted into the mempool.
+	// Otherwise, all non-standard transactions will be rejected.
+	AcceptNonStd bool
 
 	// FreeTxRelayLimit defines the given amount in thousands of bytes
 	// per minute that transactions with no fee are rate limited to.
@@ -546,8 +545,8 @@ func (mp *TxPool) maybeAcceptTransaction(tx *btcutil.Tx, isNew, rateLimit bool) 
 	nextBlockHeight := bestHeight + 1
 
 	// Don't allow non-standard transactions if the network parameters
-	// forbid their relaying.
-	if !mp.cfg.Policy.RelayNonStd {
+	// forbid their acceptance.
+	if !mp.cfg.Policy.AcceptNonStd {
 		medianTimePast := mp.cfg.MedianTimePast()
 		err = checkTransactionStandard(tx, nextBlockHeight,
 			medianTimePast, mp.cfg.Policy.MinRelayTxFee)
@@ -632,8 +631,8 @@ func (mp *TxPool) maybeAcceptTransaction(tx *btcutil.Tx, isNew, rateLimit bool) 
 	}
 
 	// Don't allow transactions with non-standard inputs if the network
-	// parameters forbid their relaying.
-	if !mp.cfg.Policy.RelayNonStd {
+	// parameters forbid their acceptance.
+	if !mp.cfg.Policy.AcceptNonStd {
 		err := checkInputsStandard(tx, utxoView)
 		if err != nil {
 			// Attempt to extract a reject code from the error so

--- a/server.go
+++ b/server.go
@@ -2349,7 +2349,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	txC := mempool.Config{
 		Policy: mempool.Policy{
 			DisableRelayPriority: cfg.NoRelayPriority,
-			RelayNonStd:          cfg.RelayNonStd,
+			AcceptNonStd:         cfg.RelayNonStd,
 			FreeTxRelayLimit:     cfg.FreeTxRelayLimit,
 			MaxOrphanTxs:         cfg.MaxOrphanTxs,
 			MaxOrphanTxSize:      defaultMaxOrphanTxSize,


### PR DESCRIPTION
This renames the `mempool.Config.RelayNonStd` option to `AcceptNonStd` which more accurately describes its behavior since the `mempool` was refactored into a separate package.

The reasoning for this change is that the `mempool` is not responsible for relaying transactions (nor should it be).  Its job is to maintain a pool of unmined transactions that are validated according to consensus and policy configuration options which are then used to provide a source of transactions that need to be mined.

Instead, it is the server that is responsible for relaying transactions.  While it is true that the current server code currently only relays txns that were accepted to the `mempool`, this does not necessarily have to be the case.  It would be entirely possible (and perhaps even a good idea as something do in the future), to separate the relay policy from the `mempool` acceptance policy (and thus indirectly the mining policy).