### PR TITLE
TravisCI: Increase linting deadline.

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -30,13 +30,13 @@ fi
 linter_targets=$(glide novendor)
 
 # Automatic checks
-test -z "$(gometalinter --disable-all \
+test -z "$(gometalinter -j 4 --disable-all \
 --enable=gofmt \
 --enable=golint \
 --enable=vet \
 --enable=gosimple \
 --enable=unconvert \
---deadline=4m $linter_targets 2>&1 | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
+--deadline=10m $linter_targets 2>&1 | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
 env GORACE="halt_on_error=1" go test -race -tags rpctest $linter_targets
 
 # Run test coverage on each subdirectories and merge the coverage profile.


### PR DESCRIPTION
This increases the deadline for the linters to run to 10 minutes and also reduces the number of threads that is uses.  This is being done because the Travis environment has become increasingly slower and it
also seems to be hampered by too many threads running concurrently.