### PR TITLE
cpuminer: Introduce cpuminerConfig.

### DIFF
--- a/server.go
+++ b/server.go
@@ -2382,7 +2382,14 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	}
 	blockTemplateGenerator := newBlkTmplGenerator(&policy, s.txMemPool,
 		s.timeSource, s.sigCache, bm)
-	s.cpuMiner = newCPUMiner(blockTemplateGenerator, &s)
+	s.cpuMiner = newCPUMiner(&cpuminerConfig{
+		ChainParams:            chainParams,
+		BlockTemplateGenerator: blockTemplateGenerator,
+		MiningAddrs:            cfg.miningAddrs,
+		ProcessBlock:           bm.ProcessBlock,
+		ConnectedCount:         s.ConnectedCount,
+		IsCurrent:              bm.IsCurrent,
+	})
 
 	// Only setup a function to return new addresses to connect to when
 	// not running in connect-only mode.  The simulation network is always


### PR DESCRIPTION
This introduces a `cpuminerConfig` type which contains the necessary information to break the direct dependency on the main server instance.

This change is a step towards being able to separate the cpu miner into its own subpackage.  No functional change.