### PR TITLE
build: Exclude .glide from test coverage.

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -46,8 +46,8 @@ echo "mode: count" > profile.cov
 
 # Standard go tooling behavior is to ignore dirs with leading underscores.
 for dir in $(find . -maxdepth 10 -not -path '.' -not -path './.git*' \
-    -not -path '*/_*' -not -path './cmd*' -not -path './release*' \
-    -not -path './vendor*' -type d)
+    -not -path './.glide*' -not -path '*/_*' -not -path './cmd*' \
+    -not -path './release*' -not -path './vendor*' -type d)
 do
 if ls $dir/*.go &> /dev/null; then
   go test -covermode=count -coverprofile=$dir/profile.tmp $dir


### PR DESCRIPTION
The most recent version of glide creates a working directory named `.glide` that includes .go files and thus must be excluded from the find operation that generates merged test coverage of all packages.