### PR TITLE
Backport filter-based JSON-RPC commands from dcrd

### DIFF
--- a/btcjson/chainsvrwscmds.go
+++ b/btcjson/chainsvrwscmds.go
@@ -178,6 +178,8 @@ func NewStopNotifySpentCmd(outPoints []OutPoint) *StopNotifySpentCmd {
 }
 
 // RescanCmd defines the rescan JSON-RPC command.
+//
+// NOTE: Deprecated. Use RescanBlocksCmd instead.
 type RescanCmd struct {
 	BeginBlock string
 	Addresses  []string
@@ -190,6 +192,8 @@ type RescanCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
+//
+// NOTE: Deprecated. Use NewRescanBlocksCmd instead.
 func NewRescanCmd(beginBlock string, addresses []string, outPoints []OutPoint, endBlock *string) *RescanCmd {
 	return &RescanCmd{
 		BeginBlock: beginBlock,
@@ -197,6 +201,24 @@ func NewRescanCmd(beginBlock string, addresses []string, outPoints []OutPoint, e
 		OutPoints:  outPoints,
 		EndBlock:   endBlock,
 	}
+}
+
+// RescanBlocksCmd defines the rescan JSON-RPC command.
+//
+// NOTE: This is a btcd extension ported from github.com/decred/dcrd/dcrjson
+// and requires a websocket connection.
+type RescanBlocksCmd struct {
+	// Block hashes as a string array.
+	BlockHashes []string
+}
+
+// NewRescanBlocksCmd returns a new instance which can be used to issue a rescan
+// JSON-RPC command.
+//
+// NOTE: This is a btcd extension ported from github.com/decred/dcrd/dcrjson
+// and requires a websocket connection.
+func NewRescanBlocksCmd(blockHashes []string) *RescanBlocksCmd {
+	return &RescanBlocksCmd{BlockHashes: blockHashes}
 }
 
 func init() {
@@ -215,4 +237,5 @@ func init() {
 	MustRegisterCmd("stopnotifyspent", (*StopNotifySpentCmd)(nil), flags)
 	MustRegisterCmd("stopnotifyreceived", (*StopNotifyReceivedCmd)(nil), flags)
 	MustRegisterCmd("rescan", (*RescanCmd)(nil), flags)
+	MustRegisterCmd("rescanblocks", (*RescanBlocksCmd)(nil), flags)
 }

--- a/btcjson/chainsvrwscmds.go
+++ b/btcjson/chainsvrwscmds.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2014-2015 The btcsuite developers
+// Copyright (c) 2014-2017 The btcsuite developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -78,12 +79,16 @@ func NewStopNotifyNewTransactionsCmd() *StopNotifyNewTransactionsCmd {
 }
 
 // NotifyReceivedCmd defines the notifyreceived JSON-RPC command.
+//
+// NOTE: Deprecated. Use LoadTxFilterCmd instead.
 type NotifyReceivedCmd struct {
 	Addresses []string
 }
 
 // NewNotifyReceivedCmd returns a new instance which can be used to issue a
 // notifyreceived JSON-RPC command.
+//
+// NOTE: Deprecated. Use NewLoadTxFilterCmd instead.
 func NewNotifyReceivedCmd(addresses []string) *NotifyReceivedCmd {
 	return &NotifyReceivedCmd{
 		Addresses: addresses,
@@ -97,13 +102,41 @@ type OutPoint struct {
 	Index uint32 `json:"index"`
 }
 
+// LoadTxFilterCmd defines the loadtxfilter request parameters to load or
+// reload a transaction filter.
+//
+// NOTE: This is a btcd extension ported from github.com/decred/dcrd/dcrjson
+// and requires a websocket connection.
+type LoadTxFilterCmd struct {
+	Reload    bool
+	Addresses []string
+	OutPoints []OutPoint
+}
+
+// NewLoadTxFilterCmd returns a new instance which can be used to issue a
+// loadtxfilter JSON-RPC command.
+//
+// NOTE: This is a btcd extension ported from github.com/decred/dcrd/dcrjson
+// and requires a websocket connection.
+func NewLoadTxFilterCmd(reload bool, addresses []string, outPoints []OutPoint) *LoadTxFilterCmd {
+	return &LoadTxFilterCmd{
+		Reload:    reload,
+		Addresses: addresses,
+		OutPoints: outPoints,
+	}
+}
+
 // NotifySpentCmd defines the notifyspent JSON-RPC command.
+//
+// NOTE: Deprecated. Use LoadTxFilterCmd instead.
 type NotifySpentCmd struct {
 	OutPoints []OutPoint
 }
 
 // NewNotifySpentCmd returns a new instance which can be used to issue a
 // notifyspent JSON-RPC command.
+//
+// NOTE: Deprecated. Use NewLoadTxFilterCmd instead.
 func NewNotifySpentCmd(outPoints []OutPoint) *NotifySpentCmd {
 	return &NotifySpentCmd{
 		OutPoints: outPoints,
@@ -111,12 +144,16 @@ func NewNotifySpentCmd(outPoints []OutPoint) *NotifySpentCmd {
 }
 
 // StopNotifyReceivedCmd defines the stopnotifyreceived JSON-RPC command.
+//
+// NOTE: Deprecated. Use LoadTxFilterCmd instead.
 type StopNotifyReceivedCmd struct {
 	Addresses []string
 }
 
 // NewStopNotifyReceivedCmd returns a new instance which can be used to issue a
 // stopnotifyreceived JSON-RPC command.
+//
+// NOTE: Deprecated. Use NewLoadTxFilterCmd instead.
 func NewStopNotifyReceivedCmd(addresses []string) *StopNotifyReceivedCmd {
 	return &StopNotifyReceivedCmd{
 		Addresses: addresses,
@@ -124,12 +161,16 @@ func NewStopNotifyReceivedCmd(addresses []string) *StopNotifyReceivedCmd {
 }
 
 // StopNotifySpentCmd defines the stopnotifyspent JSON-RPC command.
+//
+// NOTE: Deprecated. Use LoadTxFilterCmd instead.
 type StopNotifySpentCmd struct {
 	OutPoints []OutPoint
 }
 
 // NewStopNotifySpentCmd returns a new instance which can be used to issue a
 // stopnotifyspent JSON-RPC command.
+//
+// NOTE: Deprecated. Use NewLoadTxFilterCmd instead.
 func NewStopNotifySpentCmd(outPoints []OutPoint) *StopNotifySpentCmd {
 	return &StopNotifySpentCmd{
 		OutPoints: outPoints,
@@ -163,6 +204,7 @@ func init() {
 	flags := UFWebsocketOnly
 
 	MustRegisterCmd("authenticate", (*AuthenticateCmd)(nil), flags)
+	MustRegisterCmd("loadtxfilter", (*LoadTxFilterCmd)(nil), flags)
 	MustRegisterCmd("notifyblocks", (*NotifyBlocksCmd)(nil), flags)
 	MustRegisterCmd("notifynewtransactions", (*NotifyNewTransactionsCmd)(nil), flags)
 	MustRegisterCmd("notifyreceived", (*NotifyReceivedCmd)(nil), flags)

--- a/btcjson/chainsvrwscmds_test.go
+++ b/btcjson/chainsvrwscmds_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2014-2017 The btcsuite developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -190,6 +191,26 @@ func TestChainSvrWsCmds(t *testing.T) {
 				Addresses:  []string{"1Address"},
 				OutPoints:  []btcjson.OutPoint{{Hash: "123", Index: 0}},
 				EndBlock:   btcjson.String("456"),
+			},
+		},
+		{
+			name: "loadtxfilter",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("loadtxfilter", false, `["1Address"]`, `[{"hash":"0000000000000000000000000000000000000000000000000000000000000123","index":0}]`)
+			},
+			staticCmd: func() interface{} {
+				addrs := []string{"1Address"}
+				ops := []btcjson.OutPoint{{
+					Hash:  "0000000000000000000000000000000000000000000000000000000000000123",
+					Index: 0,
+				}}
+				return btcjson.NewLoadTxFilterCmd(false, addrs, ops)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"loadtxfilter","params":[false,["1Address"],[{"hash":"0000000000000000000000000000000000000000000000000000000000000123","index":0}]],"id":1}`,
+			unmarshalled: &btcjson.LoadTxFilterCmd{
+				Reload:    false,
+				Addresses: []string{"1Address"},
+				OutPoints: []btcjson.OutPoint{{Hash: "0000000000000000000000000000000000000000000000000000000000000123", Index: 0}},
 			},
 		},
 	}

--- a/btcjson/chainsvrwscmds_test.go
+++ b/btcjson/chainsvrwscmds_test.go
@@ -213,6 +213,20 @@ func TestChainSvrWsCmds(t *testing.T) {
 				OutPoints: []btcjson.OutPoint{{Hash: "0000000000000000000000000000000000000000000000000000000000000123", Index: 0}},
 			},
 		},
+		{
+			name: "rescanblocks",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("rescanblocks", `["0000000000000000000000000000000000000000000000000000000000000123"]`)
+			},
+			staticCmd: func() interface{} {
+				blockhashes := []string{"0000000000000000000000000000000000000000000000000000000000000123"}
+				return btcjson.NewRescanBlocksCmd(blockhashes)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"rescanblocks","params":[["0000000000000000000000000000000000000000000000000000000000000123"]],"id":1}`,
+			unmarshalled: &btcjson.RescanBlocksCmd{
+				BlockHashes: []string{"0000000000000000000000000000000000000000000000000000000000000123"},
+			},
+		},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/btcjson/chainsvrwsntfns.go
+++ b/btcjson/chainsvrwsntfns.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2014-2017 The btcsuite developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,22 +9,42 @@
 package btcjson
 
 const (
-	// BlockConnectedNtfnMethod is the method used for notifications from
-	// the chain server that a block has been connected.
+	// BlockConnectedNtfnMethod is the legacy, deprecated method used for
+	// notifications from the chain server that a block has been connected.
+	//
+	// NOTE: Deprecated. Use FilteredBlockConnectedNtfnMethod instead.
 	BlockConnectedNtfnMethod = "blockconnected"
 
-	// BlockDisconnectedNtfnMethod is the method used for notifications from
-	// the chain server that a block has been disconnected.
+	// BlockDisconnectedNtfnMethod is the legacy, deprecated method used for
+	// notifications from the chain server that a block has been
+	// disconnected.
+	//
+	// NOTE: Deprecated. Use FilteredBlockDisconnectedNtfnMethod instead.
 	BlockDisconnectedNtfnMethod = "blockdisconnected"
 
-	// RecvTxNtfnMethod is the method used for notifications from the chain
-	// server that a transaction which pays to a registered address has been
-	// processed.
+	// FilteredBlockConnectedNtfnMethod is the new method used for
+	// notifications from the chain server that a block has been connected.
+	FilteredBlockConnectedNtfnMethod = "filteredblockconnected"
+
+	// FilteredBlockDisconnectedNtfnMethod is the new method used for
+	// notifications from the chain server that a block has been
+	// disconnected.
+	FilteredBlockDisconnectedNtfnMethod = "filteredblockdisconnected"
+
+	// RecvTxNtfnMethod is the legacy, deprecated method used for
+	// notifications from the chain server that a transaction which pays to
+	// a registered address has been processed.
+	//
+	// NOTE: Deprecated. Use RelevantTxAcceptedNtfnMethod and
+	// FilteredBlockConnectedNtfnMethod instead.
 	RecvTxNtfnMethod = "recvtx"
 
-	// RedeemingTxNtfnMethod is the method used for notifications from the
-	// chain server that a transaction which spends a registered outpoint
-	// has been processed.
+	// RedeemingTxNtfnMethod is the legacy, deprecated method used for
+	// notifications from the chain server that a transaction which spends a
+	// registered outpoint has been processed.
+	//
+	// NOTE: Deprecated. Use RelevantTxAcceptedNtfnMethod and
+	// FilteredBlockConnectedNtfnMethod instead.
 	RedeemingTxNtfnMethod = "redeemingtx"
 
 	// RescanFinishedNtfnMethod is the method used for notifications from
@@ -44,9 +65,16 @@ const (
 	// mempool.  This differs from TxAcceptedNtfnMethod in that it provides
 	// more details in the notification.
 	TxAcceptedVerboseNtfnMethod = "txacceptedverbose"
+
+	// RelevantTxAcceptedNtfnMethod is the new method used for notifications
+	// from the chain server that inform a client that a transaction that
+	// matches the loaded filter was accepted by the mempool.
+	RelevantTxAcceptedNtfnMethod = "relevanttxaccepted"
 )
 
 // BlockConnectedNtfn defines the blockconnected JSON-RPC notification.
+//
+// NOTE: Deprecated. Use FilteredBlockConnectedNtfn instead.
 type BlockConnectedNtfn struct {
 	Hash   string
 	Height int32
@@ -55,6 +83,8 @@ type BlockConnectedNtfn struct {
 
 // NewBlockConnectedNtfn returns a new instance which can be used to issue a
 // blockconnected JSON-RPC notification.
+//
+// NOTE: Deprecated. Use NewFilteredBlockConnectedNtfn instead.
 func NewBlockConnectedNtfn(hash string, height int32, time int64) *BlockConnectedNtfn {
 	return &BlockConnectedNtfn{
 		Hash:   hash,
@@ -64,6 +94,8 @@ func NewBlockConnectedNtfn(hash string, height int32, time int64) *BlockConnecte
 }
 
 // BlockDisconnectedNtfn defines the blockdisconnected JSON-RPC notification.
+//
+// NOTE: Deprecated. Use FilteredBlockDisconnectedNtfn instead.
 type BlockDisconnectedNtfn struct {
 	Hash   string
 	Height int32
@@ -72,11 +104,47 @@ type BlockDisconnectedNtfn struct {
 
 // NewBlockDisconnectedNtfn returns a new instance which can be used to issue a
 // blockdisconnected JSON-RPC notification.
+//
+// NOTE: Deprecated. Use NewFilteredBlockDisconnectedNtfn instead.
 func NewBlockDisconnectedNtfn(hash string, height int32, time int64) *BlockDisconnectedNtfn {
 	return &BlockDisconnectedNtfn{
 		Hash:   hash,
 		Height: height,
 		Time:   time,
+	}
+}
+
+// FilteredBlockConnectedNtfn defines the filteredblockconnected JSON-RPC
+// notification.
+type FilteredBlockConnectedNtfn struct {
+	Height        int32
+	Header        string
+	SubscribedTxs []string
+}
+
+// NewFilteredBlockConnectedNtfn returns a new instance which can be used to
+// issue a filteredblockconnected JSON-RPC notification.
+func NewFilteredBlockConnectedNtfn(height int32, header string, subscribedTxs []string) *FilteredBlockConnectedNtfn {
+	return &FilteredBlockConnectedNtfn{
+		Height:        height,
+		Header:        header,
+		SubscribedTxs: subscribedTxs,
+	}
+}
+
+// FilteredBlockDisconnectedNtfn defines the filteredblockdisconnected JSON-RPC
+// notification.
+type FilteredBlockDisconnectedNtfn struct {
+	Height int32
+	Header string
+}
+
+// NewFilteredBlockDisconnectedNtfn returns a new instance which can be used to
+// issue a filteredblockdisconnected JSON-RPC notification.
+func NewFilteredBlockDisconnectedNtfn(height int32, header string) *FilteredBlockDisconnectedNtfn {
+	return &FilteredBlockDisconnectedNtfn{
+		Height: height,
+		Header: header,
 	}
 }
 
@@ -89,6 +157,9 @@ type BlockDetails struct {
 }
 
 // RecvTxNtfn defines the recvtx JSON-RPC notification.
+//
+// NOTE: Deprecated. Use RelevantTxAcceptedNtfn and FilteredBlockConnectedNtfn
+// instead.
 type RecvTxNtfn struct {
 	HexTx string
 	Block *BlockDetails
@@ -96,6 +167,9 @@ type RecvTxNtfn struct {
 
 // NewRecvTxNtfn returns a new instance which can be used to issue a recvtx
 // JSON-RPC notification.
+//
+// NOTE: Deprecated. Use NewRelevantTxAcceptedNtfn and
+// NewFilteredBlockConnectedNtfn instead.
 func NewRecvTxNtfn(hexTx string, block *BlockDetails) *RecvTxNtfn {
 	return &RecvTxNtfn{
 		HexTx: hexTx,
@@ -104,6 +178,9 @@ func NewRecvTxNtfn(hexTx string, block *BlockDetails) *RecvTxNtfn {
 }
 
 // RedeemingTxNtfn defines the redeemingtx JSON-RPC notification.
+//
+// NOTE: Deprecated. Use RelevantTxAcceptedNtfn and FilteredBlockConnectedNtfn
+// instead.
 type RedeemingTxNtfn struct {
 	HexTx string
 	Block *BlockDetails
@@ -111,6 +188,9 @@ type RedeemingTxNtfn struct {
 
 // NewRedeemingTxNtfn returns a new instance which can be used to issue a
 // redeemingtx JSON-RPC notification.
+//
+// NOTE: Deprecated. Use NewRelevantTxAcceptedNtfn and
+// NewFilteredBlockConnectedNtfn instead.
 func NewRedeemingTxNtfn(hexTx string, block *BlockDetails) *RedeemingTxNtfn {
 	return &RedeemingTxNtfn{
 		HexTx: hexTx,
@@ -180,6 +260,18 @@ func NewTxAcceptedVerboseNtfn(rawTx TxRawResult) *TxAcceptedVerboseNtfn {
 	}
 }
 
+// RelevantTxAcceptedNtfn defines the parameters to the relevanttxaccepted
+// JSON-RPC notification.
+type RelevantTxAcceptedNtfn struct {
+	Transaction string `json:"transaction"`
+}
+
+// NewRelevantTxAcceptedNtfn returns a new instance which can be used to issue a
+// relevantxaccepted JSON-RPC notification.
+func NewRelevantTxAcceptedNtfn(txHex string) *RelevantTxAcceptedNtfn {
+	return &RelevantTxAcceptedNtfn{Transaction: txHex}
+}
+
 func init() {
 	// The commands in this file are only usable by websockets and are
 	// notifications.
@@ -187,10 +279,13 @@ func init() {
 
 	MustRegisterCmd(BlockConnectedNtfnMethod, (*BlockConnectedNtfn)(nil), flags)
 	MustRegisterCmd(BlockDisconnectedNtfnMethod, (*BlockDisconnectedNtfn)(nil), flags)
+	MustRegisterCmd(FilteredBlockConnectedNtfnMethod, (*FilteredBlockConnectedNtfn)(nil), flags)
+	MustRegisterCmd(FilteredBlockDisconnectedNtfnMethod, (*FilteredBlockDisconnectedNtfn)(nil), flags)
 	MustRegisterCmd(RecvTxNtfnMethod, (*RecvTxNtfn)(nil), flags)
 	MustRegisterCmd(RedeemingTxNtfnMethod, (*RedeemingTxNtfn)(nil), flags)
 	MustRegisterCmd(RescanFinishedNtfnMethod, (*RescanFinishedNtfn)(nil), flags)
 	MustRegisterCmd(RescanProgressNtfnMethod, (*RescanProgressNtfn)(nil), flags)
 	MustRegisterCmd(TxAcceptedNtfnMethod, (*TxAcceptedNtfn)(nil), flags)
 	MustRegisterCmd(TxAcceptedVerboseNtfnMethod, (*TxAcceptedVerboseNtfn)(nil), flags)
+	MustRegisterCmd(RelevantTxAcceptedNtfnMethod, (*RelevantTxAcceptedNtfn)(nil), flags)
 }

--- a/btcjson/chainsvrwsntfns.go
+++ b/btcjson/chainsvrwsntfns.go
@@ -47,13 +47,18 @@ const (
 	// FilteredBlockConnectedNtfnMethod instead.
 	RedeemingTxNtfnMethod = "redeemingtx"
 
-	// RescanFinishedNtfnMethod is the method used for notifications from
-	// the chain server that a rescan operation has finished.
+	// RescanFinishedNtfnMethod is the legacy, deprecated method used for
+	// notifications from the chain server that a legacy, deprecated rescan
+	// operation has finished.
+	//
+	// NOTE: Deprecated. Not used with rescanblocks command.
 	RescanFinishedNtfnMethod = "rescanfinished"
 
-	// RescanProgressNtfnMethod is the method used for notifications from
-	// the chain server that a rescan operation this is underway has made
-	// progress.
+	// RescanProgressNtfnMethod is the legacy, deprecated method used for
+	// notifications from the chain server that a legacy, deprecated rescan
+	// operation this is underway has made progress.
+	//
+	// NOTE: Deprecated. Not used with rescanblocks command.
 	RescanProgressNtfnMethod = "rescanprogress"
 
 	// TxAcceptedNtfnMethod is the method used for notifications from the
@@ -199,6 +204,8 @@ func NewRedeemingTxNtfn(hexTx string, block *BlockDetails) *RedeemingTxNtfn {
 }
 
 // RescanFinishedNtfn defines the rescanfinished JSON-RPC notification.
+//
+// NOTE: Deprecated. Not used with rescanblocks command.
 type RescanFinishedNtfn struct {
 	Hash   string
 	Height int32
@@ -207,6 +214,8 @@ type RescanFinishedNtfn struct {
 
 // NewRescanFinishedNtfn returns a new instance which can be used to issue a
 // rescanfinished JSON-RPC notification.
+//
+// NOTE: Deprecated. Not used with rescanblocks command.
 func NewRescanFinishedNtfn(hash string, height int32, time int64) *RescanFinishedNtfn {
 	return &RescanFinishedNtfn{
 		Hash:   hash,
@@ -216,6 +225,8 @@ func NewRescanFinishedNtfn(hash string, height int32, time int64) *RescanFinishe
 }
 
 // RescanProgressNtfn defines the rescanprogress JSON-RPC notification.
+//
+// NOTE: Deprecated. Not used with rescanblocks command.
 type RescanProgressNtfn struct {
 	Hash   string
 	Height int32
@@ -224,6 +235,8 @@ type RescanProgressNtfn struct {
 
 // NewRescanProgressNtfn returns a new instance which can be used to issue a
 // rescanprogress JSON-RPC notification.
+//
+// NOTE: Deprecated. Not used with rescanblocks command.
 func NewRescanProgressNtfn(hash string, height int32, time int64) *RescanProgressNtfn {
 	return &RescanProgressNtfn{
 		Hash:   hash,

--- a/btcjson/chainsvrwsntfns_test.go
+++ b/btcjson/chainsvrwsntfns_test.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2014-2017 The btcsuite developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -56,6 +57,35 @@ func TestChainSvrWsNtfns(t *testing.T) {
 				Hash:   "123",
 				Height: 100000,
 				Time:   123456789,
+			},
+		},
+		{
+			name: "filteredblockconnected",
+			newNtfn: func() (interface{}, error) {
+				return btcjson.NewCmd("filteredblockconnected", 100000, "header", []string{"tx0", "tx1"})
+			},
+			staticNtfn: func() interface{} {
+				return btcjson.NewFilteredBlockConnectedNtfn(100000, "header", []string{"tx0", "tx1"})
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"filteredblockconnected","params":[100000,"header",["tx0","tx1"]],"id":null}`,
+			unmarshalled: &btcjson.FilteredBlockConnectedNtfn{
+				Height:        100000,
+				Header:        "header",
+				SubscribedTxs: []string{"tx0", "tx1"},
+			},
+		},
+		{
+			name: "filteredblockdisconnected",
+			newNtfn: func() (interface{}, error) {
+				return btcjson.NewCmd("filteredblockdisconnected", 100000, "header")
+			},
+			staticNtfn: func() interface{} {
+				return btcjson.NewFilteredBlockDisconnectedNtfn(100000, "header")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"filteredblockdisconnected","params":[100000,"header"],"id":null}`,
+			unmarshalled: &btcjson.FilteredBlockDisconnectedNtfn{
+				Height: 100000,
+				Header: "header",
 			},
 		},
 		{
@@ -180,6 +210,19 @@ func TestChainSvrWsNtfns(t *testing.T) {
 					Vout:          nil,
 					Confirmations: 0,
 				},
+			},
+		},
+		{
+			name: "relevanttxaccepted",
+			newNtfn: func() (interface{}, error) {
+				return btcjson.NewCmd("relevanttxaccepted", "001122")
+			},
+			staticNtfn: func() interface{} {
+				return btcjson.NewRelevantTxAcceptedNtfn("001122")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"relevanttxaccepted","params":["001122"],"id":null}`,
+			unmarshalled: &btcjson.RelevantTxAcceptedNtfn{
+				Transaction: "001122",
 			},
 		},
 	}

--- a/btcjson/chainsvrwsresults.go
+++ b/btcjson/chainsvrwsresults.go
@@ -1,4 +1,5 @@
-// Copyright (c) 2015 The btcsuite developers
+// Copyright (c) 2015-2017 The btcsuite developers
+// Copyright (c) 2015-2017 The Decred developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -7,4 +8,14 @@ package btcjson
 // SessionResult models the data from the session command.
 type SessionResult struct {
 	SessionID uint64 `json:"sessionid"`
+}
+
+// RescannedBlock contains the hash and all discovered transactions of a single
+// rescanned block.
+//
+// NOTE: This is a btcsuite extension ported from
+// github.com/decred/dcrd/dcrjson.
+type RescannedBlock struct {
+	Hash         string   `json:"hash"`
+	Transactions []string `json:"transactions"`
 }

--- a/btcjson/chainsvrwsresults_test.go
+++ b/btcjson/chainsvrwsresults_test.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2017 The btcsuite developers
+// Copyright (c) 2017 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package btcjson_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcjson"
+)
+
+// TestChainSvrWsResults ensures any results that have custom marshalling
+// work as inteded.
+func TestChainSvrWsResults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		result   interface{}
+		expected string
+	}{
+		{
+			name: "RescannedBlock",
+			result: &btcjson.RescannedBlock{
+				Hash:         "blockhash",
+				Transactions: []string{"serializedtx"},
+			},
+			expected: `{"hash":"blockhash","transactions":["serializedtx"]}`,
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		marshalled, err := json.Marshal(test.result)
+		if err != nil {
+			t.Errorf("Test #%d (%s) unexpected error: %v", i,
+				test.name, err)
+			continue
+		}
+		if string(marshalled) != test.expected {
+			t.Errorf("Test #%d (%s) unexpected marhsalled data - "+
+				"got %s, want %s", i, test.name, marshalled,
+				test.expected)
+			continue
+		}
+	}
+}

--- a/docs/json_rpc_api.md
+++ b/docs/json_rpc_api.md
@@ -688,16 +688,17 @@ user.  Click the method name for further details such as parameter and return in
 |#|Method|Description|Notifications|
 |---|------|-----------|-------------|
 |1|[authenticate](#authenticate)|Authenticate the connection against the username and passphrase configured for the RPC server.<br /><font color="orange">NOTE: This is only required if an HTTP Authorization header is not being used.</font>|None|
-|2|[notifyblocks](#notifyblocks)|Send notifications when a block is connected or disconnected from the best chain.|[blockconnected](#blockconnected) and [blockdisconnected](#blockdisconnected)|
+|2|[notifyblocks](#notifyblocks)|Send notifications when a block is connected or disconnected from the best chain.|[blockconnected](#blockconnected), [blockdisconnected](#blockdisconnected), [filteredblockconnected](#filteredblockconnected), and [filteredblockdisconnected](#filteredblockdisconnected)|
 |3|[stopnotifyblocks](#stopnotifyblocks)|Cancel registered notifications for whenever a block is connected or disconnected from the main (best) chain. |None|
-|4|[notifyreceived](#notifyreceived)|Send notifications when a txout spends to an address.|[recvtx](#recvtx) and [redeemingtx](#redeemingtx)|
-|5|[stopnotifyreceived](#stopnotifyreceived)|Cancel registered notifications for when a txout spends to any of the passed addresses.|None|
-|6|[notifyspent](#notifyspent)|Send notification when a txout is spent.|[redeemingtx](#redeemingtx)|
-|7|[stopnotifyspent](#stopnotifyspent)|Cancel registered spending notifications for each passed outpoint.|None|
+|4|[notifyreceived](#notifyreceived)|*DEPRECATED, for similar functionality see [loadtxfilter](#loadtxfilter)*<br />Send notifications when a txout spends to an address.|[recvtx](#recvtx) and [redeemingtx](#redeemingtx)|
+|5|[stopnotifyreceived](#stopnotifyreceived)|*DEPRECATED, for similar functionality see [loadtxfilter](#loadtxfilter)*<br />Cancel registered notifications for when a txout spends to any of the passed addresses.|None|
+|6|[notifyspent](#notifyspent)|*DEPRECATED, for similar functionality see [loadtxfilter](#loadtxfilter)*<br />Send notification when a txout is spent.|[redeemingtx](#redeemingtx)|
+|7|[stopnotifyspent](#stopnotifyspent)|*DEPRECATED, for similar functionality see [loadtxfilter](#loadtxfilter)*<br />Cancel registered spending notifications for each passed outpoint.|None|
 |8|[rescan](#rescan)|Rescan block chain for transactions to addresses and spent transaction outpoints.|[recvtx](#recvtx), [redeemingtx](#redeemingtx), [rescanprogress](#rescanprogress), and [rescanfinished](#rescanfinished) |
 |9|[notifynewtransactions](#notifynewtransactions)|Send notifications for all new transactions as they are accepted into the mempool.|[txaccepted](#txaccepted) or [txacceptedverbose](#txacceptedverbose)|
 |10|[stopnotifynewtransactions](#stopnotifynewtransactions)|Stop sending either a txaccepted or a txacceptedverbose notification when a new transaction is accepted into the mempool.|None|
 |11|[session](#session)|Return details regarding a websocket client's current connection.|None|
+|12|[loadtxfilter](#loadtxfilter)|Load, add to, or reload a websocket client's transaction filter for mempool transactions, new blocks and rescanblocks.|[relevanttxaccepted](#relevanttxaccepted)|
 
 <a name="WSExtMethodDetails" />
 **7.2 Method Details**<br />
@@ -719,7 +720,7 @@ user.  Click the method name for further details such as parameter and return in
 |   |   |
 |---|---|
 |Method|notifyblocks|
-|Notifications|[blockconnected](#blockconnected) and [blockdisconnected](#blockdisconnected)|
+|Notifications|[blockconnected](#blockconnected), [blockdisconnected](#blockdisconnected), [filteredblockconnected](#filteredblockconnected), and [filteredblockdisconnected](#filteredblockdisconnected)|
 |Parameters|None|
 |Description|Request notifications for whenever a block is connected or disconnected from the main (best) chain.<br />NOTE: If a client subscribes to both block and transaction (recvtx and redeemingtx) notifications, the blockconnected notification will be sent after all transaction notifications have been sent.  This allows clients to know when all relevant transactions for a block have been received.|
 |Returns|Nothing|
@@ -746,7 +747,7 @@ user.  Click the method name for further details such as parameter and return in
 |Method|notifyreceived|
 |Notifications|[recvtx](#recvtx) and [redeemingtx](#redeemingtx)|
 |Parameters|1. Addresses (JSON array, required)<br />&nbsp;`[ (json array of strings)`<br />&nbsp;&nbsp;`"bitcoinaddress", (string) the bitcoin address`<br />&nbsp;&nbsp;`...`<br />&nbsp;`]`|
-|Description|Send a recvtx notification when a transaction added to mempool or appears in a newly-attached block contains a txout pkScript sending to any of the passed addresses.  Matching outpoints are automatically registered for redeemingtx notifications.|
+|Description|*DEPRECATED, for similar functionality see [loadtxfilter](#loadtxfilter)*<br />Send a recvtx notification when a transaction added to mempool or appears in a newly-attached block contains a txout pkScript sending to any of the passed addresses.  Matching outpoints are automatically registered for redeemingtx notifications.|
 |Returns|Nothing|
 [Return to Overview](#WSExtMethodOverview)<br />
 
@@ -759,7 +760,7 @@ user.  Click the method name for further details such as parameter and return in
 |Method|stopnotifyreceived|
 |Notifications|None|
 |Parameters|1. Addresses (JSON array, required)<br />&nbsp;`[ (json array of strings)`<br />&nbsp;&nbsp;`"bitcoinaddress", (string) the bitcoin address`<br />&nbsp;&nbsp;`...`<br />&nbsp;`]`|
-|Description|Cancel registered receive notifications for each passed address.|
+|Description|*DEPRECATED, for similar functionality see [loadtxfilter](#loadtxfilter)*<br />Cancel registered receive notifications for each passed address.|
 |Returns|Nothing|
 [Return to Overview](#WSExtMethodOverview)<br />
 
@@ -772,7 +773,7 @@ user.  Click the method name for further details such as parameter and return in
 |Method|notifyspent|
 |Notifications|[redeemingtx](#redeemingtx)|
 |Parameters|1. Outpoints (JSON array, required)<br />&nbsp;`[ (JSON array)`<br />&nbsp;&nbsp;`{ (JSON object)`<br />&nbsp;&nbsp;&nbsp;`"hash":"data", (string) the hex-encoded bytes of the outpoint hash`<br />&nbsp;&nbsp;&nbsp;`"index":n (numeric) the txout index of the outpoint`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />&nbsp;`]`|
-|Description|Send a redeemingtx notification when a transaction spending an outpoint appears in mempool (if relayed to this btcd instance) and when such a transaction first appears in a newly-attached block.|
+|Description|*DEPRECATED, for similar functionality see [loadtxfilter](#loadtxfilter)*<br />Send a redeemingtx notification when a transaction spending an outpoint appears in mempool (if relayed to this btcd instance) and when such a transaction first appears in a newly-attached block.|
 |Returns|Nothing|
 [Return to Overview](#WSExtMethodOverview)<br />
 
@@ -785,7 +786,7 @@ user.  Click the method name for further details such as parameter and return in
 |Method|stopnotifyspent|
 |Notifications|None|
 |Parameters|1. Outpoints (JSON array, required)<br />&nbsp;`[ (JSON array)`<br />&nbsp;&nbsp;`{ (JSON object)`<br />&nbsp;&nbsp;&nbsp;`"hash":"data", (string) the hex-encoded bytes of the outpoint hash`<br />&nbsp;&nbsp;&nbsp;`"index":n (numeric) the txout index of the outpoint`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />&nbsp;`]`|
-|Description|Cancel registered spending notifications for each passed outpoint.|
+|Description|*DEPRECATED, for similar functionality see [loadtxfilter](#loadtxfilter)*<br />Cancel registered spending notifications for each passed outpoint.|
 |Returns|Nothing|
 [Return to Overview](#WSExtMethodOverview)<br />
 
@@ -842,6 +843,19 @@ user.  Click the method name for further details such as parameter and return in
 |Example Return|`{`<br />&nbsp;&nbsp;`"sessionid": 67089679842`<br />`}`|
 [Return to Overview](#WSExtMethodOverview)<br />
 
+***
+
+<a name="loadtxfilter"/>
+
+|   |   |
+|---|---|
+|Method|loadtxfilter|
+|Notifications|[relevanttxaccepted](#relevanttxaccepted)|
+|Parameters|1. Reload (boolean, required) - Load a new filter instead of adding data to an existing one<br />2. Addresses (JSON array, required) - Array of addresses to add to the transaction filter<br />3. Outpoints (JSON array, required) - Array of outpoints to add to the transaction filter|
+|Description|Load, add to, or reload a websocket client's transaction filter for mempool transactions, new blocks and [rescanblocks](#rescanblocks).|
+|Returns|Nothing|
+[Return to Overview](#WSExtMethodOverview)<br />
+
 
 <a name="Notifications" />
 ### 8. Notifications (Websocket-specific)
@@ -855,14 +869,17 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 
 |#|Method|Description|Request|
 |---|------|-----------|-------|
-|1|[blockconnected](#blockconnected)|Block connected to the main chain.|[notifyblocks](#notifyblocks)|
-|2|[blockdisconnected](#blockdisconnected)|Block disconnected from the main chain.|[notifyblocks](#notifyblocks)|
-|3|[recvtx](#recvtx)|Processed a transaction output spending to a wallet address.|[notifyreceived](#notifyreceived) and [rescan](#rescan)|
-|4|[redeemingtx](#redeemingtx)|Processed a transaction that spends a registered outpoint.|[notifyspent](#notifyspent) and [rescan](#rescan)|
+|1|[blockconnected](#blockconnected)|*DEPRECATED, for similar functionality see [filteredblockconnected](#filteredblockconnected)*<br />Block connected to the main chain.|[notifyblocks](#notifyblocks)|
+|2|[blockdisconnected](#blockdisconnected)|*DEPRECATED, for similar functionality see [filteredblockdisconnected](#filteredblockdisconnected)*<br />Block disconnected from the main chain.|[notifyblocks](#notifyblocks)|
+|3|[recvtx](#recvtx)|*DEPRECATED, for similar functionality see [relevanttxaccepted](#relevanttxaccepted) and [filteredblockconnected](#filteredblockconnected)*<br />Processed a transaction output spending to a wallet address.|[notifyreceived](#notifyreceived) and [rescan](#rescan)|
+|4|[redeemingtx](#redeemingtx)|*DEPRECATED, for similar functionality see [relevanttxaccepted](#relevanttxaccepted) and [filteredblockconnected](#filteredblockconnected)*<br />Processed a transaction that spends a registered outpoint.|[notifyspent](#notifyspent) and [rescan](#rescan)|
 |5|[txaccepted](#txaccepted)|Received a new transaction after requesting simple notifications of all new transactions accepted into the mempool.|[notifynewtransactions](#notifynewtransactions)|
 |6|[txacceptedverbose](#txacceptedverbose)|Received a new transaction after requesting verbose notifications of all new transactions accepted into the mempool.|[notifynewtransactions](#notifynewtransactions)|
 |7|[rescanprogress](#rescanprogress)|A rescan operation that is underway has made progress.|[rescan](#rescan)|
 |8|[rescanfinished](#rescanfinished)|A rescan operation has completed.|[rescan](#rescan)|
+|9|[relevanttxaccepted](#relevanttxaccepted)|A transaction matching the tx filter has been accepted into the mempool.|[loadtxfilter](#loadtxfilter)|
+|10|[filteredblockconnected](#filteredblockconnected)|Block connected to the main chain; contains any transactions that match the client's tx filter.|[notifyblocks](#notifyblocks), [loadtxfilter](#loadtxfilter)|
+|11|[filteredblockdisconnected](#filteredblockdisconnected)|Block disconnected from the main chain.|[notifyblocks](#notifyblocks), [loadtxfilter](#loadtxfilter)|
 
 <a name="NotificationDetails" />
 **8.2 Notification Details**<br />
@@ -874,7 +891,7 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |Method|blockconnected|
 |Request|[notifyblocks](#notifyblocks)|
 |Parameters|1. BlockHash (string) hex-encoded bytes of the attached block hash<br />2. BlockHeight (numeric) height of the attached block<br />3. BlockTime (numeric) unix time of the attached block|
-|Description|Notifies when a block has been added to the main chain.  Notification is sent to all connected clients.|
+|Description|*DEPRECATED, for similar functionality see [filteredblockconnected](#filteredblockconnected)*<br />Notifies when a block has been added to the main chain.  Notification is sent to all connected clients.|
 |Example|Example blockconnected notification for mainnet block 280330 (newlines added for readability):<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "blockconnected",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"000000000000000004cbdfe387f4df44b914e464ca79838a8ab777b3214dbffd",`<br />&nbsp;&nbsp;&nbsp;`280330,`<br />&nbsp;&nbsp;&nbsp;`1389636265`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
 [Return to Overview](#NotificationOverview)<br />
 
@@ -887,7 +904,7 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |Method|blockdisconnected|
 |Request|[notifyblocks](#notifyblocks)|
 |Parameters|1. BlockHash (string) hex-encoded bytes of the disconnected block hash<br />2. BlockHeight (numeric) height of the disconnected block<br />3. BlockTime (numeric) unix time of the disconnected block|
-|Description|Notifies when a block has been removed from the main chain.  Notification is sent to all connected clients.|
+|Description|*DEPRECATED, for similar functionality see [filteredblockdisconnected](#filteredblockdisconnected)*<br />Notifies when a block has been removed from the main chain.  Notification is sent to all connected clients.|
 |Example|Example blockdisconnected notification for mainnet block 280330 (newlines added for readability):<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "blockdisconnected",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"000000000000000004cbdfe387f4df44b914e464ca79838a8ab777b3214dbffd",`<br />&nbsp;&nbsp;&nbsp;`280330,`<br />&nbsp;&nbsp;&nbsp;`1389636265`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
 [Return to Overview](#NotificationOverview)<br />
 
@@ -900,7 +917,7 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |Method|recvtx|
 |Request|[rescan](#rescan) or [notifyreceived](#notifyreceived)|
 |Parameters|1. Transaction (string) full transaction encoded as a hex string<br />2. Block details (object, optional) details about a block and the index of the transaction within a block, if the transaction is mined|
-|Description|Notifies a client when a transaction is processed that contains at least a single output with a pkScript sending to a requested address.  If multiple outputs send to requested addresses, a single notification is sent.  If a mempool (unmined) transaction is processed, the block details object (second parameter) is excluded.|
+|Description|*DEPRECATED, for similar functionality see [relevanttxaccepted](#relevanttxaccepted) and [filteredblockconnected](#filteredblockconnected)*<br />Notifies a client when a transaction is processed that contains at least a single output with a pkScript sending to a requested address.  If multiple outputs send to requested addresses, a single notification is sent.  If a mempool (unmined) transaction is processed, the block details object (second parameter) is excluded.|
 |Example|Example recvtx notification for mainnet transaction 61d3696de4c888730cbe06b0ad8ecb6d72d6108e893895aa9bc067bd7eba3fad when processed by mempool (newlines added for readability):<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "recvtx",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"010000000114d9ff358894c486b4ae11c2a8cf7851b1df64c53d2e511278eff17c22fb737300000000..."`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`<br />The recvtx notification for the same txout, after the transaction was mined into block 276425:<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "recvtx",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"010000000114d9ff358894c486b4ae11c2a8cf7851b1df64c53d2e511278eff17c22fb737300000000...",`<br />&nbsp;&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"height": 276425,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"hash": "000000000000000325474bb799b9e591f965ca4461b72cb7012b808db92bb2fc",`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"index": 684,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"time": 1387737310`<br />&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
 [Return to Overview](#NotificationOverview)<br />
 
@@ -913,7 +930,7 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |Method|redeemingtx|
 |Requests|[notifyspent](#notifyspent) and [rescan](#rescan)|
 |Parameters|1. Transaction (string) full transaction encoded as a hex string<br />2. Block details (object, optional) details about a block and the index of the transaction within a block, if the transaction is mined|
-|Description|Notifies a client when an registered outpoint is spent by a transaction accepted to mempool and/or mined into a block.|
+|Description|*DEPRECATED, for similar functionality see [relevanttxaccepted](#relevanttxaccepted) and [filteredblockconnected](#filteredblockconnected)*<br />Notifies a client when an registered outpoint is spent by a transaction accepted to mempool and/or mined into a block.|
 |Example|Example redeemingtx notification for mainnet outpoint 61d3696de4c888730cbe06b0ad8ecb6d72d6108e893895aa9bc067bd7eba3fad:0 after being spent by transaction 4ad0c16ac973ff675dec1f3e5f1273f1c45be2a63554343f21b70240a1e43ece (newlines added for readability):<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "redeemingtx",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"0100000003ad3fba7ebd67c09baa9538898e10d6726dcb8eadb006be0c7388c8e46d69d3610000000..."`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`<br />The redeemingtx notification for the same txout, after the spending transaction was mined into block 279143:<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "recvtx",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"0100000003ad3fba7ebd67c09baa9538898e10d6726dcb8eadb006be0c7388c8e46d69d3610000000...",`<br />&nbsp;&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"height": 279143,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"hash": "00000000000000017188b968a371bab95aa43522665353b646e41865abae02a4",`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"index": 6,`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"time": 1389115004`<br />&nbsp;&nbsp;&nbsp;`}`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
 [Return to Overview](#NotificationOverview)<br />
 
@@ -967,6 +984,44 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |Parameters|1. Hash (string) hash of the last rescanned block<br />2. Height (numeric) height of the last rescanned block<br />3. Time (numeric) UNIX time of the last rescanned block |
 |Description|Notifies a client that the [rescan](#rescan) has completed and no further notifications will be sent.|
 |Example|`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "rescanfinished",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"0000000000000ea86b49e11843b2ad937ac89ae74a963c7edd36e0147079b89d",`<br />&nbsp;&nbsp;&nbsp;`127213,`<br />&nbsp;&nbsp;&nbsp;`1306533807`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
+[Return to Overview](#NotificationOverview)<br />
+
+***
+
+<a name="relevanttxaccepted"/>
+
+|   |   |
+|---|---|
+|Method|relevanttxaccepted|
+|Request|[loadtxfilter](#loadtxfilter)|
+|Parameters|1. Transaction (string) hex-encoded serialized transaction matching the client's filter loaded ith [loadtxfilter](#loadtxfilter)|
+|Description|Notifies a client that a transaction matching the client's tx filter has been accepted into he mempool.|
+|Example|Example `relevanttxaccepted` notification (newlines added for readability):<br />`{`<br >&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "relevanttxaccepted",`<br />&nbsp;`"params": [`<br >&nbsp;&nbsp;`"01000000014221abdcca25c8a3b0c044034875dece048c77d567a806f0c2e7e0f5e25a8f100..."`<br >&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
+
+***
+
+<a name="filteredblockconnected"/>
+
+|   |   |
+|---|---|
+|Method|filteredblockconnected|
+|Request|[notifyblocks](#notifyblocks), [loadtxfilter](#loadtxfilter)|
+|Parameters|1. BlockHeight (numeric) height of the attached block<br />2. Header (string) hex-encoded serialized header of the attached block<br />3. Transactions (JSON array) hex-encoded serialized transactions matching the filter for the client connection loaded with [loadtxfilter](#loadtxfilter)|
+|Description|Notifies when a block has been added to the main chain.  Notification is sent to all connected clients.|
+|Example|Example filteredblockconnected notification for mainnet block 280330 (newlines added for readability):<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "filteredblockconnected",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`280330,`<br />&nbsp;&nbsp;&nbsp;`"0200000052d1e8813f697293e41942aa230e7e4fcc44832d78a1372202000000000000006aa...",`<br />&nbsp;&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"01000000014221abdcca25c8a3b0c044034875dece048c77d567a806f0c2e7e0f5e25a8f100..."`<br />&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
+[Return to Overview](#NotificationOverview)<br />
+
+***
+
+<a name="filteredblockdisconnected"/>
+
+|   |   |
+|---|---|
+|Method|filteredblockdisconnected|
+|Request|[notifyblocks](#notifyblocks), [loadtxfilter](#loadtxfilter)|
+|Parameters|1. BlockHeight (numeric) height of the disconnected block<br />2. Header (string) hex-encoded serialized header of the disconnected block|
+|Description|Notifies when a block has been removed from the main chain.  Notification is sent to all connected clients.|
+|Example|Example blockdisconnected notification for mainnet block 280330 (newlines added for readability):<br />`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "blockdisconnected",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`280330,`<br />&nbsp;&nbsp;&nbsp;`"0200000052d1e8813f697293e41942aa230e7e4fcc44832d78a1372202000000000000006aa..."`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
 [Return to Overview](#NotificationOverview)<br />
 
 

--- a/docs/json_rpc_api.md
+++ b/docs/json_rpc_api.md
@@ -694,11 +694,12 @@ user.  Click the method name for further details such as parameter and return in
 |5|[stopnotifyreceived](#stopnotifyreceived)|*DEPRECATED, for similar functionality see [loadtxfilter](#loadtxfilter)*<br />Cancel registered notifications for when a txout spends to any of the passed addresses.|None|
 |6|[notifyspent](#notifyspent)|*DEPRECATED, for similar functionality see [loadtxfilter](#loadtxfilter)*<br />Send notification when a txout is spent.|[redeemingtx](#redeemingtx)|
 |7|[stopnotifyspent](#stopnotifyspent)|*DEPRECATED, for similar functionality see [loadtxfilter](#loadtxfilter)*<br />Cancel registered spending notifications for each passed outpoint.|None|
-|8|[rescan](#rescan)|Rescan block chain for transactions to addresses and spent transaction outpoints.|[recvtx](#recvtx), [redeemingtx](#redeemingtx), [rescanprogress](#rescanprogress), and [rescanfinished](#rescanfinished) |
+|8|[rescan](#rescan)|*DEPRECATED, for similar functionality see [rescanblocks](#rescanblocks)*<br />Rescan block chain for transactions to addresses and spent transaction outpoints.|[recvtx](#recvtx), [redeemingtx](#redeemingtx), [rescanprogress](#rescanprogress), and [rescanfinished](#rescanfinished) |
 |9|[notifynewtransactions](#notifynewtransactions)|Send notifications for all new transactions as they are accepted into the mempool.|[txaccepted](#txaccepted) or [txacceptedverbose](#txacceptedverbose)|
 |10|[stopnotifynewtransactions](#stopnotifynewtransactions)|Stop sending either a txaccepted or a txacceptedverbose notification when a new transaction is accepted into the mempool.|None|
 |11|[session](#session)|Return details regarding a websocket client's current connection.|None|
 |12|[loadtxfilter](#loadtxfilter)|Load, add to, or reload a websocket client's transaction filter for mempool transactions, new blocks and rescanblocks.|[relevanttxaccepted](#relevanttxaccepted)|
+|13|[rescanblocks](#rescanblocks)|Rescan blocks for transactions matching the loaded transaction filter.|None|
 
 <a name="WSExtMethodDetails" />
 **7.2 Method Details**<br />
@@ -799,7 +800,7 @@ user.  Click the method name for further details such as parameter and return in
 |Method|rescan|
 |Notifications|[recvtx](#recvtx), [redeemingtx](#redeemingtx), [rescanprogress](#rescanprogress), and [rescanfinished](#rescanfinished)|
 |Parameters|1. BeginBlock (string, required) block hash to begin rescanning from<br />2. Addresses (JSON array, required)<br />&nbsp;`[ (json array of strings)`<br />&nbsp;&nbsp;`"bitcoinaddress", (string) the bitcoin address`<br />&nbsp;&nbsp;`...` <br />&nbsp;`]`<br />3. Outpoints (JSON array, required)<br />&nbsp;`[ (JSON array)`<br />&nbsp;&nbsp;`{ (JSON object)`<br />&nbsp;&nbsp;&nbsp;`"hash":"data", (string) the hex-encoded bytes of the outpoint hash`<br />&nbsp;&nbsp;&nbsp;`"index":n (numeric) the txout index of the outpoint`<br />&nbsp;&nbsp;`},`<br />&nbsp;&nbsp;`...`<br />&nbsp;`]`<br />4. EndBlock (string, optional) hash of final block to rescan|
-|Description|Rescan block chain for transactions to addresses, starting at block BeginBlock and ending at EndBlock.  The current known UTXO set for all passed addresses at height BeginBlock should included in the Outpoints argument.  If EndBlock is omitted, the rescan continues through the best block in the main chain.  Additionally, if no EndBlock is provided, the client is automatically registered for transaction notifications for all rescanned addresses and the final UTXO set.  Rescan results are sent as recvtx and redeemingtx notifications.  This call returns once the rescan completes.|
+|Description|*DEPRECATED, for similar functionality see [rescanblocks](#rescanblocks)*<br />Rescan block chain for transactions to addresses, starting at block BeginBlock and ending at EndBlock.  The current known UTXO set for all passed addresses at height BeginBlock should included in the Outpoints argument.  If EndBlock is omitted, the rescan continues through the best block in the main chain.  Additionally, if no EndBlock is provided, the client is automatically registered for transaction notifications for all rescanned addresses and the final UTXO set.  Rescan results are sent as recvtx and redeemingtx notifications.  This call returns once the rescan completes.|
 |Returns|Nothing|
 [Return to Overview](#WSExtMethodOverview)<br />
 
@@ -856,6 +857,19 @@ user.  Click the method name for further details such as parameter and return in
 |Returns|Nothing|
 [Return to Overview](#WSExtMethodOverview)<br />
 
+***
+
+<a name="rescanblocks"/>
+
+|   |   |
+|---|---|
+|Method|rescanblocks|
+|Notifications|None|
+|Parameters|1. Blockhashes (JSON array, required) - List of hashes to rescan.  Each next block must be a child of the previous.|
+|Description|Rescan blocks for transactions matching the loaded transaction filter.|
+|Returns|`[ (JSON array)`<br />&nbsp;&nbsp;`{ (JSON object)`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"hash": "data", (string) Hash of the matching block.`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"transactions": [ (JSON array) List of matching transactions, serialized and hex-encoded.`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"serializedtx" (string) Serialized and hex-encoded transaction.`<br />&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`}`<br />`]`|
+|Example Return|`[`<br />&nbsp;&nbsp;`{`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"hash": "0000002099417930b2ae09feda10e38b58c0f6bb44b4d60fa33f0e000000000000000000d53...",`<br />&nbsp;&nbsp;&nbsp;&nbsp;`"transactions": [`<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`"493046022100cb42f8df44eca83dd0a727988dcde9384953e830b1f8004d57485e2ede1b9c8..."`<br />&nbsp;&nbsp;&nbsp;&nbsp;`]`<br />&nbsp;&nbsp;`}`<br />`]`|
+
 
 <a name="Notifications" />
 ### 8. Notifications (Websocket-specific)
@@ -875,8 +889,8 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |4|[redeemingtx](#redeemingtx)|*DEPRECATED, for similar functionality see [relevanttxaccepted](#relevanttxaccepted) and [filteredblockconnected](#filteredblockconnected)*<br />Processed a transaction that spends a registered outpoint.|[notifyspent](#notifyspent) and [rescan](#rescan)|
 |5|[txaccepted](#txaccepted)|Received a new transaction after requesting simple notifications of all new transactions accepted into the mempool.|[notifynewtransactions](#notifynewtransactions)|
 |6|[txacceptedverbose](#txacceptedverbose)|Received a new transaction after requesting verbose notifications of all new transactions accepted into the mempool.|[notifynewtransactions](#notifynewtransactions)|
-|7|[rescanprogress](#rescanprogress)|A rescan operation that is underway has made progress.|[rescan](#rescan)|
-|8|[rescanfinished](#rescanfinished)|A rescan operation has completed.|[rescan](#rescan)|
+|7|[rescanprogress](#rescanprogress)|*DEPRECATED, notifications not used by [rescanblocks](#rescanblocks)*<br />A rescan operation that is underway has made progress.|[rescan](#rescan)|
+|8|[rescanfinished](#rescanfinished)|*DEPRECATED, notifications not used by [rescanblocks](#rescanblocks)*<br />A rescan operation has completed.|[rescan](#rescan)|
 |9|[relevanttxaccepted](#relevanttxaccepted)|A transaction matching the tx filter has been accepted into the mempool.|[loadtxfilter](#loadtxfilter)|
 |10|[filteredblockconnected](#filteredblockconnected)|Block connected to the main chain; contains any transactions that match the client's tx filter.|[notifyblocks](#notifyblocks), [loadtxfilter](#loadtxfilter)|
 |11|[filteredblockdisconnected](#filteredblockdisconnected)|Block disconnected from the main chain.|[notifyblocks](#notifyblocks), [loadtxfilter](#loadtxfilter)|
@@ -969,7 +983,7 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |Method|rescanprogress|
 |Request|[rescan](#rescan)|
 |Parameters|1. Hash (string) hash of the last processed block<br />2. Height (numeric) height of the last processed block<br />3. Time (numeric) UNIX time of the last processed block|
-|Description|Notifies a client with the current progress at periodic intervals when a long-running [rescan](#rescan) is underway.|
+|Description|*DEPRECATED, notifications not used by [rescanblocks](#rescanblocks)*<br />Notifies a client with the current progress at periodic intervals when a long-running [rescan](#rescan) is underway.|
 |Example|`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "rescanprogress",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"0000000000000ea86b49e11843b2ad937ac89ae74a963c7edd36e0147079b89d",`<br />&nbsp;&nbsp;&nbsp;`127213,`<br />&nbsp;&nbsp;&nbsp;`1306533807`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
 [Return to Overview](#NotificationOverview)<br />
 
@@ -982,7 +996,7 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |Method|rescanfinished|
 |Request|[rescan](#rescan)|
 |Parameters|1. Hash (string) hash of the last rescanned block<br />2. Height (numeric) height of the last rescanned block<br />3. Time (numeric) UNIX time of the last rescanned block |
-|Description|Notifies a client that the [rescan](#rescan) has completed and no further notifications will be sent.|
+|Description|*DEPRECATED, notifications not used by [rescanblocks](#rescanblocks)*<br />Notifies a client that the [rescan](#rescan) has completed and no further notifications will be sent.|
 |Example|`{`<br />&nbsp;`"jsonrpc": "1.0",`<br />&nbsp;`"method": "rescanfinished",`<br />&nbsp;`"params":`<br />&nbsp;&nbsp;`[`<br />&nbsp;&nbsp;&nbsp;`"0000000000000ea86b49e11843b2ad937ac89ae74a963c7edd36e0147079b89d",`<br />&nbsp;&nbsp;&nbsp;`127213,`<br />&nbsp;&nbsp;&nbsp;`1306533807`<br />&nbsp;&nbsp;`],`<br />&nbsp;`"id": null`<br />`}`|
 [Return to Overview](#NotificationOverview)<br />
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -44,9 +44,9 @@ import (
 
 // API version constants
 const (
-	jsonrpcSemverString = "1.1.0"
+	jsonrpcSemverString = "1.2.0"
 	jsonrpcSemverMajor  = 1
-	jsonrpcSemverMinor  = 1
+	jsonrpcSemverMinor  = 2
 	jsonrpcSemverPatch  = 0
 )
 
@@ -232,6 +232,7 @@ var rpcUnimplemented = map[string]struct{}{
 // Commands that are available to a limited user
 var rpcLimited = map[string]struct{}{
 	// Websockets commands
+	"loadtxfilter":          {},
 	"notifyblocks":          {},
 	"notifynewtransactions": {},
 	"notifyreceived":        {},

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -44,9 +44,9 @@ import (
 
 // API version constants
 const (
-	jsonrpcSemverString = "1.2.0"
+	jsonrpcSemverString = "1.3.0"
 	jsonrpcSemverMajor  = 1
-	jsonrpcSemverMinor  = 2
+	jsonrpcSemverMinor  = 3
 	jsonrpcSemverPatch  = 0
 )
 
@@ -238,6 +238,7 @@ var rpcLimited = map[string]struct{}{
 	"notifyreceived":        {},
 	"notifyspent":           {},
 	"rescan":                {},
+	"rescanblocks":          {},
 	"session":               {},
 
 	// Websockets AND HTTP/S commands

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -606,6 +606,15 @@ var helpDescsEnUS = map[string]string{
 	"rescan-outpoints":  "List of transaction outpoints to include in the rescan",
 	"rescan-endblock":   "Hash of final block to rescan",
 
+	// RescanBlocks help.
+	"rescanblocks--synopsis":   "Rescan blocks for transactions matching the loaded transaction filter.",
+	"rescanblocks-blockhashes": "List of hashes to rescan.  Each next block must be a child of the previous.",
+	"rescanblocks--result0":    "List of matching blocks.",
+
+	// RescannedBlock help.
+	"rescannedblock-hash":         "Hash of the matching block.",
+	"rescannedblock-transactions": "List of matching transactions, serialized and hex-encoded.",
+
 	// Version help.
 	"version--synopsis":       "Returns the JSON-RPC API version (semver)",
 	"version--result0--desc":  "Version objects keyed by the program or API name",
@@ -680,6 +689,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"notifyspent":               nil,
 	"stopnotifyspent":           nil,
 	"rescan":                    nil,
+	"rescanblocks":              {(*[]btcjson.RescannedBlock)(nil)},
 }
 
 // helpCacher provides a concurrent safe type that provides help and usage for

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -590,6 +590,12 @@ var helpDescsEnUS = map[string]string{
 	"stopnotifyspent--synopsis": "Cancel registered spending notifications for each passed outpoint.",
 	"stopnotifyspent-outpoints": "List of transaction outpoints to stop monitoring.",
 
+	// LoadTxFilterCmd help.
+	"loadtxfilter--synopsis": "Load, add to, or reload a websocket client's transaction filter for mempool transactions, new blocks and rescanblocks.",
+	"loadtxfilter-reload":    "Load a new filter instead of adding data to an existing one",
+	"loadtxfilter-addresses": "Array of addresses to add to the transaction filter",
+	"loadtxfilter-outpoints": "Array of outpoints to add to the transaction filter",
+
 	// Rescan help.
 	"rescan--synopsis": "Rescan block chain for transactions to addresses.\n" +
 		"When the endblock parameter is omitted, the rescan continues through the best block in the main chain.\n" +
@@ -663,6 +669,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"version":               {(*map[string]btcjson.VersionResult)(nil)},
 
 	// Websocket commands.
+	"loadtxfilter":              nil,
 	"session":                   {(*btcjson.SessionResult)(nil)},
 	"notifyblocks":              nil,
 	"stopnotifyblocks":          nil,


### PR DESCRIPTION
This PR adds backported versions of `loadtxfilter` and `rescanblocks` commands from `dcrd` along with new `relevanttxaccepted`, `filteredblockconnected` and `filteredblockdisconnected` notifications which include additional information including the full block header and serialized transactions that match the loaded filter for the websocket client.

This is a complete replacement for old spend and receive transaction notification system which has been marked deprecated and will be removed in a future release.  In particular, the `rescan`, `notifyreceived`, `stopnotifyreceived`, `notifyspent`, and `stopnotifyspent` commands and the associated notifications `recvtx`, `redeemingtx`, `rescanprogress`, and `rescanfinished` have been deprecated in favor of the new filter-based approach.  In addition the `blockconnected` and `blockdisconnected` which are sent as a result of `notifyblocks` have been deprecated in favor of the new `filteredblockconnected` and `filteredblockdisconnected` which are now also sent when requesting block notifications via `notifyblocks`.

The theory of the new approach is that a websocket client calls `loadtxfilter` with the addresses and/or outpoints it is interested in along with calling `notifyblocks` to request notifications of block connect and disconnect events.  From that point, the client will receive `filteredblockconnected` and `filteredblockdisconnected` notifications which include the full block header along with the serialized transactions that match the filter (for `filteredblockconnected`).  In addition, any matching transactions that are added to the mempool are notified with the new `relevanttxaccepted` notification which includes the serialized transaction.

Closes #882 
Closes #884