### PR TITLE
server/mempool: Evict orphans on peer disconnect

### DIFF
--- a/blockmanager.go
+++ b/blockmanager.go
@@ -413,7 +413,7 @@ func (b *blockManager) handleTxMsg(tmsg *txMsg) {
 	// memory pool, orphan handling, etc.
 	allowOrphans := cfg.MaxOrphanTxs > 0
 	acceptedTxs, err := b.server.txMemPool.ProcessTransaction(tmsg.tx,
-		allowOrphans, true)
+		allowOrphans, true, mempool.Tag(tmsg.peer.ID()))
 
 	// Remove transaction from request maps. Either the mempool/chain
 	// already knows about it and as such we shouldn't have any more

--- a/log.go
+++ b/log.go
@@ -220,3 +220,12 @@ func directionString(inbound bool) string {
 	}
 	return "outbound"
 }
+
+// pickNoun returns the singular or plural form of a noun depending
+// on the count n.
+func pickNoun(n uint64, singular, plural string) string {
+	if n == 1 {
+		return singular
+	}
+	return plural
+}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -40,6 +40,11 @@ const (
 	orphanExpireScanInterval = time.Minute * 5
 )
 
+// Tag represents an identifier to use for tagging orphan transactions.  The
+// caller may choose any scheme it desires, however it is common to use peer IDs
+// so that orphans can be identified by which peer first relayed them.
+type Tag uint64
+
 // Config is a descriptor containing the memory pool configuration.
 type Config struct {
 	// Policy defines the various mempool configuration options related
@@ -132,6 +137,7 @@ type TxDesc struct {
 // to it such as an expiration time to help prevent caching the orphan forever.
 type orphanTx struct {
 	tx         *btcutil.Tx
+	tag        Tag
 	expiration time.Time
 }
 
@@ -268,7 +274,7 @@ func (mp *TxPool) limitNumOrphans() error {
 // addOrphan adds an orphan transaction to the orphan pool.
 //
 // This function MUST be called with the mempool lock held (for writes).
-func (mp *TxPool) addOrphan(tx *btcutil.Tx) {
+func (mp *TxPool) addOrphan(tx *btcutil.Tx, tag Tag) {
 	// Nothing to do if no orphans are allowed.
 	if mp.cfg.Policy.MaxOrphanTxs <= 0 {
 		return
@@ -281,6 +287,7 @@ func (mp *TxPool) addOrphan(tx *btcutil.Tx) {
 
 	mp.orphans[*tx.Hash()] = &orphanTx{
 		tx:         tx,
+		tag:        tag,
 		expiration: time.Now().Add(orphanTTL),
 	}
 	for _, txIn := range tx.MsgTx().TxIn {
@@ -298,7 +305,7 @@ func (mp *TxPool) addOrphan(tx *btcutil.Tx) {
 // maybeAddOrphan potentially adds an orphan to the orphan pool.
 //
 // This function MUST be called with the mempool lock held (for writes).
-func (mp *TxPool) maybeAddOrphan(tx *btcutil.Tx) error {
+func (mp *TxPool) maybeAddOrphan(tx *btcutil.Tx, tag Tag) error {
 	// Ignore orphan transactions that are too large.  This helps avoid
 	// a memory exhaustion attack based on sending a lot of really large
 	// orphans.  In the case there is a valid transaction larger than this,
@@ -318,7 +325,7 @@ func (mp *TxPool) maybeAddOrphan(tx *btcutil.Tx) error {
 	}
 
 	// Add the orphan if the none of the above disqualified it.
-	mp.addOrphan(tx)
+	mp.addOrphan(tx, tag)
 
 	return nil
 }
@@ -981,7 +988,7 @@ func (mp *TxPool) ProcessOrphans(acceptedTx *btcutil.Tx) []*TxDesc {
 // the passed one being accepted.
 //
 // This function is safe for concurrent access.
-func (mp *TxPool) ProcessTransaction(tx *btcutil.Tx, allowOrphan, rateLimit bool) ([]*TxDesc, error) {
+func (mp *TxPool) ProcessTransaction(tx *btcutil.Tx, allowOrphan, rateLimit bool, tag Tag) ([]*TxDesc, error) {
 	log.Tracef("Processing transaction %v", tx.Hash())
 
 	// Protect concurrent access.
@@ -1030,7 +1037,7 @@ func (mp *TxPool) ProcessTransaction(tx *btcutil.Tx, allowOrphan, rateLimit bool
 	}
 
 	// Potentially add the orphan transaction to the orphan pool.
-	err = mp.maybeAddOrphan(tx)
+	err = mp.maybeAddOrphan(tx, tag)
 	if err != nil {
 		return nil, err
 	}

--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -218,6 +218,23 @@ func (mp *TxPool) RemoveOrphan(tx *btcutil.Tx) {
 	mp.mtx.Unlock()
 }
 
+// RemoveOrphansByTag removes all orphan transactions tagged with the provided
+// identifier.
+//
+// This function is safe for concurrent access.
+func (mp *TxPool) RemoveOrphansByTag(tag Tag) uint64 {
+	var numEvicted uint64
+	mp.mtx.Lock()
+	for _, otx := range mp.orphans {
+		if otx.tag == tag {
+			mp.removeOrphan(otx.tx, true)
+			numEvicted++
+		}
+	}
+	mp.mtx.Unlock()
+	return numEvicted
+}
+
 // limitNumOrphans limits the number of orphan transactions by evicting a random
 // orphan if adding a new one would cause it to overflow the max allowed.
 //

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -409,7 +409,7 @@ func TestSimpleOrphanChain(t *testing.T) {
 	// none are evicted).
 	for _, tx := range chainedTxns[1 : maxOrphans+1] {
 		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, true,
-			false)
+			false, 0)
 		if err != nil {
 			t.Fatalf("ProcessTransaction: failed to accept valid "+
 				"orphan %v", err)
@@ -432,7 +432,7 @@ func TestSimpleOrphanChain(t *testing.T) {
 	// to ensure it has no bearing on whether or not already existing
 	// orphans in the pool are linked.
 	acceptedTxns, err := harness.txPool.ProcessTransaction(chainedTxns[0],
-		false, false)
+		false, false, 0)
 	if err != nil {
 		t.Fatalf("ProcessTransaction: failed to accept valid "+
 			"orphan %v", err)
@@ -471,7 +471,7 @@ func TestOrphanReject(t *testing.T) {
 	// Ensure orphans are rejected when the allow orphans flag is not set.
 	for _, tx := range chainedTxns[1:] {
 		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, false,
-			false)
+			false, 0)
 		if err == nil {
 			t.Fatalf("ProcessTransaction: did not fail on orphan "+
 				"%v when allow orphans flag is false", tx.Hash())
@@ -528,7 +528,7 @@ func TestOrphanEviction(t *testing.T) {
 	// all accepted.  This will cause an eviction.
 	for _, tx := range chainedTxns[1:] {
 		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, true,
-			false)
+			false, 0)
 		if err != nil {
 			t.Fatalf("ProcessTransaction: failed to accept valid "+
 				"orphan %v", err)
@@ -592,7 +592,7 @@ func TestBasicOrphanRemoval(t *testing.T) {
 	// none are evicted).
 	for _, tx := range chainedTxns[1 : maxOrphans+1] {
 		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, true,
-			false)
+			false, 0)
 		if err != nil {
 			t.Fatalf("ProcessTransaction: failed to accept valid "+
 				"orphan %v", err)
@@ -667,7 +667,7 @@ func TestOrphanChainRemoval(t *testing.T) {
 	// none are evicted).
 	for _, tx := range chainedTxns[1 : maxOrphans+1] {
 		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, true,
-			false)
+			false, 0)
 		if err != nil {
 			t.Fatalf("ProcessTransaction: failed to accept valid "+
 				"orphan %v", err)
@@ -730,7 +730,7 @@ func TestMultiInputOrphanDoubleSpend(t *testing.T) {
 	// except the final one.
 	for _, tx := range chainedTxns[1:maxOrphans] {
 		acceptedTxns, err := harness.txPool.ProcessTransaction(tx, true,
-			false)
+			false, 0)
 		if err != nil {
 			t.Fatalf("ProcessTransaction: failed to accept valid "+
 				"orphan %v", err)
@@ -756,7 +756,7 @@ func TestMultiInputOrphanDoubleSpend(t *testing.T) {
 		t.Fatalf("unable to create signed tx: %v", err)
 	}
 	acceptedTxns, err := harness.txPool.ProcessTransaction(doubleSpendTx,
-		true, false)
+		true, false, 0)
 	if err != nil {
 		t.Fatalf("ProcessTransaction: failed to accept valid orphan %v",
 			err)
@@ -775,7 +775,7 @@ func TestMultiInputOrphanDoubleSpend(t *testing.T) {
 	// This will cause the shared output to become a concrete spend which
 	// will in turn must cause the double spending orphan to be removed.
 	acceptedTxns, err = harness.txPool.ProcessTransaction(chainedTxns[0],
-		false, false)
+		false, false, 0)
 	if err != nil {
 		t.Fatalf("ProcessTransaction: failed to accept valid tx %v", err)
 	}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3424,8 +3424,10 @@ func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan st
 		}
 	}
 
+	// Use 0 for the tag to represent local node.
 	tx := btcutil.NewTx(&msgTx)
-	acceptedTxs, err := s.server.txMemPool.ProcessTransaction(tx, false, false)
+	acceptedTxs, err := s.server.txMemPool.ProcessTransaction(tx, false,
+		false, 0)
 	if err != nil {
 		// When the error is a rule error, it means the transaction was
 		// simply rejected as opposed to something actually going wrong,

--- a/server.go
+++ b/server.go
@@ -1596,7 +1596,7 @@ func (s *server) outboundPeerConnected(c *connmgr.ConnReq, conn net.Conn) {
 }
 
 // peerDoneHandler handles peer disconnects by notifiying the server that it's
-// done.
+// done along with other performing other desirable cleanup.
 func (s *server) peerDoneHandler(sp *serverPeer) {
 	sp.WaitForDisconnect()
 	s.donePeers <- sp
@@ -1604,6 +1604,14 @@ func (s *server) peerDoneHandler(sp *serverPeer) {
 	// Only tell block manager we are gone if we ever told it we existed.
 	if sp.VersionKnown() {
 		s.blockManager.DonePeer(sp)
+
+		// Evict any remaining orphans that were sent by the peer.
+		numEvicted := s.txMemPool.RemoveOrphansByTag(mempool.Tag(sp.ID()))
+		if numEvicted > 0 {
+			txmpLog.Debugf("Evicted %d %s from peer %v (id %d)",
+				numEvicted, pickNoun(numEvicted, "orphan",
+					"orphans"), sp, sp.ID())
+		}
 	}
 	close(sp.quit)
 }


### PR DESCRIPTION
This removes any remaining orphan transactions that were sent by a peer when it disconnects since it is extremely unlikely that the missing parents will ever materialize from elsewhere.

In order to achieve this, there are three individual commits.  The first commit modifies `mempool` to allow a tag to be associated with orphan transactions and uses the peer ID as the tag for each transaction.

The second commit modifies `mempool` to provide a `RemoveOrphansByTag` which, as its name implies, allows callers to remove all orphans associated with a given tag (and also any orphans that depend on the removed orphans, recursively).

The final commit modifies server to invoke the new `RemoveOrphansByTag` function with the peer ID as each peer disconnects.

The following shows the PR is action (IP addresses hidden and additional id annotations for clarity):

```
12:32:54 2016-10-28 [DBG] TXMP: Evicted 1 orphan from peer x.x.x.185:8333 (outbound) (id 4)
12:32:54 2016-10-28 [INF] BMGR: Lost peer x.x.x.x:8333 (outbound) (id 4)
12:34:01 2016-10-28 [DBG] TXMP: Evicted 4 orphans from peer x.x.x.58:8333 (outbound) (id 3)
12:34:01 2016-10-28 [INF] BMGR: Lost peer x.x.x.58:8333 (outbound) (id 3)
12:34:04 2016-10-28 [INF] BMGR: Lost peer x.x.x.183:8333 (outbound) (id 5)
12:34:04 2016-10-28 [DBG] TXMP: Evicted 7 orphans from peer x.x.x.183:8333 (outbound) (id 5)
12:34:11 2016-10-28 [DBG] TXMP: Evicted 10 orphans from peer x.x.x.184:8333 (outbound) (id 10)
12:34:11 2016-10-28 [INF] BMGR: Lost peer x.x.x.184:8333 (outbound) (id 10)
12:34:13 2016-10-28 [INF] BMGR: Lost peer x.x.x.235:8333 (outbound) (id 1)
12:34:13 2016-10-28 [DBG] TXMP: Evicted 5 orphans from peer x.x.x.235:8333 (outbound) (id 1)
```