### PR TITLE
rpc: add new btcd extension commands: addminingaddr, delminingaddr, listminingaddrs

### DIFF
--- a/btcd.go
+++ b/btcd.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"fmt"
+	prand "math/rand"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
@@ -13,6 +14,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"runtime/pprof"
+	"time"
 
 	"github.com/btcsuite/btcd/blockchain/indexers"
 	"github.com/btcsuite/btcd/limits"
@@ -183,4 +185,9 @@ func main() {
 	if err := btcdMain(nil); err != nil {
 		os.Exit(1)
 	}
+}
+
+func init() {
+	prand.Seed(time.Now().UnixNano())
+
 }

--- a/btcjson/btcdextcmds.go
+++ b/btcjson/btcdextcmds.go
@@ -89,6 +89,41 @@ func NewGetCurrentNetCmd() *GetCurrentNetCmd {
 	return &GetCurrentNetCmd{}
 }
 
+// AddMiningAddrCmd defines the addminingaddr JSON-RPC command.
+type AddMiningAddrCmd struct {
+	Address string `json:"address"`
+}
+
+// NewAddMiningAddrCmd returns a new instance which can be used to issue a
+// addminingaddr JSON-RPC command.
+func NewAddMiningAddrCmd(addr string) *AddMiningAddrCmd {
+	return &AddMiningAddrCmd{
+		Address: addr,
+	}
+}
+
+// DelMiningAddrCmd defines the delminingaddr JSON-RPC command.
+type DelMiningAddrCmd struct {
+	Address string `json:"address"`
+}
+
+// NewDelMiningAddrCmd returns a new instance which can be used to issue a
+// delminingaddr JSON-RPC command.
+func NewDelMiningAddrCmd(addr string) *DelMiningAddrCmd {
+	return &DelMiningAddrCmd{
+		Address: addr,
+	}
+}
+
+// ListMiningAddrsCmd defines the listminingaddrs JSON-RPC command.
+type ListMiningAddrsCmd struct{}
+
+// NewListMiningAddrsCmd returns a new instance which can be used to issue a
+// listminingaddrs JSON-RPC command.
+func NewListMiningAddrsCmd() *ListMiningAddrsCmd {
+	return &ListMiningAddrsCmd{}
+}
+
 func init() {
 	// No special flags for commands in this file.
 	flags := UsageFlag(0)
@@ -98,4 +133,7 @@ func init() {
 	MustRegisterCmd("generate", (*GenerateCmd)(nil), flags)
 	MustRegisterCmd("getbestblock", (*GetBestBlockCmd)(nil), flags)
 	MustRegisterCmd("getcurrentnet", (*GetCurrentNetCmd)(nil), flags)
+	MustRegisterCmd("addminingaddr", (*AddMiningAddrCmd)(nil), flags)
+	MustRegisterCmd("delminingaddr", (*DelMiningAddrCmd)(nil), flags)
+	MustRegisterCmd("listminingaddrs", (*ListMiningAddrsCmd)(nil), flags)
 }

--- a/btcjson/btcdextcmds_test.go
+++ b/btcjson/btcdextcmds_test.go
@@ -135,6 +135,43 @@ func TestBtcdExtCmds(t *testing.T) {
 			marshalled:   `{"jsonrpc":"1.0","method":"getcurrentnet","params":[],"id":1}`,
 			unmarshalled: &btcjson.GetCurrentNetCmd{},
 		},
+		{
+			name: "addminingaddr",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("addminingaddr", "1Address")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewAddMiningAddrCmd("1Address")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"addminingaddr","params":["1Address"],"id":1}`,
+			unmarshalled: &btcjson.AddMiningAddrCmd{
+				Address: "1Address",
+			},
+		},
+		{
+			name: "delminingaddr",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("delminingaddr", "1Address")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewDelMiningAddrCmd("1Address")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"delminingaddr","params":["1Address"],"id":1}`,
+			unmarshalled: &btcjson.DelMiningAddrCmd{
+				Address: "1Address",
+			},
+		},
+		{
+			name: "listminingaddrs",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("listminingaddrs")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewListMiningAddrsCmd()
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"listminingaddrs","params":[],"id":1}`,
+			unmarshalled: &btcjson.ListMiningAddrsCmd{},
+		},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/config.go
+++ b/config.go
@@ -764,7 +764,7 @@ func loadConfig() (*config, []string, error) {
 
 	// Ensure there is at least one mining address when the generate flag is
 	// set.
-	if cfg.Generate && len(cfg.MiningAddrs) == 0 {
+	if cfg.Generate && len(cfg.miningAddrs) == 0 {
 		str := "%s: the generate flag is set, but there are no mining " +
 			"addresses specified "
 		err := fmt.Errorf(str, funcName)

--- a/config.go
+++ b/config.go
@@ -151,8 +151,8 @@ type config struct {
 	lookup               func(string) ([]net.IP, error)
 	oniondial            func(string, string) (net.Conn, error)
 	dial                 func(string, string) (net.Conn, error)
-	miningAddrs          []btcutil.Address
 	minRelayTxFee        btcutil.Amount
+	miningAddrs          []btcutil.Address
 }
 
 // serviceOptions defines the configuration options for the daemon as a service on
@@ -369,7 +369,9 @@ func loadConfig() (*config, []string, error) {
 	// Pre-parse the command line options to see if an alternative config
 	// file or the version flag was specified.  Any errors aside from the
 	// help message error can be ignored here since they will be caught by
-	// the final parse below.
+	// the final parse below. A copy here is made on purpose. Making this a
+	// pointer causes it to set the same fields in the same config struct
+	// on the second parse which can cause duplicate entries in slices.
 	preCfg := cfg
 	preParser := newConfigParser(&preCfg, &serviceOpts, flags.HelpFlag)
 	_, err := preParser.Parse()

--- a/docs/json_rpc_api.md
+++ b/docs/json_rpc_api.md
@@ -583,6 +583,9 @@ The following is an overview of the RPC methods which are implemented by btcd, b
 |4|[searchrawtransactions](#searchrawtransactions)|Y|Query for transactions related to a particular address.|None|
 |5|[node](#node)|N|Attempts to add or remove a peer. |None|
 |6|[generate](#generate)|N|When in simnet or regtest mode, generate a set number of blocks. |None|
+|7|[addminingaddr](#addminingaddr)|N|Add a new address to the list of generation (coinbase payout) addresses. |None|
+|8|[delminingaddr](#delminingaddr)|N|Delete an address from the list of generation (coinbase payout) addresses. |None|
+|9|[listminingaddrs](#listminingaddrs)|N|List all the active generation (coinbase payout) addresses. |None|
 
 
 <a name="ExtMethodDetails" />
@@ -660,6 +663,44 @@ The following is an overview of the RPC methods which are implemented by btcd, b
 |Parameters|1. numblocks (int, required) - The number of blocks to generate |
 |Description|When in simnet or regtest mode, generates `numblocks` blocks. If blocks arrive from elsewhere, they are built upon but don't count toward the number of blocks to generate. Only generated blocks are returned. This RPC call will exit with an error if the server is already CPU mining, and will prevent the server from CPU mining for another command while it runs. |
 |Returns|`[ (json array of strings)` <br/>&nbsp;&nbsp; `"blockhash", ... hash of the generated block` <br/>`]` |
+[Return to Overview](#MethodOverview)<br />
+
+***
+
+<a name="addminingaddr"/>
+
+|   |   |
+|---|---|
+|Method|addminingaddr|
+|Parameters|1. address (string, required) - The address to add to the list of generation addresses|
+|Description|Attempts to add the specified address to the list of mining generation addresses. Attempting to add a duplicated address results in an error. All generation addresses must be unique.|
+|Returns|Nothing|
+[Return to Overview](#MethodOverview)<br />
+
+***
+
+<a name="delminingaddr"/>
+
+|   |   |
+|---|---|
+|Method|delminingaddr|
+|Parameters|1. address (string, required) - The address to delete from the list of mining addresses|
+|Description|Attempts to remove the passed address from the list of mining addresses. Attempting to delete a non-existent address results in an error.|
+|Returns|Nothing|
+[Return to Overview](#MethodOverview)<br />
+
+***
+
+***
+
+<a name="listminingaddrs"/>
+
+|   |   |
+|---|---|
+|Method|listminingaddrs|
+|Parameters|None|
+|Description|Returns a list of all the currently active generation (coinbase payout) addresses.|
+|Returns|Nothing|
 [Return to Overview](#MethodOverview)<br />
 
 ***

--- a/integration/rpcserver_test.go
+++ b/integration/rpcserver_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/rpctest"
+	"github.com/btcsuite/btcutil"
 )
 
 func testGetBestBlock(r *rpctest.Harness, t *testing.T) {
@@ -94,10 +95,80 @@ func testGetBlockHash(r *rpctest.Harness, t *testing.T) {
 	}
 }
 
+func testMiningAddrCalls(r *rpctest.Harness, t *testing.T) {
+	var err error
+	const numAddrs = 5
+
+	// First generate a few fresh addresses from the harness.
+	addrs := make([]btcutil.Address, numAddrs)
+	for i := 0; i < numAddrs; i++ {
+		addrs[i], err = r.NewAddress()
+		if err != nil {
+			t.Fatalf("unable to generate new address: %v", err)
+		}
+	}
+
+	// Next, we use the addminingaddr call to add the above generated
+	// addresses to btcd's set of mining addresses.
+	for _, addr := range addrs {
+		if err := r.Node.AddMiningAddr(addr); err != nil {
+			t.Fatalf("unable to add mining address: %v", err)
+		}
+	}
+
+	// Attempting to add the same address twice should be rejected due to
+	// duplicates.
+	if err := r.Node.AddMiningAddr(addrs[0]); err == nil {
+		t.Fatalf("duplicate mining address wasn't rejected")
+	}
+
+	// Next, try to delete a single address, then immediately try to delete
+	// the same address. The second call should result in an error as the
+	// address is no longer within the set of mining addresses.
+	if err := r.Node.DelMiningAddr(addrs[2]); err != nil {
+		t.Fatalf("unable to delete mining address: %v", err)
+	}
+	if err := r.Node.DelMiningAddr(addrs[2]); err == nil {
+		t.Fatalf("deletion of non-existent address should fail")
+	}
+
+	// Query for the list of mining addresses, there should be exactly 5
+	// addresses: one from the harness' initialization, and four of the
+	// remaining addresses we added.
+	miningAddrs, err := r.Node.ListMiningAddrs()
+	if err != nil {
+		t.Fatalf("unable to list mining addrs: %v", err)
+	}
+	if len(miningAddrs) != 5 {
+		t.Fatalf("expected %v mining addrs after deletion got %v", 5,
+			len(miningAddrs))
+	}
+
+	// Next, remove all the remaining address we generated from btcd's set
+	// of mining addresses.
+	for _, addr := range append(addrs[:2], addrs[3:]...) {
+		if err := r.Node.DelMiningAddr(addr); err != nil {
+			t.Fatalf("unable to delete mining addr: %v", err)
+		}
+	}
+
+	// Only a single address should remain at this point: the harness'
+	// original mining address.
+	miningAddrs, err = r.Node.ListMiningAddrs()
+	if err != nil {
+		t.Fatalf("unable to list mining addrs: %v", err)
+	}
+	if len(miningAddrs) != 1 {
+		t.Fatalf("expected %v mining addrs after deletion got %v", 1,
+			len(miningAddrs))
+	}
+}
+
 var rpcTestCases = []rpctest.HarnessTestCase{
 	testGetBestBlock,
 	testGetBlockCount,
 	testGetBlockHash,
+	testMiningAddrCalls,
 }
 
 var primaryHarness *rpctest.Harness

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -28,6 +28,10 @@ var helpDescsEnUS = map[string]string{
 	"debuglevel--result0":    "The string 'Done.'",
 	"debuglevel--result1":    "The list of subsystems",
 
+	// AddMiningAddrCmd help.
+	"addminingaddr--synopsis": "Adds an additional available mining address to the set of mining addresses for the daemon",
+	"addminingaddr-address":   "The address to append to the set of mining addresses",
+
 	// AddNodeCmd help.
 	"addnode--synopsis": "Attempts to add or remove a persistent peer.",
 	"addnode-addr":      "IP address and port of the peer to operate on",
@@ -111,6 +115,10 @@ var helpDescsEnUS = map[string]string{
 	// DecodeScriptCmd help.
 	"decodescript--synopsis": "Returns a JSON object with information about the provided hex-encoded script.",
 	"decodescript-hexscript": "Hex-encoded script",
+
+	// DelMiningAddrCmd help.
+	"delminingaddr--synopsis": "Attempts to delete the target address from the set of mining addresses",
+	"delminingaddr-address":   "The address to delete from the set of mining addresses",
 
 	// GenerateCmd help
 	"generate--synopsis": "Generates a set number of blocks (simnet or regtest only) and returns a JSON\n" +
@@ -456,6 +464,10 @@ var helpDescsEnUS = map[string]string{
 	"help--result0":    "List of commands",
 	"help--result1":    "Help for specified command",
 
+	// ListMiningAddrsCmd help.
+	"listminingaddrs--synopsis": "Returns a list of the current active mining addresses",
+	"listminingaddrs--result0":  "List of current active mining addresses",
+
 	// PingCmd help.
 	"ping--synopsis": "Queues a ping to be sent to each connected peer.\n" +
 		"Ping times are provided by getpeerinfo via the pingtime and pingwait fields.",
@@ -584,10 +596,12 @@ var helpDescsEnUS = map[string]string{
 // pointer to the type (or nil to indicate no return value).
 var rpcResultTypes = map[string][]interface{}{
 	"addnode":               nil,
+	"addminingaddr":         nil,
 	"createrawtransaction":  {(*string)(nil)},
 	"debuglevel":            {(*string)(nil), (*string)(nil)},
 	"decoderawtransaction":  {(*btcjson.TxRawDecodeResult)(nil)},
 	"decodescript":          {(*btcjson.DecodeScriptResult)(nil)},
+	"delminingaddr":         nil,
 	"generate":              {(*[]string)(nil)},
 	"getaddednodeinfo":      {(*[]string)(nil), (*[]btcjson.GetAddedNodeInfoResult)(nil)},
 	"getbestblock":          {(*btcjson.GetBestBlockResult)(nil)},
@@ -612,6 +626,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getrawtransaction":     {(*string)(nil), (*btcjson.TxRawResult)(nil)},
 	"gettxout":              {(*btcjson.GetTxOutResult)(nil)},
 	"getwork":               {(*btcjson.GetWorkResult)(nil), (*bool)(nil)},
+	"listminingaddrs":       {(*[]string)(nil)},
 	"node":                  nil,
 	"help":                  {(*string)(nil), (*string)(nil)},
 	"ping":                  nil,

--- a/server.go
+++ b/server.go
@@ -153,6 +153,7 @@ type server struct {
 	blockManager         *blockManager
 	txMemPool            *mempool.TxPool
 	cpuMiner             *cpuminer.CPUMiner
+	miningAddrs          *miningAddrStore
 	modifyRebroadcastInv chan interface{}
 	newPeers             chan *serverPeer
 	donePeers            chan *serverPeer
@@ -2163,6 +2164,116 @@ out:
 	s.wg.Done()
 }
 
+// miningAddrStore encapsulates a set of coinbase generation addresses in a
+// concurrent safe interface. All addresses stored MUST be unique, any
+// duplicates are rejected.
+type miningAddrStore struct {
+	miningAddrs []btcutil.Address
+	sync.RWMutex
+}
+
+// newMiningAddrStore creates a new instance of the miningAddrStore with
+// sufficient capacity to store numAddrs number of addresses.
+func newMiningAddrStore(numAddrs int) *miningAddrStore {
+	return &miningAddrStore{
+		miningAddrs: make([]btcutil.Address, 0, numAddrs),
+	}
+}
+
+// AddAddr adds a new generation address to the set of available generation
+// addresses. If the passed address is already within the set of generation
+// addresses, then a non-nil error is returned.
+//
+// NOTE: This function is safe for concurrent access.
+func (m *miningAddrStore) AddAddr(addr btcutil.Address) error {
+	m.Lock()
+	defer m.Unlock()
+
+	// Scan the current list of mining addresses to ensure that we don't
+	// add any duplicates.
+	for _, miningAddr := range m.miningAddrs {
+		if miningAddr.EncodeAddress() == addr.EncodeAddress() {
+			return fmt.Errorf("duplicate address detected")
+		}
+	}
+
+	// If adding this new address will not introduce any duplicate mining
+	// addresses, then append it to the list of available mining addresses.
+	m.miningAddrs = append(m.miningAddrs, addr)
+
+	return nil
+}
+
+// RemoveAddr attempts to remove the passed address from the set of available
+// generation addresses. If the passed address isn't a member of the set of
+// generation addresses, then a non-nil error is returned.
+//
+// NOTE: This function is safe for concurrent access.
+func (m *miningAddrStore) RemoveAddr(addr btcutil.Address) error {
+	m.Lock()
+	defer m.Unlock()
+
+	for i := range m.miningAddrs {
+		if m.miningAddrs[i].String() == addr.String() {
+			// Delete the element in-place from the slice of mining
+			// addresses by sliding elements to the right of the
+			// index over one.
+			copy(m.miningAddrs[i:], m.miningAddrs[i+1:])
+
+			// Then we set the final element to a nil value in
+			// order to avoid of GC leak, then re-slice the slice
+			// to reduce its length by one (cutting off the newly
+			// added nil element).
+			m.miningAddrs[len(m.miningAddrs)-1] = nil
+			m.miningAddrs = m.miningAddrs[:len(m.miningAddrs)-1]
+
+			return nil
+		}
+	}
+
+	// If we've reached this point, then the targeted mining address wasn't
+	// found so we return an error indicating so.
+	return fmt.Errorf("mining address not found")
+}
+
+// ListEncodedAddrs returns a slice of the string encoding of all the current
+// generation addresses.
+//
+// NOTE: This function is safe for concurrent access.
+func (m *miningAddrStore) ListEncodedAddrs() []string {
+	m.RLock()
+	defer m.RUnlock()
+
+	miningAddrs := make([]string, len(m.miningAddrs))
+	for i, miningAddr := range m.miningAddrs {
+		miningAddrs[i] = miningAddr.String()
+	}
+
+	return miningAddrs
+}
+
+// RandomAddr selects an address from the set of generation addresses using
+// a psuedo-random selection algorithm.
+//
+// NOTE: This function is safe for concurrent access.
+func (m *miningAddrStore) RandomAddr() btcutil.Address {
+	m.RLock()
+	defer m.RUnlock()
+
+	return m.miningAddrs[prand.Intn(len(m.miningAddrs))]
+}
+
+// NumAddrs returns the number of addresses within the current set of active
+// mining addresses.
+//
+// NOTE: This function is safe for concurrent access.
+func (m *miningAddrStore) NumAddrs() int {
+	m.RLock()
+	defer m.RUnlock()
+
+	return len(m.miningAddrs)
+}
+
 // newServer returns a new btcd server configured to listen on addr for the
 // bitcoin network type specified by chainParams.  Use start to begin accepting
 // connections from peers.
@@ -2315,6 +2426,15 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 		timeSource:           blockchain.NewMedianTime(),
 		services:             services,
 		sigCache:             txscript.NewSigCache(cfg.SigCacheMaxSize),
+		miningAddrs:          newMiningAddrStore(len(cfg.miningAddrs)),
+	}
+
+	// Load all the configured mining addresses into the mining addr store.
+	// Any duplicate addresses will be rejected.
+	for _, miningAddr := range cfg.miningAddrs {
+		if err := s.miningAddrs.AddAddr(miningAddr); err != nil {
+			return nil, err
+		}
 	}
 
 	// Create the transaction and address indexes if needed.
@@ -2395,10 +2515,12 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	s.cpuMiner = cpuminer.New(&cpuminer.Config{
 		ChainParams:            chainParams,
 		BlockTemplateGenerator: blockTemplateGenerator,
-		MiningAddrs:            cfg.miningAddrs,
 		ProcessBlock:           bm.ProcessBlock,
 		ConnectedCount:         s.ConnectedCount,
 		IsCurrent:              bm.IsCurrent,
+		GetMiningAddr: func() btcutil.Address {
+			return s.miningAddrs.RandomAddr()
+		},
 	})
 
 	// Only setup a function to return new addresses to connect to when

--- a/server.go
+++ b/server.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	prand "math/rand"
 	"net"
 	"runtime"
 	"strconv"


### PR DESCRIPTION
This PR adds three new `btcd` `JSON-RPC` extension commands: `addminingaddr`, `delminingaddr`, and `listminingaddrs` .  These RPC allows the caller to dynamically add, remove and list mining addresses to `btcd'`s list of generation addresses. Before this RPC, doing such a thing would've required a full restart of `btcd`. 

