### PR TITLE
integration: Add BIP0009 state transition tests

### DIFF
--- a/integration/bip0009_test.go
+++ b/integration/bip0009_test.go
@@ -8,12 +8,25 @@
 package integration
 
 import (
+	"fmt"
 	"runtime"
 	"testing"
+	"time"
 
+	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/rpctest"
+)
+
+const (
+	// vbLegacyBlockVersion is the highest legacy block version before the
+	// version bits scheme became active.
+	vbLegacyBlockVersion = 4
+
+	// vbTopBits defines the bits to set in the version to signal that the
+	// version bits scheme is being used.
+	vbTopBits = 0x20000000
 )
 
 // assertVersionBit gets the passed block hash from the given test harness and
@@ -35,6 +48,257 @@ func assertVersionBit(r *rpctest.Harness, t *testing.T, hash *chainhash.Hash, bi
 		t.Fatalf("assertion failed at line %d: block %s, version 0x%x "+
 			"has bit %d set", line, hash, block.Header.Version, bit)
 	}
+}
+
+// assertChainHeight retrieves the current chain height from the given test
+// harness and ensures it matches the provided expected height.
+func assertChainHeight(r *rpctest.Harness, t *testing.T, expectedHeight uint32) {
+	height, err := r.Node.GetBlockCount()
+	if err != nil {
+		t.Fatalf("failed to retrieve block height: %v", err)
+	}
+	if uint32(height) != expectedHeight {
+		_, _, line, _ := runtime.Caller(1)
+		t.Fatalf("assertion failed at line %d: block height of %d "+
+			"is not the expected %d", line, height, expectedHeight)
+	}
+}
+
+// thresholdStateToStatus converts the passed threshold state to the equivalent
+// status string returned in the getblockchaininfo RPC.
+func thresholdStateToStatus(state blockchain.ThresholdState) (string, error) {
+	switch state {
+	case blockchain.ThresholdDefined:
+		return "defined", nil
+	case blockchain.ThresholdStarted:
+		return "started", nil
+	case blockchain.ThresholdLockedIn:
+		return "lockedin", nil
+	case blockchain.ThresholdActive:
+		return "active", nil
+	case blockchain.ThresholdFailed:
+		return "failed", nil
+	}
+
+	return "", fmt.Errorf("unrecognized threshold state: %v", state)
+}
+
+// assertSoftForkStatus retrieves the current blockchain info from the given
+// test harness and ensures the provided soft fork key is both available and its
+// status is the equivalent of the passed state.
+func assertSoftForkStatus(r *rpctest.Harness, t *testing.T, forkKey string, state blockchain.ThresholdState) {
+	// Convert the expected threshold state into the equivalent
+	// getblockchaininfo RPC status string.
+	status, err := thresholdStateToStatus(state)
+	if err != nil {
+		_, _, line, _ := runtime.Caller(1)
+		t.Fatalf("assertion failed at line %d: unable to convert "+
+			"threshold state %v to string", line, state)
+	}
+
+	info, err := r.Node.GetBlockChainInfo()
+	if err != nil {
+		t.Fatalf("failed to retrieve chain info: %v", err)
+	}
+
+	// Ensure the key is available.
+	desc, ok := info.Bip9SoftForks[forkKey]
+	if !ok {
+		_, _, line, _ := runtime.Caller(1)
+		t.Fatalf("assertion failed at line %d: softfork status for %q "+
+			"is not in getblockchaininfo results", line, forkKey)
+	}
+
+	// Ensure the status it the expected value.
+	if desc.Status != status {
+		_, _, line, _ := runtime.Caller(1)
+		t.Fatalf("assertion failed at line %d: softfork status for %q "+
+			"is %v instead of expected %v", line, forkKey,
+			desc.Status, status)
+	}
+}
+
+// testBIP0009 ensures the BIP0009 soft fork mechanism follows the state
+// transition rules set forth by the BIP for the provided soft fork key.  It
+// uses the regression test network to signal support and advance through the
+// various threshold states including failure to achieve locked in status.
+//
+// See TestBIP0009 for an overview of what is tested.
+//
+// NOTE: This only differs from the exported version in that it accepts the
+// specific soft fork deployment to test.
+func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
+	// Initialize the primary mining node with only the genesis block.
+	r, err := rpctest.New(&chaincfg.RegressionNetParams, nil, nil)
+	if err != nil {
+		t.Fatalf("unable to create primary harness: %v", err)
+	}
+	if err := r.SetUp(false, 0); err != nil {
+		t.Fatalf("unable to setup test chain: %v", err)
+	}
+	defer r.TearDown()
+
+	// *** ThresholdDefined ***
+	//
+	// Assert the chain height is the expected value and the soft fork
+	// status starts out as defined.
+	assertChainHeight(r, t, 0)
+	assertSoftForkStatus(r, t, forkKey, blockchain.ThresholdDefined)
+
+	// *** ThresholdDefined part 2 - 1 block prior to ThresholdStarted ***
+	//
+	// Generate enough blocks to reach the height just before the first
+	// state transition without signalling support since the state should
+	// move to started once the start time has been reached regardless of
+	// support signalling.
+	//
+	// NOTE: This is two blocks before the confirmation window because the
+	// getblockchaininfo RPC reports the status for the block AFTER the
+	// current one.  All of the heights below are thus offset by one to
+	// compensate.
+	//
+	// Assert the chain height is the expected value and soft fork status is
+	// still defined and did NOT move to started.
+	confirmationWindow := r.ActiveNet.MinerConfirmationWindow
+	for i := uint32(0); i < confirmationWindow-2; i++ {
+		_, err := r.GenerateAndSubmitBlock(nil, vbLegacyBlockVersion,
+			time.Time{})
+		if err != nil {
+			t.Fatalf("failed to generated block %d: %v", i, err)
+		}
+	}
+	assertChainHeight(r, t, confirmationWindow-2)
+	assertSoftForkStatus(r, t, forkKey, blockchain.ThresholdDefined)
+
+	// *** ThresholdStarted ***
+	//
+	// Generate another block to reach the next window.
+	//
+	// Assert the chain height is the expected value and the soft fork
+	// status is started.
+	_, err = r.GenerateAndSubmitBlock(nil, vbLegacyBlockVersion, time.Time{})
+	if err != nil {
+		t.Fatalf("failed to generated block: %v", err)
+	}
+	assertChainHeight(r, t, confirmationWindow-1)
+	assertSoftForkStatus(r, t, forkKey, blockchain.ThresholdStarted)
+
+	// *** ThresholdStarted part 2 - Fail to achieve ThresholdLockedIn ***
+	//
+	// Generate enough blocks to reach the next window in such a way that
+	// the number blocks with the version bit set to signal support is 1
+	// less than required to achieve locked in status.
+	//
+	// Assert the chain height is the expected value and the soft fork
+	// status is still started and did NOT move to locked in.
+	if deploymentID > uint32(len(r.ActiveNet.Deployments)) {
+		t.Fatalf("deployment ID %d does not exist", deploymentID)
+	}
+	deployment := &r.ActiveNet.Deployments[deploymentID]
+	activationThreshold := r.ActiveNet.RuleChangeActivationThreshold
+	signalForkVersion := int32(1<<deployment.BitNumber) | vbTopBits
+	for i := uint32(0); i < activationThreshold-1; i++ {
+		_, err := r.GenerateAndSubmitBlock(nil, signalForkVersion,
+			time.Time{})
+		if err != nil {
+			t.Fatalf("failed to generated block %d: %v", i, err)
+		}
+	}
+	for i := uint32(0); i < confirmationWindow-(activationThreshold-1); i++ {
+		_, err := r.GenerateAndSubmitBlock(nil, vbLegacyBlockVersion,
+			time.Time{})
+		if err != nil {
+			t.Fatalf("failed to generated block %d: %v", i, err)
+		}
+	}
+	assertChainHeight(r, t, (confirmationWindow*2)-1)
+	assertSoftForkStatus(r, t, forkKey, blockchain.ThresholdStarted)
+
+	// *** ThresholdLockedIn ***
+	//
+	// Generate enough blocks to reach the next window in such a way that
+	// the number blocks with the version bit set to signal support is
+	// exactly the number required to achieve locked in status.
+	//
+	// Assert the chain height is the expected value and the soft fork
+	// status moved to locked in.
+	for i := uint32(0); i < activationThreshold; i++ {
+		_, err := r.GenerateAndSubmitBlock(nil, signalForkVersion,
+			time.Time{})
+		if err != nil {
+			t.Fatalf("failed to generated block %d: %v", i, err)
+		}
+	}
+	for i := uint32(0); i < confirmationWindow-activationThreshold; i++ {
+		_, err := r.GenerateAndSubmitBlock(nil, vbLegacyBlockVersion,
+			time.Time{})
+		if err != nil {
+			t.Fatalf("failed to generated block %d: %v", i, err)
+		}
+	}
+	assertChainHeight(r, t, (confirmationWindow*3)-1)
+	assertSoftForkStatus(r, t, forkKey, blockchain.ThresholdLockedIn)
+
+	// *** ThresholdLockedIn part 2 -- 1 block prior to ThresholdActive ***
+	//
+	// Generate enough blocks to reach the height just before the next
+	// window without continuing to signal support since it is already
+	// locked in.
+	//
+	// Assert the chain height is the expected value and the soft fork
+	// status is still locked in and did NOT move to active.
+	for i := uint32(0); i < confirmationWindow-1; i++ {
+		_, err := r.GenerateAndSubmitBlock(nil, vbLegacyBlockVersion,
+			time.Time{})
+		if err != nil {
+			t.Fatalf("failed to generated block %d: %v", i, err)
+		}
+	}
+	assertChainHeight(r, t, (confirmationWindow*4)-2)
+	assertSoftForkStatus(r, t, forkKey, blockchain.ThresholdLockedIn)
+
+	// *** ThresholdActive ***
+	//
+	// Generate another block to reach the next window without continuing to
+	// signal support since it is already locked in.
+	//
+	// Assert the chain height is the expected value and the soft fork
+	// status moved to active.
+	_, err = r.GenerateAndSubmitBlock(nil, vbLegacyBlockVersion, time.Time{})
+	if err != nil {
+		t.Fatalf("failed to generated block: %v", err)
+	}
+	assertChainHeight(r, t, (confirmationWindow*4)-1)
+	assertSoftForkStatus(r, t, forkKey, blockchain.ThresholdActive)
+}
+
+// TestBIP0009 ensures the BIP0009 soft fork mechanism follows the state
+// transition rules set forth by the BIP for all soft forks.  It uses the
+// regression test network to signal support and advance through the various
+// threshold states including failure to achieve locked in status.
+//
+// Overview:
+// - Assert the chain height is 0 and the state is ThresholdDefined
+// - Generate 1 fewer blocks than needed to reach the first state transition
+//   - Assert chain height is expected and state is still ThresholdDefined
+// - Generate 1 more block to reach the first state transition
+//   - Assert chain height is expected and state moved to ThresholdStarted
+// - Generate enough blocks to reach the next state transition window, but only
+//   signal support in 1 fewer than the required number to achieve
+//   ThresholdLockedIn
+//   - Assert chain height is expected and state is still ThresholdStarted
+// - Generate enough blocks to reach the next state transition window with only
+//   the exact number of blocks required to achieve locked in status signalling
+//   support.
+//   - Assert chain height is expected and state moved to ThresholdLockedIn
+// - Generate 1 fewer blocks than needed to reach the next state transition
+//   - Assert chain height is expected and state is still ThresholdLockedIn
+// - Generate 1 more block to reach the next state transition
+//   - Assert chain height is expected and state moved to ThresholdActive
+func TestBIP0009(t *testing.T) {
+	t.Parallel()
+
+	testBIP0009(t, "dummy", chaincfg.DeploymentTestDummy)
 }
 
 // TestBIP0009Mining ensures blocks built via btcd's CPU miner follow the rules
