### PR TITLE
TravisCI: Only run tests once.

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -6,7 +6,6 @@
 # 4. gosimple      (https://github.com/dominikh/go-simple)
 # 5. unconvert     (https://github.com/mdempsky/unconvert)
 # 6. race detector (http://blog.golang.org/race-detector)
-# 7. test coverage (http://blog.golang.org/cover)
 #
 # gometalinter (github.com/alecthomas/gometalinter) is used to run each static
 # checker.
@@ -38,26 +37,3 @@ test -z "$(gometalinter -j 4 --disable-all \
 --enable=unconvert \
 --deadline=10m $linter_targets 2>&1 | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
 env GORACE="halt_on_error=1" go test -race -tags rpctest $linter_targets
-
-# Run test coverage on each subdirectories and merge the coverage profile.
-
-set +x
-echo "mode: count" > profile.cov
-
-# Standard go tooling behavior is to ignore dirs with leading underscores.
-for dir in $(find . -maxdepth 10 -not -path '.' -not -path './.git*' \
-    -not -path './.glide*' -not -path '*/_*' -not -path './cmd*' \
-    -not -path './release*' -not -path './vendor*' -type d)
-do
-if ls $dir/*.go &> /dev/null; then
-  go test -covermode=count -coverprofile=$dir/profile.tmp $dir
-  if [ -f $dir/profile.tmp ]; then
-    cat $dir/profile.tmp | tail -n +2 >> profile.cov
-    rm $dir/profile.tmp
-  fi
-fi
-done
-
-# To submit the test coverage result to coveralls.io,
-# use goveralls (https://github.com/mattn/goveralls)
-# goveralls -coverprofile=profile.cov -service=travis-ci


### PR DESCRIPTION
This modifies the `goclean.sh` script that is executed on Travis to only run the tests once.

While it is nice to see coverage reports in the log, unfortunately it appears that both the `-race` and `-cover` flags can't be used together, and the tests have grown in complexity such that they are starting to get close to TravisCI time limits.

