### PR TITLE
blockchain: Use hash values in structs.

### DIFF
--- a/blockchain/blocklocator.go
+++ b/blockchain/blocklocator.go
@@ -121,7 +121,7 @@ func (bi *blockIndex) blockLocatorFromHash(hash *chainhash.Hash) BlockLocator {
 					iterNode = iterNode.parent
 				}
 				if iterNode != nil && iterNode.height == blockHeight {
-					locator = append(locator, iterNode.hash)
+					locator = append(locator, &iterNode.hash)
 				}
 				continue
 			}
@@ -176,7 +176,7 @@ func (b *BlockChain) BlockLocatorFromHash(hash *chainhash.Hash) BlockLocator {
 func (b *BlockChain) LatestBlockLocator() (BlockLocator, error) {
 	b.chainLock.RLock()
 	b.index.RLock()
-	locator := b.index.blockLocatorFromHash(b.bestNode.hash)
+	locator := b.index.blockLocatorFromHash(&b.bestNode.hash)
 	b.index.RUnlock()
 	b.chainLock.RUnlock()
 	return locator, nil

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1064,7 +1064,7 @@ func deserializeBestChainState(serializedData []byte) (bestChainState, error) {
 func dbPutBestState(dbTx database.Tx, snapshot *BestState, workSum *big.Int) error {
 	// Serialize the current best chain state.
 	serializedData := serializeBestChainState(bestChainState{
-		hash:      *snapshot.Hash,
+		hash:      snapshot.Hash,
 		height:    uint32(snapshot.Height),
 		totalTxns: snapshot.TotalTxns,
 		workSum:   workSum,
@@ -1129,7 +1129,7 @@ func (b *BlockChain) createChainState() error {
 
 		// Add the genesis block hash to height and height to hash
 		// mappings to the index.
-		err = dbPutBlockIndex(dbTx, b.bestNode.hash, b.bestNode.height)
+		err = dbPutBlockIndex(dbTx, &b.bestNode.hash, b.bestNode.height)
 		if err != nil {
 			return err
 		}

--- a/blockchain/fullblocks_test.go
+++ b/blockchain/fullblocks_test.go
@@ -165,7 +165,7 @@ func TestFullBlocks(t *testing.T) {
 
 		// Ensure hash and height match.
 		best := chain.BestSnapshot()
-		if *best.Hash != item.Block.BlockHash() ||
+		if best.Hash != item.Block.BlockHash() ||
 			best.Height != blockHeight {
 
 			t.Fatalf("block %q (hash %s, height %d) should be "+

--- a/blockchain/thresholdstate_test.go
+++ b/blockchain/thresholdstate_test.go
@@ -69,7 +69,7 @@ nextTest:
 			hash[0] = uint8(i + 1)
 
 			// Ensure the hash isn't available in the cache already.
-			_, ok := cache.Lookup(hash)
+			_, ok := cache.Lookup(&hash)
 			if ok {
 				t.Errorf("Lookup (%s): has entry for hash %v",
 					test.name, hash)
@@ -78,8 +78,8 @@ nextTest:
 
 			// Ensure hash that was added to the cache reports it's
 			// available and the state is the expected value.
-			cache.Update(hash, test.state)
-			state, ok := cache.Lookup(hash)
+			cache.Update(&hash, test.state)
+			state, ok := cache.Lookup(&hash)
 			if !ok {
 				t.Errorf("Lookup (%s): missing entry for hash "+
 					"%v", test.name, hash)
@@ -118,7 +118,7 @@ nextTest:
 
 			// Ensure hash is still available in the cache and the
 			// state is the expected value.
-			state, ok = cache.Lookup(hash)
+			state, ok = cache.Lookup(&hash)
 			if !ok {
 				t.Errorf("Lookup (%s): missing entry after "+
 					"flush for hash %v", test.name, hash)
@@ -134,8 +134,8 @@ nextTest:
 			// Ensure adding an existing hash with the same state
 			// doesn't break the existing entry and it is NOT added
 			// to the database updates map.
-			cache.Update(hash, test.state)
-			state, ok = cache.Lookup(hash)
+			cache.Update(&hash, test.state)
+			state, ok = cache.Lookup(&hash)
 			if !ok {
 				t.Errorf("Lookup (%s): missing entry after "+
 					"second add for hash %v", test.name,
@@ -160,8 +160,8 @@ nextTest:
 			if newState == test.state {
 				newState = ThresholdStarted
 			}
-			cache.Update(hash, newState)
-			state, ok = cache.Lookup(hash)
+			cache.Update(&hash, newState)
+			state, ok = cache.Lookup(&hash)
 			if !ok {
 				t.Errorf("Lookup (%s): missing entry after "+
 					"state change for hash %v", test.name,

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -968,7 +968,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *btcutil.Block, vi
 	}
 
 	// Ensure the view is for the node being checked.
-	if !view.BestHash().IsEqual(node.parentHash) {
+	if !view.BestHash().IsEqual(&node.parentHash) {
 		return AssertError(fmt.Sprintf("inconsistent view when "+
 			"checking block connection: best hash is %v instead "+
 			"of expected %v", view.BestHash(), node.hash))
@@ -1146,7 +1146,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *btcutil.Block, vi
 
 	// Update the best hash for view to include this block since all of its
 	// transactions have been connected.
-	view.SetBestHash(node.hash)
+	view.SetBestHash(&node.hash)
 
 	return nil
 }
@@ -1173,6 +1173,6 @@ func (b *BlockChain) CheckConnectBlock(block *btcutil.Block) error {
 	// Leave the spent txouts entry nil in the state since the information
 	// is not needed and thus extra work can be avoided.
 	view := NewUtxoViewpoint()
-	view.SetBestHash(prevNode.hash)
+	view.SetBestHash(&prevNode.hash)
 	return b.checkConnectBlock(newNode, block, view, nil)
 }

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -378,7 +378,7 @@ func (b *blockManager) handleDonePeerMsg(peers *list.List, sp *serverPeer) {
 		b.syncPeer = nil
 		if b.headersFirstMode {
 			best := b.chain.BestSnapshot()
-			b.resetHeaderState(best.Hash, best.Height)
+			b.resetHeaderState(&best.Hash, best.Height)
 		}
 		b.startSync(peers)
 	}
@@ -595,7 +595,7 @@ func (b *blockManager) handleBlockMsg(bmsg *blockMsg) {
 		// potential sync node candidacy.
 		best := b.chain.BestSnapshot()
 		heightUpdate = best.Height
-		blkHashUpdate = best.Hash
+		blkHashUpdate = &best.Hash
 
 		// Clear the rejected transactions.
 		b.rejectedTxns = make(map[chainhash.Hash]struct{})
@@ -1417,7 +1417,7 @@ func newBlockManager(s *server, indexManager blockchain.IndexManager) (*blockMan
 		// Initialize the next checkpoint based on the current height.
 		bm.nextCheckpoint = bm.findNextHeaderCheckpoint(best.Height)
 		if bm.nextCheckpoint != nil {
-			bm.resetHeaderState(best.Hash, best.Height)
+			bm.resetHeaderState(&best.Hash, best.Height)
 		}
 	} else {
 		bmgrLog.Info("Checkpoints are disabled")

--- a/cmd/findcheckpoint/findcheckpoint.go
+++ b/cmd/findcheckpoint/findcheckpoint.go
@@ -166,7 +166,7 @@ func main() {
 	fmt.Printf("Block database loaded with block height %d\n", best.Height)
 
 	// Find checkpoint candidates.
-	candidates, err := findCandidates(chain, best.Hash)
+	candidates, err := findCandidates(chain, &best.Hash)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Unable to identify candidates:", err)
 		return

--- a/mining/cpuminer/cpuminer.go
+++ b/mining/cpuminer/cpuminer.go
@@ -162,7 +162,7 @@ func (m *CPUMiner) submitBlock(block *btcutil.Block) bool {
 	// a new block, but the check only happens periodically, so it is
 	// possible a block was found and submitted in between.
 	msgBlock := block.MsgBlock()
-	if !msgBlock.Header.PrevBlock.IsEqual(m.g.BestSnapshot().Hash) {
+	if !msgBlock.Header.PrevBlock.IsEqual(&m.g.BestSnapshot().Hash) {
 		log.Debugf("Block submitted via CPU miner with previous "+
 			"block %s is stale", msgBlock.Header.PrevBlock)
 		return false
@@ -249,7 +249,7 @@ func (m *CPUMiner) solveBlock(msgBlock *wire.MsgBlock, blockHeight int32,
 				// The current block is stale if the best block
 				// has changed.
 				best := m.g.BestSnapshot()
-				if !header.PrevBlock.IsEqual(best.Hash) {
+				if !header.PrevBlock.IsEqual(&best.Hash) {
 					return false
 				}
 

--- a/mining/mining.go
+++ b/mining/mining.go
@@ -435,7 +435,7 @@ func NewBlkTmplGenerator(policy *Policy, params *chaincfg.Params,
 func (g *BlkTmplGenerator) NewBlockTemplate(payToAddress btcutil.Address) (*BlockTemplate, error) {
 	// Extend the most recently known best block.
 	best := g.chain.BestSnapshot()
-	prevHash := best.Hash
+	prevHash := &best.Hash
 	nextBlockHeight := best.Height + 1
 
 	// Create a standard coinbase transaction paying to the provided

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1470,7 +1470,7 @@ func (state *gbtWorkState) updateBlockTemplate(s *rpcServer, useCoinbaseValue bo
 	// generated.
 	var msgBlock *wire.MsgBlock
 	var targetDifficulty string
-	latestHash := s.server.blockManager.chain.BestSnapshot().Hash
+	latestHash := &s.server.blockManager.chain.BestSnapshot().Hash
 	template := state.template
 	if template == nil || state.prevHash == nil ||
 		!state.prevHash.IsEqual(latestHash) ||
@@ -2026,9 +2026,9 @@ func handleGetBlockTemplateProposal(s *rpcServer, request *btcjson.TemplateReque
 	block := btcutil.NewBlock(&msgBlock)
 
 	// Ensure the block is building from the expected previous block.
-	expectedPrevHash := s.server.blockManager.chain.BestSnapshot().Hash
+	expectedPrevHash := &s.server.blockManager.chain.BestSnapshot().Hash
 	prevHash := &block.MsgBlock().Header.PrevBlock
-	if expectedPrevHash == nil || !expectedPrevHash.IsEqual(prevHash) {
+	if !expectedPrevHash.IsEqual(prevHash) {
 		return "bad-prevblk", nil
 	}
 

--- a/rpcwebsocket.go
+++ b/rpcwebsocket.go
@@ -2471,7 +2471,7 @@ fetchRange:
 			blockManager := wsc.server.server.blockManager
 			pauseGuard := blockManager.Pause()
 			best := blockManager.chain.BestSnapshot()
-			curHash := best.Hash
+			curHash := &best.Hash
 			again := true
 			if lastBlockHash == nil || *lastBlockHash == *curHash {
 				again = false

--- a/server.go
+++ b/server.go
@@ -246,7 +246,7 @@ func newServerPeer(s *server, isPersistent bool) *serverPeer {
 // required by the configuration for the peer package.
 func (sp *serverPeer) newestBlock() (*chainhash.Hash, int32, error) {
 	best := sp.server.blockManager.chain.BestSnapshot()
-	return best.Hash, best.Height, nil
+	return &best.Hash, best.Height, nil
 }
 
 // addKnownAddresses adds the given addresses to the set of known addresses to
@@ -1130,7 +1130,7 @@ func (s *server) pushBlockMsg(sp *serverPeer, hash *chainhash.Hash, doneChan cha
 	if sendInv {
 		best := sp.server.blockManager.chain.BestSnapshot()
 		invMsg := wire.NewMsgInvSizeHint(1)
-		iv := wire.NewInvVect(wire.InvTypeBlock, best.Hash)
+		iv := wire.NewInvVect(wire.InvTypeBlock, &best.Hash)
 		invMsg.AddInvVect(iv)
 		sp.QueueMessage(invMsg, doneChan)
 		sp.continueHash = nil


### PR DESCRIPTION
**This PR requires #916**

This modifies the `blockNode` and `BestState` structs in the `blockchain` package to store hashes directly instead of pointers to them and updates callers to deal with the API change in the exported `BestState` struct.

In general, the preferred approach for hashes moving forward is to store hash values in complex data structures, particularly those that will be used for cache entries, and accept pointers to hashes in arguments to functions.

Some of the reasoning behind making this change is:

- It is generally preferred to avoid storing pointers to data in cache objects since doing so can easily lead to storing interior pointers into other structs that then can't be GC'd
- Keeping the hash values directly in the block node provides better cache locality
