### PR TITLE
mining: Introduce a block template generator.

### DIFF
--- a/server.go
+++ b/server.go
@@ -2365,7 +2365,9 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	}
 	s.txMemPool = mempool.New(&txC)
 
-	// Create the mining policy based on the configuration options.
+	// Create the mining policy and block template generator based on the
+	// configuration options.
+	//
 	// NOTE: The CPU miner relies on the mempool, so the mempool has to be
 	// created before calling the function to create the CPU miner.
 	policy := mining.Policy{
@@ -2374,7 +2376,9 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		BlockPrioritySize: cfg.BlockPrioritySize,
 		TxMinFreeFee:      cfg.minRelayTxFee,
 	}
-	s.cpuMiner = newCPUMiner(&policy, &s)
+	blockTemplateGenerator := newBlkTmplGenerator(&policy, s.txMemPool,
+		s.timeSource, s.sigCache, bm)
+	s.cpuMiner = newCPUMiner(blockTemplateGenerator, &s)
 
 	// Only setup a function to return new addresses to connect to when
 	// not running in connect-only mode.  The simulation network is always
@@ -2449,7 +2453,8 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	}
 
 	if !cfg.DisableRPC {
-		s.rpcServer, err = newRPCServer(cfg.RPCListeners, &policy, &s)
+		s.rpcServer, err = newRPCServer(cfg.RPCListeners,
+			blockTemplateGenerator, &s)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**This requires PR #809**

This introduces a new type named `BlkTmplGenerator` which encapsulates the various state needed to generate block templates.

This is useful since it means code that needs to generate block templates can simply accept the generator rather than needing access to all of the additional state which in turn will ultimately make it easier to split the mining code into its own package.
