### PR TITLE
wire: Make NewMsgTx accept the tx version.

### DIFF
--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -282,7 +282,7 @@ func (g *testGenerator) createCoinbaseTx(blockHeight int32) *wire.MsgTx {
 		panic(err)
 	}
 
-	tx := wire.NewMsgTx()
+	tx := wire.NewMsgTx(1)
 	tx.AddTxIn(&wire.TxIn{
 		// Coinbase transactions have no inputs, so previous outpoint is
 		// zero hash and max index.
@@ -436,7 +436,7 @@ func additionalTx(tx *wire.MsgTx) func(*wire.MsgBlock) {
 // script which avoids the need to track addresses and signature scripts in the
 // tests.
 func createSpendTx(spend *spendableOut, fee btcutil.Amount) *wire.MsgTx {
-	spendTx := wire.NewMsgTx()
+	spendTx := wire.NewMsgTx(1)
 	spendTx.AddTxIn(&wire.TxIn{
 		PreviousOutPoint: spend.prevOut,
 		Sequence:         wire.MaxTxInSequenceNum,

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -111,8 +111,7 @@ func TestCheckBlockSanity(t *testing.T) {
 func TestCheckSerializedHeight(t *testing.T) {
 	// Create an empty coinbase template to be used in the tests below.
 	coinbaseOutpoint := wire.NewOutPoint(&chainhash.Hash{}, math.MaxUint32)
-	coinbaseTx := wire.NewMsgTx()
-	coinbaseTx.Version = 2
+	coinbaseTx := wire.NewMsgTx(1)
 	coinbaseTx.AddTxIn(wire.NewTxIn(coinbaseOutpoint, nil))
 
 	// Expected rule errors.

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,12 @@
 hash: 8f89ba1940f8798b8a0449810532e3f0bc552ed97d907bc3447a8941a2ea3a4a
-updated: 2016-09-21T18:04:46.586977232-04:00
+updated: 2016-10-26T22:53:00.0848822-05:00
 imports:
 - name: github.com/btcsuite/btclog
   version: 73889fb79bd687870312b6e40effcecffbd57d30
 - name: github.com/btcsuite/btcrpcclient
   version: 2b780d16b042054d07aa322146194118fd7f7b81
 - name: github.com/btcsuite/btcutil
-  version: 68e5965458062d031a6e333b35c778ce464fb73f
+  version: aa9087a7efc961fbd253d4ae9c8b7a318749c273
   subpackages:
   - .
   - base58

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -152,7 +152,7 @@ func (p *poolHarness) CreateCoinbaseTx(blockHeight int32, numOutputs uint32) (*b
 		return nil, err
 	}
 
-	tx := wire.NewMsgTx()
+	tx := wire.NewMsgTx(wire.TxVersion)
 	tx.AddTxIn(&wire.TxIn{
 		// Coinbase transactions have no inputs, so previous outpoint is
 		// zero hash and max index.
@@ -194,7 +194,7 @@ func (p *poolHarness) CreateSignedTx(inputs []spendableOutput, numOutputs uint32
 	amountPerOutput := int64(totalInput) / int64(numOutputs)
 	remainder := int64(totalInput) - amountPerOutput*int64(numOutputs)
 
-	tx := wire.NewMsgTx()
+	tx := wire.NewMsgTx(wire.TxVersion)
 	for _, input := range inputs {
 		tx.AddTxIn(&wire.TxIn{
 			PreviousOutPoint: input.outPoint,
@@ -240,7 +240,7 @@ func (p *poolHarness) CreateTxChain(firstOutput spendableOutput, numTxns uint32)
 		// Create the transaction using the previous transaction output
 		// and paying the full amount to the payment address associated
 		// with the harness.
-		tx := wire.NewMsgTx()
+		tx := wire.NewMsgTx(wire.TxVersion)
 		tx.AddTxIn(&wire.TxIn{
 			PreviousOutPoint: prevOutPoint,
 			SignatureScript:  nil,

--- a/mining/mining.go
+++ b/mining/mining.go
@@ -268,7 +268,7 @@ func createCoinbaseTx(params *chaincfg.Params, coinbaseScript []byte, nextBlockH
 		}
 	}
 
-	tx := wire.NewMsgTx()
+	tx := wire.NewMsgTx(wire.TxVersion)
 	tx.AddTxIn(&wire.TxIn{
 		// Coinbase transactions have no inputs, so previous outpoint is
 		// zero hash and max index.

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -450,7 +450,7 @@ func TestPeerListeners(t *testing.T) {
 		},
 		{
 			"OnTx",
-			wire.NewMsgTx(),
+			wire.NewMsgTx(wire.TxVersion),
 		},
 		{
 			"OnBlock",

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -538,7 +538,7 @@ func handleCreateRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan 
 
 	// Add all transaction inputs to a new transaction after performing
 	// some validity checks.
-	mtx := wire.NewMsgTx()
+	mtx := wire.NewMsgTx(wire.TxVersion)
 	for _, input := range c.Inputs {
 		txHash, err := chainhash.NewHashFromStr(input.Txid)
 		if err != nil {
@@ -3402,8 +3402,8 @@ func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan st
 	if err != nil {
 		return nil, rpcDecodeHexError(hexStr)
 	}
-	msgtx := wire.NewMsgTx()
-	err = msgtx.Deserialize(bytes.NewReader(serializedTx))
+	var msgTx wire.MsgTx
+	err = msgTx.Deserialize(bytes.NewReader(serializedTx))
 	if err != nil {
 		return nil, &btcjson.RPCError{
 			Code:    btcjson.ErrRPCDeserialization,
@@ -3411,7 +3411,7 @@ func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan st
 		}
 	}
 
-	tx := btcutil.NewTx(msgtx)
+	tx := btcutil.NewTx(&msgTx)
 	acceptedTxs, err := s.server.txMemPool.ProcessTransaction(tx, false, false)
 	if err != nil {
 		// When the error is a rule error, it means the transaction was

--- a/rpctest/blockgen.go
+++ b/rpctest/blockgen.go
@@ -96,7 +96,7 @@ func createCoinbaseTx(coinbaseScript []byte, nextBlockHeight int32,
 		return nil, err
 	}
 
-	tx := wire.NewMsgTx()
+	tx := wire.NewMsgTx(wire.TxVersion)
 	tx.AddTxIn(&wire.TxIn{
 		// Coinbase transactions have no inputs, so previous outpoint is
 		// zero hash and max index.

--- a/rpctest/memwallet.go
+++ b/rpctest/memwallet.go
@@ -437,7 +437,7 @@ func (m *memWallet) CreateTransaction(outputs []*wire.TxOut, feeRate btcutil.Amo
 	m.Lock()
 	defer m.Unlock()
 
-	tx := wire.NewMsgTx()
+	tx := wire.NewMsgTx(wire.TxVersion)
 
 	// Tally up the total amount to be sent in order to perform coin
 	// selection shortly below.

--- a/txscript/example_test.go
+++ b/txscript/example_test.go
@@ -101,7 +101,7 @@ func ExampleSignTxOutput() {
 	// For this example, create a fake transaction that represents what
 	// would ordinarily be the real transaction that is being spent.  It
 	// contains a single output that pays to address in the amount of 1 BTC.
-	originTx := wire.NewMsgTx()
+	originTx := wire.NewMsgTx(wire.TxVersion)
 	prevOut := wire.NewOutPoint(&chainhash.Hash{}, ^uint32(0))
 	txIn := wire.NewTxIn(prevOut, []byte{txscript.OP_0, txscript.OP_0})
 	originTx.AddTxIn(txIn)
@@ -115,7 +115,7 @@ func ExampleSignTxOutput() {
 	originTxHash := originTx.TxHash()
 
 	// Create the transaction to redeem the fake transaction.
-	redeemTx := wire.NewMsgTx()
+	redeemTx := wire.NewMsgTx(wire.TxVersion)
 
 	// Add the input(s) the redeeming transaction will spend.  There is no
 	// signature script at this point since it hasn't been created or signed

--- a/txscript/reference_test.go
+++ b/txscript/reference_test.go
@@ -164,7 +164,7 @@ func parseScriptFlags(flagStr string) (ScriptFlags, error) {
 // createSpendTx generates a basic spending transaction given the passed
 // signature and public key scripts.
 func createSpendingTx(sigScript, pkScript []byte) *wire.MsgTx {
-	coinbaseTx := wire.NewMsgTx()
+	coinbaseTx := wire.NewMsgTx(wire.TxVersion)
 
 	outPoint := wire.NewOutPoint(&chainhash.Hash{}, ^uint32(0))
 	txIn := wire.NewTxIn(outPoint, []byte{OP_0, OP_0})
@@ -172,7 +172,7 @@ func createSpendingTx(sigScript, pkScript []byte) *wire.MsgTx {
 	coinbaseTx.AddTxIn(txIn)
 	coinbaseTx.AddTxOut(txOut)
 
-	spendingTx := wire.NewMsgTx()
+	spendingTx := wire.NewMsgTx(wire.TxVersion)
 	coinbaseTxHash := coinbaseTx.TxHash()
 	outPoint = wire.NewOutPoint(&coinbaseTxHash, 0)
 	txIn = wire.NewTxIn(outPoint, sigScript)
@@ -642,7 +642,7 @@ func TestCalcSignatureHash(t *testing.T) {
 			t.Fatalf("TestCalcSignatureHash: Test #%d has "+
 				"wrong length.", i)
 		}
-		tx := wire.NewMsgTx()
+		var tx wire.MsgTx
 		rawTx, _ := hex.DecodeString(test[0].(string))
 		err := tx.Deserialize(bytes.NewReader(rawTx))
 		if err != nil {
@@ -660,7 +660,7 @@ func TestCalcSignatureHash(t *testing.T) {
 		}
 
 		hashType := SigHashType(testVecF64ToUint32(test[3].(float64)))
-		hash := calcSignatureHash(parsedScript, hashType, tx,
+		hash := calcSignatureHash(parsedScript, hashType, &tx,
 			int(test[2].(float64)))
 
 		expectedHash, _ := chainhash.NewHashFromStr(test[4].(string))

--- a/txscript/sign_test.go
+++ b/txscript/sign_test.go
@@ -1629,7 +1629,7 @@ func TestSignatureScript(t *testing.T) {
 
 nexttest:
 	for i := range sigScriptTests {
-		tx := wire.NewMsgTx()
+		tx := wire.NewMsgTx(wire.TxVersion)
 
 		output := wire.NewTxOut(500, []byte{OP_RETURN})
 		tx.AddTxOut(output)

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -62,7 +62,7 @@ func TestMessage(t *testing.T) {
 	msgInv := NewMsgInv()
 	msgGetData := NewMsgGetData()
 	msgNotFound := NewMsgNotFound()
-	msgTx := NewMsgTx()
+	msgTx := NewMsgTx(1)
 	msgPing := NewMsgPing(123123)
 	msgPong := NewMsgPong(123123)
 	msgGetHeaders := NewMsgGetHeaders()

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -636,9 +636,9 @@ func (msg *MsgTx) PkScriptLocs() []int {
 // are no transaction inputs or outputs.  Also, the lock time is set to zero
 // to indicate the transaction is valid immediately as opposed to some time in
 // future.
-func NewMsgTx() *MsgTx {
+func NewMsgTx(version int32) *MsgTx {
 	return &MsgTx{
-		Version: TxVersion,
+		Version: version,
 		TxIn:    make([]*TxIn, 0, defaultTxInOutAlloc),
 		TxOut:   make([]*TxOut, 0, defaultTxInOutAlloc),
 	}

--- a/wire/msgtx_test.go
+++ b/wire/msgtx_test.go
@@ -28,7 +28,7 @@ func TestTx(t *testing.T) {
 
 	// Ensure the command is expected value.
 	wantCmd := "tx"
-	msg := NewMsgTx()
+	msg := NewMsgTx(1)
 	if cmd := msg.Command(); cmd != wantCmd {
 		t.Errorf("NewMsgAddr: wrong command - got %v want %v",
 			cmd, wantCmd)
@@ -139,7 +139,7 @@ func TestTxHash(t *testing.T) {
 	}
 
 	// First transaction from block 113875.
-	msgTx := NewMsgTx()
+	msgTx := NewMsgTx(1)
 	txIn := TxIn{
 		PreviousOutPoint: OutPoint{
 			Hash:  chainhash.Hash{},
@@ -180,7 +180,7 @@ func TestTxHash(t *testing.T) {
 // of transaction inputs and outputs and protocol versions.
 func TestTxWire(t *testing.T) {
 	// Empty tx message.
-	noTx := NewMsgTx()
+	noTx := NewMsgTx(1)
 	noTx.Version = 1
 	noTxEncoded := []byte{
 		0x01, 0x00, 0x00, 0x00, // Version
@@ -374,7 +374,7 @@ func TestTxWireErrors(t *testing.T) {
 
 // TestTxSerialize tests MsgTx serialize and deserialize.
 func TestTxSerialize(t *testing.T) {
-	noTx := NewMsgTx()
+	noTx := NewMsgTx(1)
 	noTx.Version = 1
 	noTxEncoded := []byte{
 		0x01, 0x00, 0x00, 0x00, // Version
@@ -615,7 +615,7 @@ func TestTxOverflowErrors(t *testing.T) {
 // transactions is accurate.
 func TestTxSerializeSize(t *testing.T) {
 	// Empty tx message.
-	noTx := NewMsgTx()
+	noTx := NewMsgTx(1)
 	noTx.Version = 1
 
 	tests := []struct {


### PR DESCRIPTION
**Requires PR btcsuite/btcutil#82**

This modifies the `NewMsgTx` function to accept the transaction version as a parameter and updates all callers.

The reason for this change is so the transaction version can be bumped in wire without breaking existing tests and to provide the caller with the flexibility to create the specific transaction version they desire.