@@ -64,6 +328,9 @@ func TestBIP0009Mining(t *testing.T) {
 	}
 	defer r.TearDown()
 
+	// Assert the chain only consists of the gensis block.
+	assertChainHeight(r, t, 0)
+
 	// *** ThresholdDefined ***
 	//
 	// Generate a block that extends the genesis block.  It should not have
@@ -75,6 +342,7 @@ func TestBIP0009Mining(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unable to generate blocks: %v", err)
 	}
+	assertChainHeight(r, t, 1)
 	assertVersionBit(r, t, hashes[0], testDummyBitNum, false)
 
 	// *** ThresholdStarted ***
@@ -93,6 +361,7 @@ func TestBIP0009Mining(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to generated %d blocks: %v", numNeeded, err)
 	}
+	assertChainHeight(r, t, confirmationWindow)
 	assertVersionBit(r, t, hashes[len(hashes)-2], testDummyBitNum, false)
 	assertVersionBit(r, t, hashes[len(hashes)-1], testDummyBitNum, true)
 
@@ -108,6 +377,7 @@ func TestBIP0009Mining(t *testing.T) {
 		t.Fatalf("failed to generated %d blocks: %v", confirmationWindow,
 			err)
 	}
+	assertChainHeight(r, t, confirmationWindow*2)
 	assertVersionBit(r, t, hashes[len(hashes)-1], testDummyBitNum, true)
 
 	// *** ThresholdActivated ***
