### PR TITLE
multi: Remove unnecessary convs found by unconvert.

### DIFF
--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -246,12 +246,12 @@ func GroupKey(na *wire.NetAddress) string {
 	}
 	if IsRFC6145(na) || IsRFC6052(na) {
 		// last four bytes are the ip address
-		ip := net.IP(na.IP[12:16])
+		ip := na.IP[12:16]
 		return ip.Mask(net.CIDRMask(16, 32)).String()
 	}
 
 	if IsRFC3964(na) {
-		ip := net.IP(na.IP[2:6])
+		ip := na.IP[2:6]
 		return ip.Mask(net.CIDRMask(16, 32)).String()
 
 	}

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -843,7 +843,8 @@ func LockTimeToSequence(isSeconds bool, locktime uint32) uint32 {
 	// shift the locktime over by 9 since the time granularity is in
 	// 512-second intervals (2^9). This results in a max lock-time of
 	// 33,553,920 seconds, or 1.1 years.
-	return wire.SequenceLockTimeIsSeconds | uint32(locktime>>wire.SequenceLockTimeGranularity)
+	return wire.SequenceLockTimeIsSeconds |
+		locktime>>wire.SequenceLockTimeGranularity
 }
 
 // getReorganizeNodes finds the fork point between the main chain and the passed

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -875,7 +875,7 @@ func CheckTransactionInputs(tx *btcutil.Tx, txHeight int32, utxoView *UtxoViewpo
 		// Ensure the transaction is not spending coins which have not
 		// yet reached the required coinbase maturity.
 		if utxoEntry.IsCoinBase() {
-			originHeight := int32(utxoEntry.BlockHeight())
+			originHeight := utxoEntry.BlockHeight()
 			blocksSincePrev := txHeight - originHeight
 			coinbaseMaturity := int32(chainParams.CoinbaseMaturity)
 			if blocksSincePrev < coinbaseMaturity {

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -572,7 +572,7 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 			} else {
 				bmgrLog.Debugf("Extracted height of %v from "+
 					"orphan block", cbHeight)
-				heightUpdate = int32(cbHeight)
+				heightUpdate = cbHeight
 				blkHashUpdate = blockHash
 			}
 		}
@@ -615,7 +615,7 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 	if blkHashUpdate != nil && heightUpdate != 0 {
 		bmsg.peer.UpdateLastBlockHeight(heightUpdate)
 		if isOrphan || b.current() {
-			go b.server.UpdatePeerHeights(blkHashUpdate, int32(heightUpdate), bmsg.peer)
+			go b.server.UpdatePeerHeights(blkHashUpdate, heightUpdate, bmsg.peer)
 		}
 	}
 
@@ -882,7 +882,7 @@ func (b *blockManager) handleInvMsg(imsg *invMsg) {
 	if lastBlock != -1 && b.current() {
 		blkHeight, err := b.chain.BlockHeightByHash(&invVects[lastBlock].Hash)
 		if err == nil {
-			imsg.peer.UpdateLastBlockHeight(int32(blkHeight))
+			imsg.peer.UpdateLastBlockHeight(blkHeight)
 		}
 	}
 

--- a/config.go
+++ b/config.go
@@ -562,7 +562,7 @@ func loadConfig() (*config, []string, error) {
 	}
 
 	// Don't allow ban durations that are too short.
-	if cfg.BanDuration < time.Duration(time.Second) {
+	if cfg.BanDuration < time.Second {
 		str := "%s: The banduration option may not be less than 1s -- parsed [%v]"
 		err := fmt.Errorf(str, funcName, cfg.BanDuration)
 		fmt.Fprintln(os.Stderr, err)
@@ -983,9 +983,9 @@ func createDefaultConfigFile(destinationPath string) error {
 		}
 
 		if strings.Contains(line, "rpcuser=") {
-			line = "rpcuser=" + string(generatedRPCUser) + "\n"
+			line = "rpcuser=" + generatedRPCUser + "\n"
 		} else if strings.Contains(line, "rpcpass=") {
-			line = "rpcpass=" + string(generatedRPCPass) + "\n"
+			line = "rpcpass=" + generatedRPCPass + "\n"
 		}
 
 		if _, err := dest.WriteString(line); err != nil {

--- a/database/ffldb/blockio.go
+++ b/database/ffldb/blockio.go
@@ -760,7 +760,7 @@ func newBlockStore(basePath string, network wire.BitcoinNet) *blockStore {
 		writeCursor: &writeCursor{
 			curFile:    &lockableFile{},
 			curFileNum: uint32(fileNum),
-			curOffset:  uint32(fileOff),
+			curOffset:  fileOff,
 		},
 	}
 	store.openFileFunc = store.openFile

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -454,7 +454,7 @@ func (p *Peer) UpdateLastBlockHeight(newHeight int32) {
 	p.statsMtx.Lock()
 	log.Tracef("Updating last block height of peer %v from %v to %v",
 		p.addr, p.lastBlock, newHeight)
-	p.lastBlock = int32(newHeight)
+	p.lastBlock = newHeight
 	p.statsMtx.Unlock()
 }
 
@@ -805,7 +805,7 @@ func (p *Peer) localVersionMsg() (*wire.MsgVersion, error) {
 	sentNonces.Add(nonce)
 
 	// Version message.
-	msg := wire.NewMsgVersion(ourNA, theirNA, nonce, int32(blockNum))
+	msg := wire.NewMsgVersion(ourNA, theirNA, nonce, blockNum)
 	msg.AddUserAgent(p.cfg.UserAgentName, p.cfg.UserAgentVersion)
 
 	// XXX: bitcoind appears to always enable the full node services flag
@@ -2054,7 +2054,7 @@ func newPeerBase(origCfg *Config, inbound bool) *Peer {
 	// caller.
 	cfg := *origCfg // Copy to avoid mutating caller.
 	if cfg.ProtocolVersion == 0 {
-		cfg.ProtocolVersion = uint32(MaxProtocolVersion)
+		cfg.ProtocolVersion = MaxProtocolVersion
 	}
 
 	// Set the chain parameters to testnet if the caller did not specify any.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -545,7 +545,7 @@ func handleCreateRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan 
 			return nil, rpcDecodeHexError(input.Txid)
 		}
 
-		prevOut := wire.NewOutPoint(txHash, uint32(input.Vout))
+		prevOut := wire.NewOutPoint(txHash, input.Vout)
 		txIn := wire.NewTxIn(prevOut, []byte{})
 		if c.LockTime != nil && *c.LockTime != 0 {
 			txIn.Sequence = wire.MaxTxInSequenceNum - 1
@@ -1200,7 +1200,7 @@ func handleGetBlockHeader(s *rpcServer, cmd interface{}, closeChan <-chan struct
 	blockHeaderReply := btcjson.GetBlockHeaderVerboseResult{
 		Hash:          c.Hash,
 		Confirmations: uint64(1 + best.Height - blockHeight),
-		Height:        int32(blockHeight),
+		Height:        blockHeight,
 		Version:       blockHeader.Version,
 		MerkleRoot:    blockHeader.MerkleRoot.String(),
 		NextHash:      nextHashString,
@@ -3647,12 +3647,11 @@ func handleVerifyMessage(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 	}
 
 	// Reconstruct the pubkey hash.
-	btcPK := (*btcec.PublicKey)(pk)
 	var serializedPK []byte
 	if wasCompressed {
-		serializedPK = btcPK.SerializeCompressed()
+		serializedPK = pk.SerializeCompressed()
 	} else {
-		serializedPK = btcPK.SerializeUncompressed()
+		serializedPK = pk.SerializeUncompressed()
 	}
 	address, err := btcutil.NewAddressPubKey(serializedPK,
 		activeNetParams.Params)

--- a/rpctest/memwallet.go
+++ b/rpctest/memwallet.go
@@ -448,7 +448,7 @@ func (m *memWallet) CreateTransaction(outputs []*wire.TxOut, feeRate btcutil.Amo
 	}
 
 	// Attempt to fund the transaction with spendable utxos.
-	if err := m.fundTx(tx, outputAmt, btcutil.Amount(feeRate)); err != nil {
+	if err := m.fundTx(tx, outputAmt, feeRate); err != nil {
 		return nil, err
 	}
 

--- a/rpctest/rpc_harness.go
+++ b/rpctest/rpc_harness.go
@@ -115,7 +115,7 @@ func New(activeNet *chaincfg.Params, handlers *btcrpcclient.NotificationHandlers
 			"of the supported chain networks")
 	}
 
-	harnessID := strconv.Itoa(int(numTestInstances))
+	harnessID := strconv.Itoa(numTestInstances)
 	nodeTestData, err := ioutil.TempDir("", "rpctest-"+harnessID)
 	if err != nil {
 		return nil, err

--- a/rpcwebsocket.go
+++ b/rpcwebsocket.go
@@ -420,8 +420,8 @@ func (*wsNotificationManager) notifyBlockConnected(clients map[chan struct{}]*ws
 	block *btcutil.Block) {
 
 	// Notify interested websocket clients about the connected block.
-	ntfn := btcjson.NewBlockConnectedNtfn(block.Hash().String(),
-		int32(block.Height()), block.MsgBlock().Header.Timestamp.Unix())
+	ntfn := btcjson.NewBlockConnectedNtfn(block.Hash().String(), block.Height(),
+		block.MsgBlock().Header.Timestamp.Unix())
 	marshalledJSON, err := btcjson.MarshalCmd(nil, ntfn)
 	if err != nil {
 		rpcsLog.Error("Failed to marshal block connected notification: "+
@@ -445,7 +445,7 @@ func (*wsNotificationManager) notifyBlockDisconnected(clients map[chan struct{}]
 
 	// Notify interested websocket clients about the disconnected block.
 	ntfn := btcjson.NewBlockDisconnectedNtfn(block.Hash().String(),
-		int32(block.Height()), block.MsgBlock().Header.Timestamp.Unix())
+		block.Height(), block.MsgBlock().Header.Timestamp.Unix())
 	marshalledJSON, err := btcjson.MarshalCmd(nil, ntfn)
 	if err != nil {
 		rpcsLog.Error("Failed to marshal block disconnected "+
@@ -602,7 +602,7 @@ func blockDetails(block *btcutil.Block, txIndex int) *btcjson.BlockDetails {
 		return nil
 	}
 	return &btcjson.BlockDetails{
-		Height: int32(block.Height()),
+		Height: block.Height(),
 		Hash:   block.Hash().String(),
 		Index:  txIndex,
 		Time:   block.MsgBlock().Header.Timestamp.Unix(),
@@ -2026,8 +2026,7 @@ fetchRange:
 			}
 
 			n := btcjson.NewRescanProgressNtfn(hashList[i].String(),
-				int32(blk.Height()),
-				blk.MsgBlock().Header.Timestamp.Unix())
+				blk.Height(), blk.MsgBlock().Header.Timestamp.Unix())
 			mn, err := btcjson.MarshalCmd(nil, n)
 			if err != nil {
 				rpcsLog.Errorf("Failed to marshal rescan "+

--- a/txscript/scriptbuilder.go
+++ b/txscript/scriptbuilder.go
@@ -135,7 +135,7 @@ func (b *ScriptBuilder) addData(data []byte) *ScriptBuilder {
 		b.script = append(b.script, OP_0)
 		return b
 	} else if dataLen == 1 && data[0] <= 16 {
-		b.script = append(b.script, byte((OP_1-1)+data[0]))
+		b.script = append(b.script, (OP_1-1)+data[0])
 		return b
 	} else if dataLen == 1 && data[0] == 0x81 {
 		b.script = append(b.script, byte(OP_1NEGATE))

--- a/wire/msgalert.go
+++ b/wire/msgalert.go
@@ -165,7 +165,7 @@ func (alert *Alert) Serialize(w io.Writer, pver uint32) error {
 	if err != nil {
 		return err
 	}
-	for i := 0; i < int(count); i++ {
+	for i := 0; i < count; i++ {
 		err = writeElement(w, alert.SetCancel[i])
 		if err != nil {
 			return err
@@ -187,7 +187,7 @@ func (alert *Alert) Serialize(w io.Writer, pver uint32) error {
 	if err != nil {
 		return err
 	}
-	for i := 0; i < int(count); i++ {
+	for i := 0; i < count; i++ {
 		err = WriteVarString(w, pver, alert.SetSubVer[i])
 		if err != nil {
 			return err


### PR DESCRIPTION
This removes all unnecessary typecast conversions as found by the [unconvert](https://github.com/mdempsky/unconvert) linter.