### PR TITLE
mempool: Implement orphan expiration.

### DIFF
--- a/mempool/log.go
+++ b/mempool/log.go
@@ -30,3 +30,12 @@ func DisableLog() {
 func UseLogger(logger btclog.Logger) {
 	log = logger
 }
+
+// pickNoun returns the singular or plural form of a noun depending
+// on the count n.
+func pickNoun(n int, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}


### PR DESCRIPTION
**This requires PR #806**

This implements orphan expiration in the `mempool` such that any orphans that have not had their ancestors materialize within 15 minutes of their initial arrival time will be evicted which in turn will remove any other orphans that attempted to redeem it.

In order to perform the evictions with reasonable efficiency, an opportunistic scan interval of 5 minutes is used.  That is to say that there is not a hard deadline on the scan interval and instead it runs when a new orphan is added to the pool if enough time has passed.

The following is an example of running this code against the main network for around 30 minutes:

> 23:05:34 2016-10-24 [DBG] TXMP: Expired 3 orphans (remaining: 254)
> 23:10:38 2016-10-24 [DBG] TXMP: Expired 112 orphans (remaining: 231)
> 23:15:43 2016-10-24 [DBG] TXMP: Expired 95 orphans (remaining: 206)
> 23:20:44 2016-10-24 [DBG] TXMP: Expired 90 orphans (remaining: 191)
> 23:25:51 2016-10-24 [DBG] TXMP: Expired 71 orphans (remaining: 191)
> 23:30:55 2016-10-24 [DBG] TXMP: Expired 70 orphans (remaining: 105)
> 23:36:19 2016-10-24 [DBG] TXMP: Expired 55 orphans (remaining: 107)

As can be seen from the above, without orphan expiration on this data set, the orphan pool would have grown an additional 496 entries.