### PR TITLE
wire: Change NewNetAddress to accept a *net.TCPConn.

### DIFF
--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -41,16 +41,10 @@ func TestMessage(t *testing.T) {
 
 	// MsgVersion.
 	addrYou := &net.TCPAddr{IP: net.ParseIP("192.168.0.1"), Port: 8333}
-	you, err := NewNetAddress(addrYou, SFNodeNetwork)
-	if err != nil {
-		t.Errorf("NewNetAddress: %v", err)
-	}
+	you := NewNetAddress(addrYou, SFNodeNetwork)
 	you.Timestamp = time.Time{} // Version message has zero value timestamp.
 	addrMe := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8333}
-	me, err := NewNetAddress(addrMe, SFNodeNetwork)
-	if err != nil {
-		t.Errorf("NewNetAddress: %v", err)
-	}
+	me := NewNetAddress(addrMe, SFNodeNetwork)
 	me.Timestamp = time.Time{} // Version message has zero value timestamp.
 	msgVersion := NewMsgVersion(me, you, 123123, 0)
 

--- a/wire/msgaddr_test.go
+++ b/wire/msgaddr_test.go
@@ -39,11 +39,8 @@ func TestAddr(t *testing.T) {
 
 	// Ensure NetAddresses are added properly.
 	tcpAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8333}
-	na, err := NewNetAddress(tcpAddr, SFNodeNetwork)
-	if err != nil {
-		t.Errorf("NewNetAddress: %v", err)
-	}
-	err = msg.AddAddress(na)
+	na := NewNetAddress(tcpAddr, SFNodeNetwork)
+	err := msg.AddAddress(na)
 	if err != nil {
 		t.Errorf("AddAddress: %v", err)
 	}

--- a/wire/msgversion_test.go
+++ b/wire/msgversion_test.go
@@ -23,15 +23,9 @@ func TestVersion(t *testing.T) {
 	// Create version message data.
 	lastBlock := int32(234234)
 	tcpAddrMe := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8333}
-	me, err := NewNetAddress(tcpAddrMe, SFNodeNetwork)
-	if err != nil {
-		t.Errorf("NewNetAddress: %v", err)
-	}
+	me := NewNetAddress(tcpAddrMe, SFNodeNetwork)
 	tcpAddrYou := &net.TCPAddr{IP: net.ParseIP("192.168.0.1"), Port: 8333}
-	you, err := NewNetAddress(tcpAddrYou, SFNodeNetwork)
-	if err != nil {
-		t.Errorf("NewNetAddress: %v", err)
-	}
+	you := NewNetAddress(tcpAddrYou, SFNodeNetwork)
 	nonce, err := RandomUint64()
 	if err != nil {
 		t.Errorf("RandomUint64: error generating nonce: %v", err)

--- a/wire/netaddress.go
+++ b/wire/netaddress.go
@@ -6,15 +6,10 @@ package wire
 
 import (
 	"encoding/binary"
-	"errors"
 	"io"
 	"net"
 	"time"
 )
-
-// ErrInvalidNetAddr describes an error that indicates the caller didn't specify
-// a TCP address as required.
-var ErrInvalidNetAddr = errors.New("provided net.Addr is not a net.TCPAddr")
 
 // maxNetAddressPayload returns the max payload size for a bitcoin NetAddress
 // based on the protocol version.
@@ -85,17 +80,8 @@ func NewNetAddressIPPort(ip net.IP, port uint16, services ServiceFlag) *NetAddre
 
 // NewNetAddress returns a new NetAddress using the provided TCP address and
 // supported services with defaults for the remaining fields.
-//
-// Note that addr must be a net.TCPAddr.  An ErrInvalidNetAddr is returned
-// if it is not.
-func NewNetAddress(addr net.Addr, services ServiceFlag) (*NetAddress, error) {
-	tcpAddr, ok := addr.(*net.TCPAddr)
-	if !ok {
-		return nil, ErrInvalidNetAddr
-	}
-
-	na := NewNetAddressIPPort(tcpAddr.IP, uint16(tcpAddr.Port), services)
-	return na, nil
+func NewNetAddress(addr *net.TCPAddr, services ServiceFlag) *NetAddress {
+	return NewNetAddressIPPort(addr.IP, uint16(addr.Port), services)
 }
 
 // readNetAddress reads an encoded NetAddress from r depending on the protocol

--- a/wire/netaddress_test.go
+++ b/wire/netaddress_test.go
@@ -21,14 +21,7 @@ func TestNetAddress(t *testing.T) {
 	port := 8333
 
 	// Test NewNetAddress.
-	tcpAddr := &net.TCPAddr{
-		IP:   ip,
-		Port: port,
-	}
-	na, err := NewNetAddress(tcpAddr, 0)
-	if err != nil {
-		t.Errorf("NewNetAddress: %v", err)
-	}
+	na := NewNetAddress(&net.TCPAddr{IP: ip, Port: port}, 0)
 
 	// Ensure we get the same ip, port, and services back out.
 	if !na.IP.Equal(ip) {
@@ -75,14 +68,6 @@ func TestNetAddress(t *testing.T) {
 		t.Errorf("maxNetAddressPayload: wrong max payload length for "+
 			"protocol version %d - got %v, want %v", pver,
 			maxPayload, wantPayload)
-	}
-
-	// Check for expected failure on wrong address type.
-	udpAddr := &net.UDPAddr{}
-	_, err = NewNetAddress(udpAddr, 0)
-	if err != ErrInvalidNetAddr {
-		t.Errorf("NewNetAddress: expected error not received - "+
-			"got %v, want %v", err, ErrInvalidNetAddr)
 	}
 }
 


### PR DESCRIPTION
**This PR requires #841**

Rather than accepting a `net.Addr` interface and returning an error when it's not specifically a `*net.TCPConn`, just accept a `*net.TCPConn` directly so the compiler will assert it.  Also, remove the error return since it can no longer occur.
