### PR TITLE
connmgr: Retry only if below target outbound conns

### DIFF
--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -171,11 +171,11 @@ type ConnManager struct {
 // retry duration. Otherwise, if required, it makes a new connection request.
 // After maxFailedConnectionAttempts new connections will be retried after the
 // configured retry duration.
-func (cm *ConnManager) handleFailedConn(c *ConnReq, retry bool) {
+func (cm *ConnManager) handleFailedConn(c *ConnReq) {
 	if atomic.LoadInt32(&cm.stop) != 0 {
 		return
 	}
-	if retry && c.Permanent {
+	if c.Permanent {
 		c.retryCount++
 		d := time.Duration(c.retryCount) * cm.cfg.RetryDuration
 		if d > maxRetryDuration {
@@ -240,7 +240,9 @@ out:
 						go cm.cfg.OnDisconnection(connReq)
 					}
 
-					cm.handleFailedConn(connReq, msg.retry)
+					if uint32(len(conns)) < cm.cfg.TargetOutbound && msg.retry {
+						cm.handleFailedConn(connReq)
+					}
 				} else {
 					log.Errorf("Unknown connection: %d", msg.id)
 				}
@@ -249,7 +251,7 @@ out:
 				connReq := msg.c
 				connReq.updateState(ConnFailed)
 				log.Debugf("Failed to connect to %v: %v", connReq, msg.err)
-				cm.handleFailedConn(connReq, true)
+				cm.handleFailedConn(connReq)
 			}
 
 		case <-cm.quit:

--- a/server.go
+++ b/server.go
@@ -1254,7 +1254,7 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 	}
 
 	if sp.connReq != nil {
-		s.connManager.Remove(sp.connReq.ID())
+		s.connManager.Disconnect(sp.connReq.ID())
 	}
 
 	// Update the address' last seen time if the peer has acknowledged

--- a/server.go
+++ b/server.go
@@ -1414,6 +1414,11 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 
 	case connectNodeMsg:
 		// XXX(oga) duplicate oneshots?
+		// Limit max number of total peers.
+		if state.Count() >= cfg.MaxPeers {
+			msg.reply <- errors.New("max peers reached")
+			return
+		}
 		for _, peer := range state.persistentPeers {
 			if peer.Addr() == msg.addr {
 				if msg.permanent {


### PR DESCRIPTION
By default `connmgr` maintains a fixed number of connections (defaults to 8). In addition to this, connections can be added using the `node connect` rpc. Therefore it is more accurate to refer to the limit as a target rather than max. Accordingly renamed references in the code from max to target.

In case we already have more than the default number of target connections, we should be able to drop a connection without triggering a auto retry. This has been fixed.

If we have hit max peers, we cannot accommodate any new outbound peers. Therefore it's better to exit early and avoid making an unnecessary connection.  This has been fixed.

