### PR TITLE
blockchain: Store side chain blocks in database.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -4,7 +4,10 @@
 
 package blockchain
 
-import "github.com/btcsuite/btcutil"
+import (
+	"github.com/btcsuite/btcd/database"
+	"github.com/btcsuite/btcutil"
+)
 
 // maybeAcceptBlock potentially accepts a block into the block chain and, if
 // accepted, returns whether or not it is on the main chain.  It performs
@@ -42,6 +45,22 @@ func (b *BlockChain) maybeAcceptBlock(block *btcutil.Block, flags BehaviorFlags)
 	// The block must pass all of the validation rules which depend on the
 	// position of the block within the block chain.
 	err = b.checkBlockContext(block, prevNode, flags)
+	if err != nil {
+		return false, err
+	}
+
+	// Insert the block into the database if it's not already there.  Even
+	// though it is possible the block will ultimately fail to connect, it
+	// has already passed all proof-of-work and validity tests which means
+	// it would be prohibitively expensive for an attacker to fill up the
+	// disk with a bunch of blocks that fail to connect.  This is necessary
+	// since it allows block download to be decoupled from the much more
+	// expensive connection logic.  It also has some other nice properties
+	// such as making blocks that never become part of the main chain or
+	// blocks that fail to connect available for further analysis.
+	err = b.db.Update(func(dbTx database.Tx) error {
+		return dbMaybeStoreBlock(dbTx, block)
+	})
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This modifies the `blockchain` code to store all blocks that have passed proof-of-work and contextual validity tests in the database even if they may ultimately fail to connect.

This eliminates the need to store those blocks in memory, allows them to be available as orphans later even if they were never part of the main chain, and helps pave the way toward being able to separate the download logic from the connection logic.