### PR TITLE
rpc: implement getblockchaininfo 

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -75,16 +75,41 @@ type GetAddedNodeInfoResult struct {
 	Addresses *[]GetAddedNodeInfoResultAddr `json:"addresses,omitempty"`
 }
 
+// SoftForkDescription describes the current state of a soft-fork which was
+// deployed using a super-majority block signalling.
+type SoftForkDescription struct {
+	ID      string `json:"id"`
+	Version uint32 `json:"version"`
+	Reject  struct {
+		Status bool `json:"status"`
+	} `json:"reject"`
+}
+
+// Bip9SoftForkDescription describes the current state of a defined BIP0009
+// version bits soft-fork.
+type Bip9SoftForkDescription struct {
+	Status    string `json:"status"`
+	Bit       uint8  `json:"bit"`
+	StartTime int64  `json:"startTime"`
+	Timeout   int64  `json:"timeout"`
+	Since     int32  `json:"since"`
+}
+
 // GetBlockChainInfoResult models the data returned from the getblockchaininfo
 // command.
 type GetBlockChainInfoResult struct {
-	Chain                string  `json:"chain"`
-	Blocks               int32   `json:"blocks"`
-	Headers              int32   `json:"headers"`
-	BestBlockHash        string  `json:"bestblockhash"`
-	Difficulty           float64 `json:"difficulty"`
-	VerificationProgress float64 `json:"verificationprogress"`
-	ChainWork            string  `json:"chainwork"`
+	Chain                string                              `json:"chain"`
+	Blocks               int32                               `json:"blocks"`
+	Headers              int32                               `json:"headers"`
+	BestBlockHash        string                              `json:"bestblockhash"`
+	Difficulty           float64                             `json:"difficulty"`
+	MedianTime           int64                               `json:"mediantime"`
+	VerificationProgress float64                             `json:"verificationprogress,omitempty"`
+	Pruned               bool                                `json:"pruned"`
+	PruneHeight          int32                               `json:"pruneheight,omitempty"`
+	ChainWork            string                              `json:"chainwork,omitempty"`
+	SoftForks            []*SoftForkDescription              `json:"softforks"`
+	Bip9SoftForks        map[string]*Bip9SoftForkDescription `json:"bip9_softforks"`
 }
 
 // GetBlockTemplateResultTx models the transactions field of the

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,10 @@
 hash: 8f89ba1940f8798b8a0449810532e3f0bc552ed97d907bc3447a8941a2ea3a4a
-updated: 2016-10-26T22:53:00.0848822-05:00
+updated: 2016-11-11T17:21:09.070085014-08:00
 imports:
 - name: github.com/btcsuite/btclog
   version: 73889fb79bd687870312b6e40effcecffbd57d30
 - name: github.com/btcsuite/btcrpcclient
-  version: 2b780d16b042054d07aa322146194118fd7f7b81
+  version: c6e1d711da0db56803309479a5deabb02b816e88
 - name: github.com/btcsuite/btcutil
   version: aa9087a7efc961fbd253d4ae9c8b7a318749c273
   subpackages:

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -156,6 +156,32 @@ var helpDescsEnUS = map[string]string{
 	"getblock--condition1": "verbose=true",
 	"getblock--result0":    "Hex-encoded bytes of the serialized block",
 
+	// GetBlockChainInfoCmd help.
+	"getblockchaininfo--synopsis": "Returns information about the current blockchain state and the status of any active soft-fork deployments.",
+
+	// GetBlockChainInfoResult help.
+	"getblockchaininforesult-chain":                 "The name of the chain the daemon is on (testnet, mainnet, etc)",
+	"getblockchaininforesult-blocks":                "The number of blocks in the best known chain",
+	"getblockchaininforesult-headers":               "The number of headers that we've gathered for in the best known chain",
+	"getblockchaininforesult-bestblockhash":         "The block hash for the latest block in the main chain",
+	"getblockchaininforesult-difficulty":            "The current chain difficulty",
+	"getblockchaininforesult-mediantime":            "The median time from the PoV of the best block in the chain",
+	"getblockchaininforesult-verificationprogress":  "An estimate for how much of the best chain we've verified",
+	"getblockchaininforesult-pruned":                "A bool that indicates if the node is pruned or not",
+	"getblockchaininforesult-pruneheight":           "The lowest block retained in the current pruned chain",
+	"getblockchaininforesult-chainwork":             "The total cumulative work in the best chain",
+	"getblockchaininforesult-softforks":             "The status of the super-majority soft-forks",
+	"getblockchaininforesult-bip9_softforks":        "JSON object describing active BIP0009 deployments",
+	"getblockchaininforesult-bip9_softforks--key":   "bip9_softforks",
+	"getblockchaininforesult-bip9_softforks--value": "An object describing a particular BIP009 deployment",
+	"getblockchaininforesult-bip9_softforks--desc":  "The status of any defined BIP0009 soft-fork deployments",
+
+	// SoftForkDescription help.
+	"softforkdescription-reject":  "The current activation status of the softfork",
+	"softforkdescription-version": "The block version that signals enforcement of this softfork",
+	"softforkdescription-id":      "The string identifier for the soft fork",
+	"-status":                     "A bool which indicates if the soft fork is active",
+
 	// TxRawResult help.
 	"txrawresult-hex":           "Hex-encoded transaction",
 	"txrawresult-txid":          "The hash of the transaction",
@@ -599,6 +625,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getblockhash":          {(*string)(nil)},
 	"getblockheader":        {(*string)(nil), (*btcjson.GetBlockHeaderVerboseResult)(nil)},
 	"getblocktemplate":      {(*btcjson.GetBlockTemplateResult)(nil), (*string)(nil), nil},
+	"getblockchaininfo":     {(*btcjson.GetBlockChainInfoResult)(nil)},
 	"getconnectioncount":    {(*int32)(nil)},
 	"getcurrentnet":         {(*uint32)(nil)},
 	"getdifficulty":         {(*float64)(nil)},


### PR DESCRIPTION
This commit implements the `getblockchaininfo` as it's defined in BC to the best of btcd's current capabilities. Due to some differences in header storage, and `BIP0009` state storage between `btcd` and BC, some of the information within the call isn't readily or easily accessible to `btcd`, therefore they are currently blank within the PR. 