### PR TITLE
server: Notify connmgr of available connection requests.

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1865,7 +1865,7 @@ func (p *Peer) QueueInventory(invVect *wire.InvVect) {
 	p.outputInvChan <- invVect
 }
 
-// AssociateConnection associates the given conn to the peer. Calling this
+// AssociateConnection associates the given conn to the peer.   Calling this
 // function when the peer is already connected will have no effect.
 func (p *Peer) AssociateConnection(conn net.Conn) {
 	// Already connected?
@@ -1893,7 +1893,7 @@ func (p *Peer) AssociateConnection(conn net.Conn) {
 
 	go func() {
 		if err := p.start(); err != nil {
-			log.Warnf("Cannot start peer %v: %v", p, err)
+			log.Debugf("Cannot start peer %v: %v", p, err)
 			p.Disconnect()
 		}
 	}()
@@ -1970,7 +1970,6 @@ func (p *Peer) WaitForDisconnect() {
 // peer.  If the next message is not a version message or the version is not
 // acceptable then return an error.
 func (p *Peer) readRemoteVersionMsg() error {
-
 	// Read their version message.
 	msg, _, err := p.readMessage()
 	if err != nil {
@@ -1999,7 +1998,6 @@ func (p *Peer) readRemoteVersionMsg() error {
 
 // writeLocalVersionMsg writes our version message to the remote peer.
 func (p *Peer) writeLocalVersionMsg() error {
-
 	localVerMsg, err := p.localVersionMsg()
 	if err != nil {
 		return err
@@ -2019,7 +2017,6 @@ func (p *Peer) writeLocalVersionMsg() error {
 // then sends our version message. If the events do not occur in that order then
 // it returns an error.
 func (p *Peer) negotiateInboundProtocol() error {
-
 	if err := p.readRemoteVersionMsg(); err != nil {
 		return err
 	}
@@ -2031,7 +2028,6 @@ func (p *Peer) negotiateInboundProtocol() error {
 // version message from the peer.  If the events do not occur in that order then
 // it returns an error.
 func (p *Peer) negotiateOutboundProtocol() error {
-
 	if err := p.writeLocalVersionMsg(); err != nil {
 		return err
 	}

--- a/server.go
+++ b/server.go
@@ -1245,7 +1245,7 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 		if !sp.Inbound() && sp.VersionKnown() {
 			state.outboundGroups[addrmgr.GroupKey(sp.NA())]--
 		}
-		if sp.persistent && sp.connReq != nil {
+		if !sp.Inbound() && sp.connReq != nil {
 			s.connManager.Disconnect(sp.connReq.ID())
 		}
 		delete(list, sp.ID())
@@ -1568,25 +1568,30 @@ func (s *server) listenHandler(listener net.Listener) {
 		}
 		sp := newServerPeer(s, false)
 		sp.Peer = peer.NewInboundPeer(newPeerConfig(sp))
-		go s.peerDoneHandler(sp)
 		sp.AssociateConnection(conn)
+		go s.peerDoneHandler(sp)
 	}
 	s.wg.Done()
 	srvrLog.Tracef("Listener handler done for %s", listener.Addr())
 }
 
-// newOutboundPeer initializes a new outbound peer and setups the message
-// listeners.
-func (s *server) newOutboundPeer(addr string, persistent bool) *serverPeer {
-	sp := newServerPeer(s, persistent)
-	p, err := peer.NewOutboundPeer(newPeerConfig(sp), addr)
+// outboundPeerConnected is invoked by the connection manager when a new
+// outbound connection is established.  It initializes a new outbound server
+// peer instance, associates it with the relevant state such as the connection
+// request instance and the connection itself, and finally notifies the address
+// manager of the attempt.
+func (s *server) outboundPeerConnected(c *connmgr.ConnReq, conn net.Conn) {
+	sp := newServerPeer(s, c.Permanent)
+	p, err := peer.NewOutboundPeer(newPeerConfig(sp), c.Addr)
 	if err != nil {
-		srvrLog.Errorf("Cannot create outbound peer %s: %v", addr, err)
-		return nil
+		srvrLog.Debugf("Cannot create outbound peer %s: %v", c.Addr, err)
+		s.connManager.Disconnect(c.ID())
 	}
 	sp.Peer = p
+	sp.connReq = c
+	sp.AssociateConnection(conn)
 	go s.peerDoneHandler(sp)
-	return sp
+	s.addrManager.Attempt(sp.NA())
 }
 
 // peerDoneHandler handles peer disconnects by notifiying the server that it's
@@ -2430,14 +2435,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		RetryDuration: connectionRetryInterval,
 		MaxOutbound:   defaultMaxOutbound,
 		Dial:          btcdDial,
-		OnConnection: func(c *connmgr.ConnReq, conn net.Conn) {
-			sp := s.newOutboundPeer(c.Addr, c.Permanent)
-			if sp != nil {
-				sp.AssociateConnection(conn)
-				sp.connReq = c
-				s.addrManager.Attempt(sp.NA())
-			}
-		},
+		OnConnection:  s.outboundPeerConnected,
 		GetNewAddress: newAddressFunc,
 	})
 	if err != nil {


### PR DESCRIPTION
This corrects a few issues introduced with the connection manager where the server was not notifying the connection manager when a connection request is available again.

The cases resolved are:
- Unable to initialize a server peer instance in response to the connection
- Failure to associate the connection with the server peer instance
- Disconnection of a non-persistent outbound peer

It also changes the log message to a debug in the former case because it's not something that should be shown to the user as an error given it's not due to anything the user has misconfigured nor is it even unexpected if an invalid address is provided.

Finally, it also changes the log message in peer for inability to start a peer to debug since the inability for a peer to negotiate is not something that should be a warning which implies something is wrong.  On the contrary, it is quite expected that various peers will connect (or be connected to) that are unable to properly negotiate for a variety of reasons.  One example would be a peer that is too old.
