### PR TITLE
server: Cap max outbound at max peers

### DIFF
--- a/server.go
+++ b/server.go
@@ -2440,9 +2440,13 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	}
 
 	// Create a connection manager.
+	maxOutbound := defaultMaxOutbound
+	if cfg.MaxPeers < maxOutbound {
+		maxOutbound = cfg.MaxPeers
+	}
 	cmgr, err := connmgr.New(&connmgr.Config{
 		RetryDuration: connectionRetryInterval,
-		MaxOutbound:   defaultMaxOutbound,
+		MaxOutbound:   uint32(maxOutbound),
 		Dial:          btcdDial,
 		OnConnection:  s.outboundPeerConnected,
 		GetNewAddress: newAddressFunc,


### PR DESCRIPTION
The number of max outbound connections cannot be more max peers, so we cap that at max peers.