### PR TITLE
mempool: Modify default orphan tx policy.

### DIFF
--- a/config.go
+++ b/config.go
@@ -50,8 +50,8 @@ const (
 	blockMaxSizeMin              = 1000
 	blockMaxSizeMax              = wire.MaxBlockPayload - 1000
 	defaultGenerate              = false
-	defaultMaxOrphanTransactions = 1000
-	defaultMaxOrphanTxSize       = 5000
+	defaultMaxOrphanTransactions = 100
+	defaultMaxOrphanTxSize       = mempool.MaxStandardTxSize
 	defaultSigCacheMaxSize       = 100000
 	sampleConfigFilename         = "sample-btcd.conf"
 	defaultTxIndex               = false

--- a/doc.go
+++ b/doc.go
@@ -94,7 +94,7 @@ Application Options:
       --norelaypriority     Do not require free or low-fee transactions to have
                             high priority for relaying
       --maxorphantx=        Max number of orphan transactions to keep in memory
-                            (1000)
+                            (100)
       --generate            Generate (mine) bitcoins using the CPU
       --miningaddr=         Add the specified payment address to the list of
                             addresses to use for generated blocks -- At least

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -19,10 +19,10 @@ const (
 	// that are considered standard in a pay-to-script-hash script.
 	maxStandardP2SHSigOps = 15
 
-	// maxStandardTxSize is the maximum size allowed for transactions that
+	// MaxStandardTxSize is the maximum size allowed for transactions that
 	// are considered standard and will therefore be relayed and considered
 	// for mining.
-	maxStandardTxSize = 100000
+	MaxStandardTxSize = 100000
 
 	// maxStandardSigScriptSize is the maximum size allowed for a
 	// transaction input signature script to be considered standard.  This
@@ -276,9 +276,9 @@ func checkTransactionStandard(tx *btcutil.Tx, height int32,
 	// size of a transaction.  This also helps mitigate CPU exhaustion
 	// attacks.
 	serializedLen := msgTx.SerializeSize()
-	if serializedLen > maxStandardTxSize {
+	if serializedLen > MaxStandardTxSize {
 		str := fmt.Sprintf("transaction size of %v is larger than max "+
-			"allowed size of %v", serializedLen, maxStandardTxSize)
+			"allowed size of %v", serializedLen, MaxStandardTxSize)
 		return txRuleError(wire.RejectNonstandard, str)
 	}
 

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -41,13 +41,13 @@ func TestCalcMinRequiredTxRelayFee(t *testing.T) {
 		},
 		{
 			"max standard tx size with default minimum relay fee",
-			maxStandardTxSize,
+			MaxStandardTxSize,
 			DefaultMinRelayTxFee,
 			100000,
 		},
 		{
 			"max standard tx size with max satoshi relay fee",
-			maxStandardTxSize,
+			MaxStandardTxSize,
 			btcutil.MaxSatoshi,
 			btcutil.MaxSatoshi,
 		},
@@ -360,7 +360,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 				TxOut: []*wire.TxOut{{
 					Value: 0,
 					PkScript: bytes.Repeat([]byte{0x00},
-						maxStandardTxSize+1),
+						MaxStandardTxSize+1),
 				}},
 				LockTime: 0,
 			},

--- a/sample-btcd.conf
+++ b/sample-btcd.conf
@@ -236,8 +236,8 @@
 ; Require high priority for relaying free or low-fee transactions.
 ; norelaypriority=0
 
-; Limit orphan transaction pool to 1000 transactions.
-; maxorphantx=1000
+; Limit orphan transaction pool to 100 transactions.
+; maxorphantx=100
 
 ; Do not accept transactions from remote peers.
 ; blocksonly=1


### PR DESCRIPTION
The current max orphan transaction size causes problems with dependent transaction relay due to its artificially small size in relation to the max standard transaction size.

Consequently, this modifies the orphan transaction policy by increasing the max size of each orphan to the same value allowed for standard non-orphan transactions and reducing the default max allowed number of orphans to 100.

From a memory usage standpoint, the worst case max mem usage prior to this change was 5MB plus structure and tracking overhead (1000 max orphans * 5KB max each).  With this, that is raised to 10MB (100 max orphans * 100KB max each) in the worst case.

It is important to note that the values were originally implemented as a naive means to control the size of the orphan pool before several of the recent enhancements which more aggressively remove orphans from the orphan pool were added, so they needed to be evaluated again.

For a very long time prior to recent changes, the orphan pool would quickly reach the max allowed worst-case usage and effectively stay there forever whereas with more recent changes, the actual run-time orphan pool usage is usually much smaller (typically trending towards zero).

Finally, as another point in favor of this change, as the network has evolved, nodes have generally become better about orphan management and as such missing ancestors will typically either be broadcast or mined fairly quickly resulting in fewer overall orphans.

As a data point, the following shows the orphan pool counts for an hour run with all of the most recent orphan-related changes (modified to remove hashes for easier readability):

```
15:55:35 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 3)
15:55:47 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 4)
15:55:53 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 4)
15:55:53 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 5)
15:55:54 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 6)
15:55:54 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 7)
15:55:54 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 8)
15:55:54 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 4)
15:55:54 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 5)
15:55:55 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 4)
15:55:55 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 5)
15:55:55 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 6)
15:55:55 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 7)
15:55:55 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 8)
15:55:55 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 9)
15:55:55 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 10)
15:55:55 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 11)
15:55:55 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 12)
15:56:01 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 4)
15:58:14 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 4)
15:58:14 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 5)
15:58:14 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 6)
15:58:14 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 7)
15:58:14 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 8)
15:58:14 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 9)
16:00:59 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 3)
16:07:22 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 3)
16:10:25 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 3)
16:10:48 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 3)
16:11:01 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 3)
16:11:16 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 3)
16:12:53 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 1)
16:12:54 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 1)
16:17:20 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 1)
16:17:23 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 1)
16:18:33 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 1)
16:22:56 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 1)
16:23:34 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 1)
16:23:37 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 1)
16:25:52 2016-10-28 [DBG] TXMP: Stored orphan transaction xx (total: 2)
```