**NOTE:** This PR depends on btcsuite/btcrpcclient#105. 

The addition of this RPC also adds a new degree of flexibility to automated deployments of `btcd` using orchestration tools like `Docker`. The original inspiration for this RPC was spurred by some workarounds I had to implement when attempting to package `btcd` and `lnd` into a development environment using `docker-compose`.

A breakdown of the changes is as follows: 
 * New RPC's: `addminingaddr`, `delminingaddr`, and `listminingaddrs` have been added. In order to ensure thread-safety, a mutex `miningAddrMTx` has been added to the `config` struct. This mutex must be held at all times when reading/modifying the `miningAddr` slice. 
 * The `cpuminer.Config` struct has been modified to use a closure function for obtaining new mining addresses. This decouple the current logic of selecting a mining address (randomly select from a list) from the internals of the `cpuminer` package. In the future if/when alternate selection logic is added, then code within the package shouldn't need to change at all. 
* The `Config` struct has been modified to change the `MiningAddr` paramter from a `[]string` to a `string`. When writing integration tests for these new RPC's, I discovered that the address set via the `--miningaddr` flag was being duplicated. This change fixes the duplication. 

An interesting extension of this RPC was briefly discussed on IRC between myself and `davec`: the call could be extended to possibly accept a `BIP0032` extended public key rather than a series of addresses. Within the daemon, when generating new blocks, `btcd` could instead iterate through the HD keychain grabbing fresh addresses for each block rather than repeating through a statically coded list of addresses. Taking it a set further, further logic would be added to generate multi-sig `p2sh` addresses from addresses plucked from the keychain. 

For simplicity of this patch set, I've only implemented the most basic behavior round dynamically setting generation addresses, however the two extensions I mentioned above my be worth pursuing. 