### PR TITLE
goclean.sh: Make it more robust

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -13,6 +13,22 @@
 
 set -ex
 
+# Make sure glide is installed and $GOPATH/bin is in your path.
+# $ go get -u github.com/Masterminds/glide
+# $ glide install
+if [ ! -x "$(type -p glide)" ]; then
+  exit 1
+fi
+
+# Make sure gometalinter is installed and $GOPATH/bin is in your path.
+# $ go get -v github.com/alecthomas/gometalinter"
+# $ gometalinter --install"
+if [ ! -x "$(type -p gometalinter)" ]; then
+  exit 1
+fi
+
+linter_targets=$(glide novendor)
+
 # Automatic checks
 test -z "$(gometalinter --disable-all \
 --enable=gofmt \
@@ -20,8 +36,8 @@ test -z "$(gometalinter --disable-all \
 --enable=vet \
 --enable=gosimple \
 --enable=unconvert \
---deadline=4m $(glide novendor) | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
-env GORACE="halt_on_error=1" go test -race -tags rpctest $(glide novendor)
+--deadline=4m $linter_targets 2>&1 | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
+env GORACE="halt_on_error=1" go test -race -tags rpctest $linter_targets
 
 # Run test coverage on each subdirectories and merge the coverage profile.
 


### PR DESCRIPTION
Fail fast if glide or gometalinter isn't available.
And also fail if running glide or gometalinter fails.

Before goclean.sh could pass even if glide or gometalinter wasn't
available at all. It seems that even though we use `set -ex`, their
failure was hidden either inside the $() or behind the pipe.