### PR TITLE
blockchain: Use int64 timestamps in block nodes.

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2016 The btcsuite developers
+// Copyright (c) 2015-2017 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -1092,7 +1093,7 @@ func (b *BlockChain) createChainState() error {
 	numTxns := uint64(len(genesisBlock.MsgBlock().Transactions))
 	blockSize := uint64(genesisBlock.MsgBlock().SerializeSize())
 	b.stateSnapshot = newBestState(b.bestNode, blockSize, numTxns, numTxns,
-		b.bestNode.timestamp)
+		time.Unix(b.bestNode.timestamp, 0))
 
 	// Create the initial the database chain state including creating the
 	// necessary index buckets and inserting the genesis block.

--- a/blockchain/internal_test.go
+++ b/blockchain/internal_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2013-2017 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -14,7 +14,6 @@ package blockchain
 
 import (
 	"sort"
-	"time"
 )
 
 // TstSetCoinbaseMaturity makes the ability to set the coinbase maturity
@@ -25,7 +24,7 @@ func (b *BlockChain) TstSetCoinbaseMaturity(maturity uint16) {
 
 // TstTimeSorter makes the internal timeSorter type available to the test
 // package.
-func TstTimeSorter(times []time.Time) sort.Interface {
+func TstTimeSorter(times []int64) sort.Interface {
 	return timeSorter(times)
 }
 

--- a/blockchain/timesorter.go
+++ b/blockchain/timesorter.go
@@ -1,16 +1,12 @@
-// Copyright (c) 2013-2014 The btcsuite developers
+// Copyright (c) 2013-2017 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
 package blockchain
 
-import (
-	"time"
-)
-
 // timeSorter implements sort.Interface to allow a slice of timestamps to
 // be sorted.
-type timeSorter []time.Time
+type timeSorter []int64
 
 // Len returns the number of timestamps in the slice.  It is part of the
 // sort.Interface implementation.
@@ -27,5 +23,5 @@ func (s timeSorter) Swap(i, j int) {
 // Less returns whether the timstamp with index i should sort before the
 // timestamp with index j.  It is part of the sort.Interface implementation.
 func (s timeSorter) Less(i, j int) bool {
-	return s[i].Before(s[j])
+	return s[i] < s[j]
 }

--- a/blockchain/timesorter_test.go
+++ b/blockchain/timesorter_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2014 The btcsuite developers
+// Copyright (c) 2013-2017 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"sort"
 	"testing"
-	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
 )
@@ -16,31 +15,29 @@ import (
 // TestTimeSorter tests the timeSorter implementation.
 func TestTimeSorter(t *testing.T) {
 	tests := []struct {
-		in   []time.Time
-		want []time.Time
+		in   []int64
+		want []int64
 	}{
 		{
-			in: []time.Time{
-				time.Unix(1351228575, 0), // Fri Oct 26 05:16:15 UTC 2012 (Block #205000)
-				time.Unix(1351228575, 1), // Fri Oct 26 05:16:15 UTC 2012 (+1 nanosecond)
-				time.Unix(1348310759, 0), // Sat Sep 22 10:45:59 UTC 2012 (Block #200000)
-				time.Unix(1305758502, 0), // Wed May 18 22:41:42 UTC 2011 (Block #125000)
-				time.Unix(1347777156, 0), // Sun Sep 16 06:32:36 UTC 2012 (Block #199000)
-				time.Unix(1349492104, 0), // Sat Oct  6 02:55:04 UTC 2012 (Block #202000)
+			in: []int64{
+				1351228575, // Fri Oct 26 05:16:15 UTC 2012 (Block #205000)
+				1348310759, // Sat Sep 22 10:45:59 UTC 2012 (Block #200000)
+				1305758502, // Wed May 18 22:41:42 UTC 2011 (Block #125000)
+				1347777156, // Sun Sep 16 06:32:36 UTC 2012 (Block #199000)
+				1349492104, // Sat Oct  6 02:55:04 UTC 2012 (Block #202000)
 			},
-			want: []time.Time{
-				time.Unix(1305758502, 0), // Wed May 18 22:41:42 UTC 2011 (Block #125000)
-				time.Unix(1347777156, 0), // Sun Sep 16 06:32:36 UTC 2012 (Block #199000)
-				time.Unix(1348310759, 0), // Sat Sep 22 10:45:59 UTC 2012 (Block #200000)
-				time.Unix(1349492104, 0), // Sat Oct  6 02:55:04 UTC 2012 (Block #202000)
-				time.Unix(1351228575, 0), // Fri Oct 26 05:16:15 UTC 2012 (Block #205000)
-				time.Unix(1351228575, 1), // Fri Oct 26 05:16:15 UTC 2012 (+1 nanosecond)
+			want: []int64{
+				1305758502, // Wed May 18 22:41:42 UTC 2011 (Block #125000)
+				1347777156, // Sun Sep 16 06:32:36 UTC 2012 (Block #199000)
+				1348310759, // Sat Sep 22 10:45:59 UTC 2012 (Block #200000)
+				1349492104, // Sat Oct  6 02:55:04 UTC 2012 (Block #202000)
+				1351228575, // Fri Oct 26 05:16:15 UTC 2012 (Block #205000)
 			},
 		},
 	}
 
 	for i, test := range tests {
-		result := make([]time.Time, len(test.in))
+		result := make([]int64, len(test.in))
 		copy(result, test.in)
 		sort.Sort(blockchain.TstTimeSorter(result))
 		if !reflect.DeepEqual(result, test.want) {

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2016 The btcsuite developers
+// Copyright (c) 2013-2017 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -1011,7 +1011,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *btcutil.Block, vi
 	// "standard" type.  The rules for this BIP only apply to transactions
 	// after the timestamp defined by txscript.Bip16Activation.  See
 	// https://en.bitcoin.it/wiki/BIP_0016 for more details.
-	enforceBIP0016 := node.timestamp.After(txscript.Bip16Activation)
+	enforceBIP0016 := node.timestamp >= txscript.Bip16Activation.Unix()
 
 	// The number of signature operations must be less than the maximum
 	// allowed per block.  Note that the preliminary sanity checks on a


### PR DESCRIPTION
This modifies the block nodes used in the `blockchain` package for keeping track of the block index to use `int64` for the timestamps instead of `time.Time`.

This is being done because a `time.Time` takes 24 bytes while an `int64` only takes 8 and the plan is to eventually move the entire block index into memory instead of the dynamically-loaded version, so cutting the number of bytes used for the timestamp by a third is highly desirable.

Also, the consensus code requires working with unix-style timestamps anyways, so switching over to them in the block node does not seem unreasonable.

Finally, this does not go so far as to change all of the `time.Time` references, particularly those that are in the public API, so it is purely an internal change.