### PR TITLE
chaincfg: Remove bitseed.xf2.org DNS seed.

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -220,7 +220,6 @@ var MainNetParams = Params{
 		{"dnsseed.bitcoin.dashjr.org", false},
 		{"seed.bitcoinstats.com", true},
 		{"seed.bitnodes.io", false},
-		{"bitseed.xf2.org", false},
 		{"seed.bitcoin.jonasschnelli.ch", true},
 	},
 


### PR DESCRIPTION
This DNS seed does not appear to resolve IPv6 and the returned addresses rarely seem correspond to functioning nodes.