### PR TITLE
Add support for defining additional checkpoints

### DIFF
--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -43,9 +43,7 @@ func TestHaveBlock(t *testing.T) {
 	}
 	defer teardownFunc()
 
-	// Since we're not dealing with the real block chain, disable
-	// checkpoints and set the coinbase maturity to 1.
-	chain.DisableCheckpoints(true)
+	// Since we're not dealing with the real block chain, set the coinbase maturity to 1.
 	chain.TstSetCoinbaseMaturity(1)
 
 	for i := 1; i < len(blocks); i++ {
@@ -131,9 +129,7 @@ func TestCalcSequenceLock(t *testing.T) {
 	}
 	defer teardownFunc()
 
-	// Since we're not dealing with the real block chain, disable
-	// checkpoints and set the coinbase maturity to 1.
-	chain.DisableCheckpoints(true)
+	// Since we're not dealing with the real block chain, set the coinbase maturity to 1.
 	chain.TstSetCoinbaseMaturity(1)
 
 	// Load all the blocks into our test chain.

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -116,6 +116,7 @@ func chainSetup(dbName string, params *chaincfg.Params) (*blockchain.BlockChain,
 	chain, err := blockchain.New(&blockchain.Config{
 		DB:          db,
 		ChainParams: &paramsCopy,
+		Checkpoints: nil,
 		TimeSource:  blockchain.NewMedianTime(),
 		SigCache:    txscript.NewSigCache(1000),
 	})

--- a/blockchain/reorganization_test.go
+++ b/blockchain/reorganization_test.go
@@ -52,9 +52,7 @@ func TestReorganization(t *testing.T) {
 	}
 	defer teardownFunc()
 
-	// Since we're not dealing with the real block chain, disable
-	// checkpoints and set the coinbase maturity to 1.
-	chain.DisableCheckpoints(true)
+	// Since we're not dealing with the real block chain set the coinbase maturity to 1.
 	chain.TstSetCoinbaseMaturity(1)
 
 	expectedOrphans := map[int]struct{}{5: {}, 6: {}}

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1107,7 +1107,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *btcutil.Block, vi
 	// will therefore be detected by the next checkpoint).  This is a huge
 	// optimization because running the scripts is the most time consuming
 	// portion of block handling.
-	checkpoint := b.latestCheckpoint()
+	checkpoint := b.LatestCheckpoint()
 	runScripts := !b.noVerify
 	if checkpoint != nil && node.height <= checkpoint.Height {
 		runScripts = false

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -182,7 +183,7 @@ func (b *blockManager) findNextHeaderCheckpoint(height int32) *chaincfg.Checkpoi
 	if cfg.DisableCheckpoints {
 		return nil
 	}
-	checkpoints := b.server.chainParams.Checkpoints
+	checkpoints := b.chain.Checkpoints()
 	if len(checkpoints) == 0 {
 		return nil
 	}
@@ -1324,6 +1325,57 @@ func (b *blockManager) Pause() chan<- struct{} {
 	return c
 }
 
+// checkpointSorter implements sort.Interface to allow a slice of checkpoints to
+// be sorted.
+type checkpointSorter []chaincfg.Checkpoint
+
+// Len returns the number of checkpoints in the slice.  It is part of the
+// sort.Interface implementation.
+func (s checkpointSorter) Len() int {
+	return len(s)
+}
+
+// Swap swaps the checkpoints at the passed indices.  It is part of the
+// sort.Interface implementation.
+func (s checkpointSorter) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Less returns whether the checkpoint with index i should sort before the
+// checkpoint with index j.  It is part of the sort.Interface implementation.
+func (s checkpointSorter) Less(i, j int) bool {
+	return s[i].Height < s[j].Height
+}
+
+// mergeCheckpoints returns two slices of checkpoints merged into one slice
+// such that the checkpoints are sorted by height.  In the case the additional
+// checkpoints contain a checkpoint with the same height as a checkpoint in the
+// default checkpoints, the additional checkpoint will take precedence and
+// overwrite the default one.
+func mergeCheckpoints(defaultCheckpoints, additional []chaincfg.Checkpoint) []chaincfg.Checkpoint {
+	// Create a map of the additional checkpoint heights to detect
+	// duplicates.
+	additionalHeights := make(map[int32]struct{})
+	for _, checkpoint := range additional {
+		additionalHeights[checkpoint.Height] = struct{}{}
+	}
+
+	// Add all default checkpoints that do not have an override in the
+	// additional checkpoints.
+	numDefault := len(defaultCheckpoints)
+	checkpoints := make([]chaincfg.Checkpoint, 0, numDefault+len(additional))
+	for _, checkpoint := range defaultCheckpoints {
+		if _, exists := additionalHeights[checkpoint.Height]; !exists {
+			checkpoints = append(checkpoints, checkpoint)
+		}
+	}
+
+	// Append the additional checkpoints and return the sorted results.
+	checkpoints = append(checkpoints, additional...)
+	sort.Sort(checkpointSorter(checkpoints))
+	return checkpoints
+}
+
 // newBlockManager returns a new bitcoin block manager.
 // Use Start to begin processing asynchronous block and inv updates.
 func newBlockManager(s *server, indexManager blockchain.IndexManager) (*blockManager, error) {
@@ -1338,11 +1390,18 @@ func newBlockManager(s *server, indexManager blockchain.IndexManager) (*blockMan
 		quit:            make(chan struct{}),
 	}
 
+	// Merge given checkpoints with the default ones unless they are disabled.
+	var checkpoints []chaincfg.Checkpoint
+	if !cfg.DisableCheckpoints {
+		checkpoints = mergeCheckpoints(s.chainParams.Checkpoints, cfg.addCheckpoints)
+	}
+
 	// Create a new block chain instance with the appropriate configuration.
 	var err error
 	bm.chain, err = blockchain.New(&blockchain.Config{
 		DB:            s.db,
 		ChainParams:   s.chainParams,
+		Checkpoints:   checkpoints,
 		TimeSource:    s.timeSource,
 		Notifications: bm.handleNotifyMsg,
 		SigCache:      s.sigCache,
@@ -1352,7 +1411,6 @@ func newBlockManager(s *server, indexManager blockchain.IndexManager) (*blockMan
 		return nil, err
 	}
 	best := bm.chain.BestSnapshot()
-	bm.chain.DisableCheckpoints(cfg.DisableCheckpoints)
 	if !cfg.DisableCheckpoints {
 		// Initialize the next checkpoint based on the current height.
 		bm.nextCheckpoint = bm.findNextHeaderCheckpoint(best.Height)

--- a/config.go
+++ b/config.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/connmgr"
 	"github.com/btcsuite/btcd/database"
 	_ "github.com/btcsuite/btcd/database/ffldb"
@@ -123,6 +125,7 @@ type config struct {
 	TestNet3             bool          `long:"testnet" description:"Use the test network"`
 	RegressionTest       bool          `long:"regtest" description:"Use the regression test network"`
 	SimNet               bool          `long:"simnet" description:"Use the simulation test network"`
+	AddCheckpoints       []string      `long:"addcheckpoint" description:"Add a custom checkpoint. Format: '<height>:<hash>'"`
 	DisableCheckpoints   bool          `long:"nocheckpoints" description:"Disable built-in checkpoints.  Don't do this unless you know what you're doing."`
 	DbType               string        `long:"dbtype" description:"Database backend to use for the Block Chain"`
 	Profile              string        `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
@@ -150,6 +153,7 @@ type config struct {
 	lookup               func(string) ([]net.IP, error)
 	oniondial            func(string, string, time.Duration) (net.Conn, error)
 	dial                 func(string, string, time.Duration) (net.Conn, error)
+	addCheckpoints       []chaincfg.Checkpoint
 	miningAddrs          []btcutil.Address
 	minRelayTxFee        btcutil.Amount
 }
@@ -301,6 +305,49 @@ func normalizeAddresses(addrs []string, defaultPort string) []string {
 	}
 
 	return removeDuplicateAddresses(addrs)
+}
+
+// newCheckpointFromStr parses checkpoints in the '<height>:<hash>' format.
+func newCheckpointFromStr(checkpoint string) (chaincfg.Checkpoint, error) {
+	parts := strings.Split(checkpoint, ":")
+	if len(parts) != 2 {
+		return chaincfg.Checkpoint{}, errors.New("checkpoints must use the " +
+			"syntax '<height>:<hash>'")
+	}
+
+	height, err := strconv.ParseInt(parts[0], 10, 32)
+	if err != nil {
+		return chaincfg.Checkpoint{}, fmt.Errorf("unable to parse checkpoint "+
+			"due to malformed height: %s", parts[0])
+	}
+
+	hash, err := chainhash.NewHashFromStr(parts[1])
+	if err != nil {
+		return chaincfg.Checkpoint{}, fmt.Errorf("unable to parse checkpoint "+
+			"due to malformed hash: %s", parts[1])
+	}
+
+	return chaincfg.Checkpoint{
+		Height: int32(height),
+		Hash:   hash,
+	}, nil
+}
+
+// parseCheckpoints checks the checkpoint strings for valid syntax
+// ('<height>:<hash>') and parses them to chaincfg.Checkpoint instances.
+func parseCheckpoints(checkpointStrings []string) ([]chaincfg.Checkpoint, error) {
+	if len(checkpointStrings) == 0 {
+		return nil, nil
+	}
+	checkpoints := make([]chaincfg.Checkpoint, len(checkpointStrings))
+	for i, cpString := range checkpointStrings {
+		checkpoint, err := newCheckpointFromStr(cpString)
+		if err != nil {
+			return nil, err
+		}
+		checkpoints[i] = checkpoint
+	}
+	return checkpoints, nil
 }
 
 // filesExists reports whether the named file or directory exists.
@@ -799,6 +846,16 @@ func loadConfig() (*config, []string, error) {
 	if cfg.NoOnion && cfg.OnionProxy != "" {
 		err := fmt.Errorf("%s: the --noonion and --onion options may "+
 			"not be activated at the same time", funcName)
+		fmt.Fprintln(os.Stderr, err)
+		fmt.Fprintln(os.Stderr, usageMessage)
+		return nil, nil, err
+	}
+
+	// Check the checkpoints for syntax errors.
+	cfg.addCheckpoints, err = parseCheckpoints(cfg.AddCheckpoints)
+	if err != nil {
+		str := "%s: Error parsing checkpoints: %v"
+		err := fmt.Errorf(str, funcName, err)
 		fmt.Fprintln(os.Stderr, err)
 		fmt.Fprintln(os.Stderr, usageMessage)
 		return nil, nil, err

--- a/doc.go
+++ b/doc.go
@@ -74,6 +74,8 @@ Application Options:
       --testnet             Use the test network
       --regtest             Use the regression test network
       --simnet              Use the simulation test network
+      --addcheckpoint=      Add ad additional checkpoint.
+                            Format: '<height>:<hash>'
       --nocheckpoints       Disable built-in checkpoints.  Don't do this unless
                             you know what you're doing.
       --dbtype=             Database backend to use for the Block Chain (ffldb)

--- a/sample-btcd.conf
+++ b/sample-btcd.conf
@@ -153,6 +153,9 @@
 ; Disable peer bloom filtering.  See BIP0111.
 ; nopeerbloomfilters=1
 
+; Add additional checkpoints. Format: '<height>:<hash>'
+; addcheckpoint=<height>:<hash>
+
 
 ; ------------------------------------------------------------------------------
 ; RPC server options - The following options control the built-in RPC server


### PR DESCRIPTION
Adds a config option and cmd line flag `--checkpoint` that allows for defining custom checkpoints that will be used for verifying the active chain.

It also changes the way `--nocheckpoints` is handled: instead of keeping a flag to indicate checkpoint support, the built-in checkpoints and possible custom checkpoints are copied into the blockchain struct. This allows for overwriting the built-in ones as well.

I did not add tests for testing the flag, I wouldn't know where to start, but I can give it a shot if it's preferred!