### PR TITLE
addrmgr/btcd: Updates for staticcheck results.

### DIFF
--- a/addrmgr/knownaddress_test.go
+++ b/addrmgr/knownaddress_test.go
@@ -61,7 +61,7 @@ func TestIsBad(t *testing.T) {
 	secondsOld := time.Now().Add(-2 * time.Second)
 	minutesOld := time.Now().Add(-27 * time.Minute)
 	hoursOld := time.Now().Add(-5 * time.Hour)
-	zeroTime, _ := time.Parse("Jan 1, 1970 at 0:00am (GMT)", "Jan 1, 1970 at 0:00am (GMT)")
+	zeroTime := time.Time{}
 
 	futureNa := &wire.NetAddress{Timestamp: future}
 	minutesOldNa := &wire.NetAddress{Timestamp: minutesOld}

--- a/upgrade.go
+++ b/upgrade.go
@@ -13,6 +13,9 @@ import (
 // dirEmpty returns whether or not the specified directory path is empty.
 func dirEmpty(dirPath string) (bool, error) {
 	f, err := os.Open(dirPath)
+	if err != nil {
+		return false, err
+	}
 	defer f.Close()
 
 	// Read the names of a max of one entry from the directory.  When the


### PR DESCRIPTION
This makes two modifications based on the results of `staticcheck`.

The first is to use a simplified zero value for the time in the `addrmgr` package tests.

The second is check any errors when opening a directory while attempting to perform old version upgrades.