### PR TITLE
multi: Simplify code per gosimple linter.

### DIFF
--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -267,7 +267,7 @@ func uniqueOpReturnScript() []byte {
 		panic(err)
 	}
 
-	data := make([]byte, 8, 8)
+	data := make([]byte, 8)
 	binary.LittleEndian.PutUint64(data[0:8], rand)
 	return opReturnScript(data)
 }

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -614,7 +614,7 @@ func ExtractCoinbaseHeight(coinbaseTx *btcutil.Tx) (int32, error) {
 		return 0, ruleError(ErrMissingCoinbaseHeight, str)
 	}
 
-	serializedHeightBytes := make([]byte, 8, 8)
+	serializedHeightBytes := make([]byte, 8)
 	copy(serializedHeightBytes, sigScript[1:serializedLen+1])
 	serializedHeight := binary.LittleEndian.Uint64(serializedHeightBytes)
 

--- a/btcec/signature.go
+++ b/btcec/signature.go
@@ -62,7 +62,7 @@ func (sig *Signature) Serialize() []byte {
 	// total length of returned signature is 1 byte for each magic and
 	// length (6 total), plus lengths of r and s
 	length := 6 + len(rb) + len(sb)
-	b := make([]byte, length, length)
+	b := make([]byte, length)
 
 	b[0] = 0x30
 	b[1] = byte(length - 2)

--- a/goclean.sh
+++ b/goclean.sh
@@ -30,13 +30,13 @@ fi
 linter_targets=$(glide novendor)
 
 # Automatic checks
-test -z "$(gometalinter --disable-all \
+test -z "$(gometalinter -j 4 --disable-all \
 --enable=gofmt \
 --enable=golint \
 --enable=vet \
 --enable=gosimple \
 --enable=unconvert \
---deadline=4m $linter_targets 2>&1 | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
+--deadline=10m $linter_targets 2>&1 | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
 env GORACE="halt_on_error=1" go test -race -tags rpctest $linter_targets
 
 # Run test coverage on each subdirectories and merge the coverage profile.

--- a/mining/cpuminer/cpuminer.go
+++ b/mining/cpuminer/cpuminer.go
@@ -566,7 +566,7 @@ func (m *CPUMiner) GenerateNBlocks(n uint32) ([]*chainhash.Hash, error) {
 	log.Tracef("Generating %d blocks", n)
 
 	i := uint32(0)
-	blockHashes := make([]*chainhash.Hash, n, n)
+	blockHashes := make([]*chainhash.Hash, n)
 
 	// Start a ticker which is used to signal checks for stale work and
 	// updates to the speed monitor.

--- a/txscript/stack.go
+++ b/txscript/stack.go
@@ -155,7 +155,7 @@ func (s *stack) nipN(idx int32) ([]byte, error) {
 	if idx == 0 {
 		s.stk = s.stk[:sz-1]
 	} else if idx == sz-1 {
-		s1 := make([][]byte, sz-1, sz-1)
+		s1 := make([][]byte, sz-1)
 		copy(s1, s.stk[1:])
 		s.stk = s1
 	} else {

--- a/wire/fixedIO_test.go
+++ b/wire/fixedIO_test.go
@@ -39,7 +39,7 @@ func (w *fixedWriter) Bytes() []byte {
 // newFixedWriter returns a new io.Writer that will error once more bytes than
 // the specified max have been written.
 func newFixedWriter(max int) io.Writer {
-	b := make([]byte, max, max)
+	b := make([]byte, max)
 	fw := fixedWriter{b, 0}
 	return &fw
 }
@@ -66,7 +66,7 @@ func (fr *fixedReader) Read(p []byte) (n int, err error) {
 // newFixedReader returns a new io.Reader that will error once more bytes than
 // the specified max have been read.
 func newFixedReader(max int, buf []byte) io.Reader {
-	b := make([]byte, max, max)
+	b := make([]byte, max)
 	if buf != nil {
 		copy(b[:], buf)
 	}

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -114,7 +114,7 @@ type scriptFreeList chan []byte
 // ignored and allowed to go the garbage collector.
 func (c scriptFreeList) Borrow(size uint64) []byte {
 	if size > freeListMaxScriptSize {
-		return make([]byte, size, size)
+		return make([]byte, size)
 	}
 
 	var buf []byte
@@ -293,7 +293,7 @@ func (msg *MsgTx) Copy() *MsgTx {
 		oldScript := oldTxIn.SignatureScript
 		oldScriptLen := len(oldScript)
 		if oldScriptLen > 0 {
-			newScript = make([]byte, oldScriptLen, oldScriptLen)
+			newScript = make([]byte, oldScriptLen)
 			copy(newScript, oldScript[:oldScriptLen])
 		}
 
@@ -314,7 +314,7 @@ func (msg *MsgTx) Copy() *MsgTx {
 		oldScript := oldTxOut.PkScript
 		oldScriptLen := len(oldScript)
 		if oldScriptLen > 0 {
-			newScript = make([]byte, oldScriptLen, oldScriptLen)
+			newScript = make([]byte, oldScriptLen)
 			copy(newScript, oldScript[:oldScriptLen])
 		}
 


### PR DESCRIPTION
This simplifies the code based on the recommendations of the [gosimple](https://github.com/dominikh/go-simple) lint tool.

Also, it increases the deadline for the linters to run to 10 minutes and reduces the number of threads that is uses. This is being done because the Travis environment has become increasingly slower and it also seems to be hampered by too many threads running concurrently.