### PR TITLE
peer: No error log on unexpected EOF.

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1422,7 +1422,9 @@ out:
 			// remote peer has not disconnected.
 			if p.shouldHandleReadError(err) {
 				errMsg := fmt.Sprintf("Can't read message from %s: %v", p, err)
-				log.Errorf(errMsg)
+				if err != io.ErrUnexpectedEOF {
+					log.Errorf(errMsg)
+				}
 
 				// Push a reject message for the malformed message and wait for
 				// the message to be sent before disconnecting.


### PR DESCRIPTION
This modifies the error handling path in the peer read loop such that it will no longer log an error when the error is `io.ErrUnexpectedEOF`.  This is being done because that error is almost always the result of a peer
being remotely disconnected and thus it isn't useful information to log.

However, since it might actually be due to a malformed message, a reject message is still queued up to be sent back to the peer (which will simply be discarded if the peer disconnected) before it is disconnected.

While it would be ideal to only log if it's not due to a disconnect, and the code already attempts to handle that, it's not 100% possible to detect upon the read returning an error without attempting to read again
which will not happen until the next loop iteration.