### PR TITLE
peer: Use prng to generate self detection nonce.

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -794,10 +794,7 @@ func (p *Peer) localVersionMsg() (*wire.MsgVersion, error) {
 	// Generate a unique nonce for this peer so self connections can be
 	// detected.  This is accomplished by adding it to a size-limited map of
 	// recently seen nonces.
-	nonce, err := wire.RandomUint64()
-	if err != nil {
-		return nil, err
-	}
+	nonce := uint64(rand.Int63())
 	sentNonces.Add(nonce)
 
 	// Version message.


### PR DESCRIPTION
This changes the nonce generated to detect self connections over to use pseudo randoms instead of a cryptographically random nonce.

There is really not a good reason for it to be cryptographically strong, using the prng is much faster, and the prng also doesn't burn entropy.
