### PR TITLE
connmgr: switch to using net.Addr interface throughout for addresses

### DIFF
--- a/config.go
+++ b/config.go
@@ -1001,11 +1001,11 @@ func createDefaultConfigFile(destinationPath string) error {
 // example, .onion addresses will be dialed using the onion specific proxy if
 // one was specified, but will otherwise use the normal dial function (which
 // could itself use a proxy or not).
-func btcdDial(network, address string) (net.Conn, error) {
-	if strings.Contains(address, ".onion:") {
-		return cfg.oniondial(network, address)
+func btcdDial(addr net.Addr) (net.Conn, error) {
+	if strings.Contains(addr.String(), ".onion:") {
+		return cfg.oniondial(addr.Network(), addr.String())
 	}
-	return cfg.dial(network, address)
+	return cfg.dial(addr.Network(), addr.String())
 }
 
 // btcdLookup returns the correct DNS lookup function to use depending on the


### PR DESCRIPTION
This commit modifies the ConnManager to use the `net.Addr interface through the package instead of a plain string to represent and manipulate addresses. This change makes the package much more general as users of the package can possibly utilize custom implementations of the net.Addr interface to establish connections.

More precisely, the `ConnReq` struct has been modified to use a net.Addr instance explicitly, and the `DialFunc` type has also been modified to take a `net.Addr` directly. This latter change gives functions that adhere to the `DialFunc` type more flexibility as to exactly how the connection is established.

My motivation for this change is that I'd like to use the `connmgr` package within [`lnd`](https://github.com/lightningnetwork/lnd) to manage attempting to establish persistent outbound connections to channel counter parties. Within the Lightning Network, [all p2p connections are encrypted+authenticated by default](https://github.com/lightningnetwork/lnd/blob/master/brontide/noise.go). 

Before this commit, this additional constraint meant that I couldn't directly use the `connmgr` because all the functions/structs referred to addresses explicitly by a string. This is rather limiting as in LN addresses also are tied to a long-term identity public key. By modifying the package to use a `net.Addr` throughout, I'm utilize our implementation of `net.Addr` whose concrete struct contains the additional information required to establish an encrypted connection to peers on the network. 