### PR TITLE
btcd: fix error in mempool response inv counting

### DIFF
--- a/server.go
+++ b/server.go
@@ -385,14 +385,14 @@ func (sp *serverPeer) OnMemPool(_ *peer.Peer, msg *wire.MsgMemPool) {
 	txDescs := txMemPool.TxDescs()
 	invMsg := wire.NewMsgInvSizeHint(uint(len(txDescs)))
 
-	for i, txDesc := range txDescs {
+	for _, txDesc := range txDescs {
 		// Either add all transactions when there is no bloom filter,
 		// or only the transactions that match the filter when there is
 		// one.
 		if !sp.filter.IsLoaded() || sp.filter.MatchTxAndUpdate(txDesc.Tx) {
 			iv := wire.NewInvVect(wire.InvTypeTx, txDesc.Tx.Hash())
 			invMsg.AddInvVect(iv)
-			if i+1 >= wire.MaxInvPerMsg {
+			if len(invMsg.InvList)+1 > wire.MaxInvPerMsg {
 				break
 			}
 		}


### PR DESCRIPTION
I came across this, not sure if that was intended behavior, but it could currently break without having added any messages.