### PR TITLE
rpcserver: Allow limited user access to `getblockheader` command.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -254,6 +254,7 @@ var rpcLimited = map[string]struct{}{
 	"getblock":              {},
 	"getblockcount":         {},
 	"getblockhash":          {},
+	"getblockheader":        {},
 	"getcurrentnet":         {},
 	"getdifficulty":         {},
 	"getheaders":            {},


### PR DESCRIPTION
This PR adds the `getblockheader` RPC call to the `rpcLimited` map to allow the limited user access to the command.