### PR TITLE
build: Add unconvert linter to goclean.sh.

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -17,6 +17,7 @@ test -z "$(gometalinter --disable-all \
 --enable=golint \
 --enable=vet \
 --enable=gosimple \
+--enable=unconvert \
 --deadline=20s $(glide novendor) | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
 env GORACE="halt_on_error=1" go test -v -race -tags rpctest $(glide novendor)
 


### PR DESCRIPTION
**This PR requires #836**

This modifies the `goclean.sh` script to include the [unconvert](https://github.com/mdempsky/unconvert) lint tool in the `gometalinter` configuration.