@@ -126,6 +396,7 @@ func TestBIP0009Mining(t *testing.T) {
 		t.Fatalf("failed to generated %d blocks: %v", confirmationWindow,
 			err)
 	}
+	assertChainHeight(r, t, confirmationWindow*3)
 	assertVersionBit(r, t, hashes[len(hashes)-2], testDummyBitNum, true)
 	assertVersionBit(r, t, hashes[len(hashes)-1], testDummyBitNum, false)
 }

--- a/rpctest/utils.go
+++ b/rpctest/utils.go
@@ -140,7 +140,7 @@ func TearDownAll() error {
 	defer harnessStateMtx.Unlock()
 
 	for _, harness := range testInstances {
-		if err := harness.TearDown(); err != nil {
+		if err := harness.tearDown(); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
** This PR requires #871 **

This adds tests which exercise the BIP0009 state transitions using the newly available soft fork status information in the `getblockchaininfo` RPC.

The following is an overview of the tests added:
- Assert the chain height is 0 and the state is `ThresholdDefined`
- Generate 1 fewer blocks than needed to reach the first state transition
  - Assert chain height is expected and state is still `ThresholdDefined`
- Generate 1 more block to reach the first state transition
  - Assert chain height is expected and state moved to `ThresholdStarted`
- Generate enough blocks to reach the next state transition window, but only signal support in 1 fewer than the required number to achieve `ThresholdLockedIn`
  - Assert chain height is expected and state is still `ThresholdStarted`
- Generate enough blocks to reach the next state transition window with only the exact number of blocks required to achieve locked in status signalling support
  - Assert chain height is expected and state moved to `ThresholdLockedIn`
- Generate 1 fewer blocks than needed to reach the next state transition
  - Assert chain height is expected and state is still `ThresholdLockedIn`
- Generate 1 more block to reach the next state transition
  - Assert chain height is expected and state moved to `ThresholdActive`

In addition, it updates the existing BIP0009 mining tests to include extra assertions that the chain height is at the expected height in addition to checking that the bits are correctly set according to the expected state.
