### PR TITLE
Switch to gometalint in goclean

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ install:
   - glide install
   - go install . ./cmd/...
   - go get -v golang.org/x/tools/cmd/cover
-  - go get -v github.com/golang/lint/golint
+  - go get -v github.com/alecthomas/gometalinter
+  - gometalinter --install
 script:
   - export PATH=$PATH:$HOME/gopath/bin
   - ./goclean.sh

--- a/goclean.sh
+++ b/goclean.sh
@@ -5,13 +5,18 @@
 # 3. go vet        (http://golang.org/cmd/vet)
 # 4. race detector (http://blog.golang.org/race-detector)
 # 5. test coverage (http://blog.golang.org/cover)
+#
+# gometaling (github.com/alecthomas/gometalinter) is used to run each each
+# static checker.
 
 set -ex
 
 # Automatic checks
-test -z "$(go fmt $(glide novendor) | tee /dev/stderr)"
-test -z "$(for package in $(glide novendor); do golint $package; done | grep -v 'ALL_CAPS\|OP_' | tee /dev/stderr)"
-test -z "$(go vet $(glide novendor) 2>&1 | tee /dev/stderr)"
+test -z "$(gometalinter --disable-all \
+--enable=gofmt \
+--enable=golint \
+--enable=vet \
+--vendor --deadline=20s ./... | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
 env GORACE="halt_on_error=1" go test -v -race -tags rpctest $(glide novendor)
 
 # Run test coverage on each subdirectories and merge the coverage profile.

--- a/goclean.sh
+++ b/goclean.sh
@@ -16,7 +16,7 @@ test -z "$(gometalinter --disable-all \
 --enable=gofmt \
 --enable=golint \
 --enable=vet \
---vendor --deadline=20s ./... | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
+--deadline=20s $(glide novendor) | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
 env GORACE="halt_on_error=1" go test -v -race -tags rpctest $(glide novendor)
 
 # Run test coverage on each subdirectories and merge the coverage profile.


### PR DESCRIPTION
This switches goclean to use gometalint instead of running each
checking tool one at a time.

This runs them concurrently.

More importantly it will allow us to easily add additional
linters as desired.