### PR TITLE
cpuminer: Refactor code to its own package.

### DIFF
--- a/cpuminer.go
+++ b/cpuminer.go
@@ -548,14 +548,6 @@ func (m *CPUMiner) NumWorkers() int32 {
 func (m *CPUMiner) GenerateNBlocks(n uint32) ([]*chainhash.Hash, error) {
 	m.Lock()
 
-	// Respond with an error if there's virtually 0 chance of CPU-mining a block.
-	if !m.cfg.ChainParams.GenerateSupported {
-		m.Unlock()
-		return nil, errors.New("No support for `generate` on the current " +
-			"network, " + m.cfg.ChainParams.Net.String() +
-			", as it's unlikely to be possible to CPU-mine a block.")
-	}
-
 	// Respond with an error if server is already mining.
 	if m.started || m.discreteMining {
 		m.Unlock()

--- a/log.go
+++ b/log.go
@@ -15,6 +15,7 @@ import (
 	"github.com/btcsuite/btcd/database"
 	"github.com/btcsuite/btcd/mempool"
 	"github.com/btcsuite/btcd/mining"
+	"github.com/btcsuite/btcd/mining/cpuminer"
 	"github.com/btcsuite/btcd/peer"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btclog"
@@ -129,6 +130,7 @@ func useLogger(subsystemID string, logger btclog.Logger) {
 	case "MINR":
 		minrLog = logger
 		mining.UseLogger(logger)
+		cpuminer.UseLogger(logger)
 
 	case "PEER":
 		peerLog = logger

--- a/mining/cpuminer/README.md
+++ b/mining/cpuminer/README.md
@@ -1,0 +1,26 @@
+cpuminer
+========
+
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
+(https://travis-ci.org/btcsuite/btcd) [![ISC License]
+(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
+(http://godoc.org/github.com/btcsuite/btcd/mining/cpuminer)
+
+## Overview
+
+This package is currently a work in progress.  It works without issue since it
+is used in several of the integration tests, but the API is not really ready for
+public consumption as it has simply been refactored out of the main codebase for
+now.
+
+## Installation and Updating
+
+```bash
+$ go get -u github.com/btcsuite/btcd/mining/cpuminer
+```
+
+## License
+
+Package cpuminer is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/mining/cpuminer/log.go
+++ b/mining/cpuminer/log.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package cpuminer
+
+import (
+	"errors"
+	"io"
+
+	"github.com/btcsuite/btclog"
+)
+
+// log is a logger that is initialized with no output filters.  This
+// means the package will not perform any logging by default until the caller
+// requests it.
+var log btclog.Logger
+
+// The default amount of logging is none.
+func init() {
+	DisableLog()
+}
+
+// DisableLog disables all library log output.  Logging output is disabled
+// by default until either UseLogger or SetLogWriter are called.
+func DisableLog() {
+	log = btclog.Disabled
+}
+
+// UseLogger uses a specified Logger to output package logging info.
+// This should be used in preference to SetLogWriter if the caller is also
+// using btclog.
+func UseLogger(logger btclog.Logger) {
+	log = logger
+}
+
+// SetLogWriter uses a specified io.Writer to output package logging info.
+// This allows a caller to direct package logging output without needing a
+// dependency on seelog.  If the caller is also using btclog, UseLogger should
+// be used instead.
+func SetLogWriter(w io.Writer, level string) error {
+	if w == nil {
+		return errors.New("nil writer")
+	}
+
+	lvl, ok := btclog.LogLevelFromString(level)
+	if !ok {
+		return errors.New("invalid log level")
+	}
+
+	l, err := btclog.NewLoggerFromWriter(w, lvl)
+	if err != nil {
+		return err
+	}
+
+	UseLogger(l)
+	return nil
+}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -856,6 +856,19 @@ func handleGenerate(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (i
 		}
 	}
 
+	// Respond with an error if there's virtually 0 chance of mining a block
+	// with the CPU.
+	params := s.server.chainParams
+	if !s.server.chainParams.GenerateSupported {
+		return nil, &btcjson.RPCError{
+			Code: btcjson.ErrRPCDifficulty,
+			Message: fmt.Sprintf("No support for `generate` on "+
+				"the current network, %s, as it's unlikely to "+
+				"be possible to main a block with the CPU.",
+				params.Net),
+		}
+	}
+
 	c := cmd.(*btcjson.GenerateCmd)
 
 	// Respond with an error if the client is requesting 0 blocks to be generated.

--- a/server.go
+++ b/server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/btcsuite/btcd/database"
 	"github.com/btcsuite/btcd/mempool"
 	"github.com/btcsuite/btcd/mining"
+	"github.com/btcsuite/btcd/mining/cpuminer"
 	"github.com/btcsuite/btcd/peer"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
@@ -153,7 +154,7 @@ type server struct {
 	rpcServer            *rpcServer
 	blockManager         *blockManager
 	txMemPool            *mempool.TxPool
-	cpuMiner             *CPUMiner
+	cpuMiner             *cpuminer.CPUMiner
 	modifyRebroadcastInv chan interface{}
 	newPeers             chan *serverPeer
 	donePeers            chan *serverPeer
@@ -2378,7 +2379,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	blockTemplateGenerator := mining.NewBlkTmplGenerator(&policy,
 		s.chainParams, s.txMemPool, s.blockManager.chain, s.timeSource,
 		s.sigCache)
-	s.cpuMiner = newCPUMiner(&cpuminerConfig{
+	s.cpuMiner = cpuminer.New(&cpuminer.Config{
 		ChainParams:            chainParams,
 		BlockTemplateGenerator: blockTemplateGenerator,
 		MiningAddrs:            cfg.miningAddrs,


### PR DESCRIPTION
This does the minimum work necessary to refactor the CPU miner code into its own package.  The idea is that separating this code into its own package will improve its testability and ultimately be useful to other parts of the codebase such as the various tests which currently effectively have their own stripped-down versions of this code.

The API will certainly need some additional cleanup and changes to make it more usable outside of the specific circumstances it was originally designed to support (namely the generate RPC), however it is better to do that in future commits in order to keep the changeset as small as possible during this refactor.

Overview of the major changes:

- Create the new package
- Move `cpuminer.go` -> `cpuminer/cpuminer.go`
- Update mining logging to use the new `cpuminer` package logger
- Rename `cpuminerConfig` to `Config` (so it's now `cpuminer.Config`)
- Rename `newCPUMiner` to `New` (so it's now `cpuminer.New`)
- Update all references to the `cpuminer` to use the package
- Add a skeleton `README.md`
