### PR TITLE
docs: Clarify model commit message summary

### DIFF
--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -228,6 +228,12 @@ Further paragraphs come after blank lines.
 - Use a hanging indent
 ```
 
+Prefix the summary with the subsystem/package when possible. Many other
+projects make use of the code and this makes it easier for them to tell when
+something they're using has changed. Have a look at [past
+commits](https://github.com/btcsuite/btcd/commits/master) for examples of
+commit messages.
+
 Here are some of the reasons why wrapping your commit messages to 72 columns is
 a good thing.
 


### PR DESCRIPTION
Add a paragraph about prefixing commit message summaries with the
package/subsystem that they're changing to
code_contribution_guidelines.md.