### PR TITLE
peer: disconnected peer - return non-nil LocalAddr

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -686,7 +686,7 @@ func (p *Peer) LastRecv() time.Time {
 // This function is safe fo concurrent access.
 func (p *Peer) LocalAddr() net.Addr {
 	var localAddr net.Addr
-	if p.Connected() {
+	if atomic.LoadInt32(&p.connected) != 0 {
 		localAddr = p.conn.LocalAddr()
 	}
 	return localAddr


### PR DESCRIPTION
The check in `LocalAddr` was stricter than necessary, causing it to return `nil` for a disconnected peer. Updated to only return `nil` if the peer never connected. 

Fixes #846.