### PR TITLE
blockchain: Ignore side chains in exists check.

### DIFF
--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -52,6 +52,24 @@ func (b *BlockChain) blockExists(hash *chainhash.Hash) (bool, error) {
 	err := b.db.View(func(dbTx database.Tx) error {
 		var err error
 		exists, err = dbTx.HasBlock(hash)
+		if err != nil || !exists {
+			return err
+		}
+
+		// Ignore side chain blocks in the database.  This is necessary
+		// because there is not currently any record of the associated
+		// block index data such as its block height, so it's not yet
+		// possible to efficiently load the block and do anything useful
+		// with it.
+		//
+		// Ultimately the entire block index should be serialized
+		// instead of only the current main chain so it can be consulted
+		// directly.
+		_, err = dbFetchHeightByHash(dbTx, hash)
+		if isNotInMainChainErr(err) {
+			exists = false
+			return nil
+		}
 		return err
 	})
 	return exists, err


### PR DESCRIPTION
Since the code base is currently in the process of changing over to decouple download and connection logic, but not all of the necessary parts are updated yet, ensure blocks that are in the database, but do
not have an associated main chain block index entry, are treated as if they do not exist for the purposes of chain connection and selection logic.