### PR TITLE
build: Add gosimple linter to goclean.sh.

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -16,6 +16,7 @@ test -z "$(gometalinter --disable-all \
 --enable=gofmt \
 --enable=golint \
 --enable=vet \
+--enable=gosimple \
 --deadline=20s $(glide novendor) | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
 env GORACE="halt_on_error=1" go test -v -race -tags rpctest $(glide novendor)
 


### PR DESCRIPTION
**This PR requires #837**

#This modifies the `goclean.sh` script to include the [gosimple](https://github.com/dominikh/go-simple) lint tool to the `gometalinter` configuration.
