### PR TITLE
multi: Update markdown files for GFM changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 btcd
 ====
 
-[![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)]
-(https://travis-ci.org/btcsuite/btcd)
+[![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcd)
 
 btcd is an alternative full node bitcoin implementation written in Go (golang).
 

--- a/blockchain/README.md
+++ b/blockchain/README.md
@@ -1,11 +1,9 @@
 blockchain
 ==========
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
-(https://travis-ci.org/btcsuite/btcd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/blockchain)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcd/blockchain)
 
 Package blockchain implements bitcoin block handling and chain selection rules.
 The test coverage is currently only around 60%, but will be increasing over
@@ -63,21 +61,18 @@ is by no means exhaustive:
 
 ## Examples
 
-* [ProcessBlock Example]
-  (http://godoc.org/github.com/btcsuite/btcd/blockchain#example-BlockChain-ProcessBlock)  
+* [ProcessBlock Example](http://godoc.org/github.com/btcsuite/btcd/blockchain#example-BlockChain-ProcessBlock)  
   Demonstrates how to create a new chain instance and use ProcessBlock to
   attempt to attempt add a block to the chain.  This example intentionally
   attempts to insert a duplicate genesis block to illustrate how an invalid
   block is handled.
 
-* [CompactToBig Example]
-  (http://godoc.org/github.com/btcsuite/btcd/blockchain#example-CompactToBig)  
+* [CompactToBig Example](http://godoc.org/github.com/btcsuite/btcd/blockchain#example-CompactToBig)  
   Demonstrates how to convert the compact "bits" in a block header which
   represent the target difficulty to a big integer and display it using the
   typical hex notation.
 
-* [BigToCompact Example]
-  (http://godoc.org/github.com/btcsuite/btcd/blockchain#example-BigToCompact)  
+* [BigToCompact Example](http://godoc.org/github.com/btcsuite/btcd/blockchain#example-BigToCompact)  
   Demonstrates how to convert how to convert a target difficulty into the
   compact "bits" in a block header which represent that target difficulty.
 

--- a/blockchain/fullblocktests/README.md
+++ b/blockchain/fullblocktests/README.md
@@ -1,11 +1,9 @@
 fullblocktests
 ==============
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
-(https://travis-ci.org/btcsuite/btcd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/blockchain/fullblocktests)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcd/blockchain/fullblocktests)
 
 Package fullblocktests provides a set of full block tests to be used for testing
 the consensus validation rules.  The tests are intended to be flexible enough to

--- a/blockchain/indexers/README.md
+++ b/blockchain/indexers/README.md
@@ -1,8 +1,9 @@
 indexers
 ========
 
-[![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)]
-(https://travis-ci.org/btcsuite/btcd)
+[![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://godoc.org/github.com/btcsuite/btcd/blockchain/indexers?status.png)](http://godoc.org/github.com/btcsuite/btcd/blockchain/indexers)
 
 Package indexers implements optional block chain indexes.
 
@@ -18,19 +19,6 @@ via an RPC interface.
   - Creates a mapping from every address to all transactions which either credit
     or debit the address
   - Requires the transaction-by-hash index
-
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/btcsuite/btcd/blockchain/indexers?status.png)]
-(http://godoc.org/github.com/btcsuite/btcd/blockchain/indexers)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/btcsuite/btcd/blockchain/indexers
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcd/blockchain/indexers
 
 ## Installation
 

--- a/btcec/README.md
+++ b/btcec/README.md
@@ -1,11 +1,9 @@
 btcec
 =====
 
-[![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)]
-(https://travis-ci.org/btcsuite/btcec) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://godoc.org/github.com/btcsuite/btcd/btcec?status.png)]
-(http://godoc.org/github.com/btcsuite/btcd/btcec)
+[![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)](https://travis-ci.org/btcsuite/btcec)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://godoc.org/github.com/btcsuite/btcd/btcec?status.png)](http://godoc.org/github.com/btcsuite/btcd/btcec)
 
 Package btcec implements elliptic curve cryptography needed for working with
 Bitcoin (secp256k1 only for now). It is designed so that it may be used with the
@@ -27,23 +25,19 @@ $ go get -u github.com/btcsuite/btcd/btcec
 
 ## Examples
 
-* [Sign Message]
-  (http://godoc.org/github.com/btcsuite/btcd/btcec#example-package--SignMessage)  
+* [Sign Message](http://godoc.org/github.com/btcsuite/btcd/btcec#example-package--SignMessage)  
   Demonstrates signing a message with a secp256k1 private key that is first
   parsed form raw bytes and serializing the generated signature.
 
-* [Verify Signature]
-  (http://godoc.org/github.com/btcsuite/btcd/btcec#example-package--VerifySignature)  
+* [Verify Signature](http://godoc.org/github.com/btcsuite/btcd/btcec#example-package--VerifySignature)  
   Demonstrates verifying a secp256k1 signature against a public key that is
   first parsed from raw bytes.  The signature is also parsed from raw bytes.
 
-* [Encryption]
-  (http://godoc.org/github.com/btcsuite/btcd/btcec#example-package--EncryptMessage)
+* [Encryption](http://godoc.org/github.com/btcsuite/btcd/btcec#example-package--EncryptMessage)
   Demonstrates encrypting a message for a public key that is first parsed from
   raw bytes, then decrypting it using the corresponding private key.
 
-* [Decryption]
-  (http://godoc.org/github.com/btcsuite/btcd/btcec#example-package--DecryptMessage)
+* [Decryption](http://godoc.org/github.com/btcsuite/btcd/btcec#example-package--DecryptMessage)
   Demonstrates decrypting a message using a private key that is first parsed
   from raw bytes.
 

--- a/btcjson/README.md
+++ b/btcjson/README.md
@@ -1,11 +1,9 @@
 btcjson
 =======
 
-[![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)]
-(https://travis-ci.org/btcsuite/btcd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/btcjson)
+[![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcd/btcjson)
 
 Package btcjson implements concrete types for marshalling to and from the
 bitcoin JSON-RPC API.  A comprehensive suite of tests is provided to ensure
@@ -32,21 +30,17 @@ $ go get -u github.com/btcsuite/btcd/btcjson
 
 ## Examples
 
-* [Marshal Command]
-  (http://godoc.org/github.com/btcsuite/btcd/btcjson#example-MarshalCmd)  
+* [Marshal Command](http://godoc.org/github.com/btcsuite/btcd/btcjson#example-MarshalCmd)  
   Demonstrates how to create and marshal a command into a JSON-RPC request.
 
-* [Unmarshal Command]
-  (http://godoc.org/github.com/btcsuite/btcd/btcjson#example-UnmarshalCmd)  
+* [Unmarshal Command](http://godoc.org/github.com/btcsuite/btcd/btcjson#example-UnmarshalCmd)  
   Demonstrates how to unmarshal a JSON-RPC request and then unmarshal the
   concrete request into a concrete command.
 
-* [Marshal Response]
-  (http://godoc.org/github.com/btcsuite/btcd/btcjson#example-MarshalResponse)  
+* [Marshal Response](http://godoc.org/github.com/btcsuite/btcd/btcjson#example-MarshalResponse)  
   Demonstrates how to marshal a JSON-RPC response.
 
-* [Unmarshal Response]
-  (http://godoc.org/github.com/btcsuite/btcd/btcjson#example-package--UnmarshalResponse)  
+* [Unmarshal Response](http://godoc.org/github.com/btcsuite/btcd/btcjson#example-package--UnmarshalResponse)  
   Demonstrates how to unmarshal a JSON-RPC response and then unmarshal the
   result field in the response to a concrete type.
 

--- a/chaincfg/README.md
+++ b/chaincfg/README.md
@@ -1,11 +1,9 @@
 chaincfg
 ========
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
-(https://travis-ci.org/btcsuite/btcd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/chaincfg)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcd/chaincfg)
 
 Package chaincfg defines chain configuration parameters for the three standard
 Bitcoin networks and provides the ability for callers to define their own custom

--- a/chaincfg/chainhash/README.md
+++ b/chaincfg/chainhash/README.md
@@ -1,11 +1,9 @@
 chainhash
 =========
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
-(https://travis-ci.org/btcsuite/btcd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/chaincfg/chainhash)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcd/chaincfg/chainhash)
 
 chainhash provides a generic hash type and associated functions that allows the
 specific hash algorithm to be abstracted.

--- a/connmgr/README.md
+++ b/connmgr/README.md
@@ -1,11 +1,9 @@
 connmgr
 =======
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
-(https://travis-ci.org/btcsuite/btcd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/connmgr)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcd/connmgr)
 
 Package connmgr implements a generic Bitcoin network connection manager.
 

--- a/database/README.md
+++ b/database/README.md
@@ -1,11 +1,9 @@
 database
 ========
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
-(https://travis-ci.org/btcsuite/btcd)  [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/database)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcd/database)
 
 Package database provides a block and metadata storage database.
 
@@ -16,8 +14,7 @@ and that entity will be btcd.
 
 When a client wants programmatic access to the data provided by btcd, they'll
 likely want to use the [btcrpcclient](https://github.com/btcsuite/btcrpcclient)
-package which makes use of the [JSON-RPC API]
-(https://github.com/btcsuite/btcd/tree/master/docs/json_rpc_api.md).
+package which makes use of the [JSON-RPC API](https://github.com/btcsuite/btcd/tree/master/docs/json_rpc_api.md).
 
 However, this package could be extremely useful for any applications requiring
 Bitcoin block storage capabilities.
@@ -45,13 +42,11 @@ $ go get -u github.com/btcsuite/btcd/database
 
 ## Examples
 
-* [Basic Usage Example]
-  (http://godoc.org/github.com/btcsuite/btcd/database#example-package--BasicUsage)  
+* [Basic Usage Example](http://godoc.org/github.com/btcsuite/btcd/database#example-package--BasicUsage)  
   Demonstrates creating a new database and using a managed read-write
   transaction to store and retrieve metadata.
 
-* [Block Storage and Retrieval Example]
-  (http://godoc.org/github.com/btcsuite/btcd/database#example-package--BlockStorageAndRetrieval)  
+* [Block Storage and Retrieval Example](http://godoc.org/github.com/btcsuite/btcd/database#example-package--BlockStorageAndRetrieval)  
   Demonstrates creating a new database, using a managed read-write transaction
   to store a block, and then using a managed read-only transaction to fetch the
   block.

--- a/database/ffldb/README.md
+++ b/database/ffldb/README.md
@@ -1,8 +1,9 @@
 ffldb
 =====
 
-[![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)]
-(https://travis-ci.org/btcsuite/btcd)
+[![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://godoc.org/github.com/btcsuite/btcd/database/ffldb?status.png)](http://godoc.org/github.com/btcsuite/btcd/database/ffldb)
 
 Package ffldb implements a driver for the database package that uses leveldb for
 the backing metadata and flat files for block storage.
@@ -32,19 +33,6 @@ if err != nil {
 	// Handle error
 }
 ```
-
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/btcsuite/btcd/database/ffldb?status.png)]
-(http://godoc.org/github.com/btcsuite/btcd/database/ffldb)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/btcsuite/btcd/database/ffldb
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcd/database/ffldb
 
 ## License
 

--- a/database/internal/treap/README.md
+++ b/database/internal/treap/README.md
@@ -1,8 +1,9 @@
 treap
 =====
 
-[![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)]
-(https://travis-ci.org/btcsuite/btcd)
+[![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://godoc.org/github.com/btcsuite/btcd/database/internal/treap?status.png)](http://godoc.org/github.com/btcsuite/btcd/database/internal/treap)
 
 Package treap implements a treap data structure that is used to hold ordered
 key/value pairs using a combination of binary search tree and heap semantics.
@@ -31,19 +32,6 @@ Package treap is licensed under the copyfree ISC license.
 
 This package is only used internally in the database code and as such is not
 available for use outside of it.
-
-## Documentation
-
-[![GoDoc](https://godoc.org/github.com/btcsuite/btcd/database/internal/treap?status.png)]
-(http://godoc.org/github.com/btcsuite/btcd/database/internal/treap)
-
-Full `go doc` style documentation for the project can be viewed online without
-installing this package by using the GoDoc site here:
-http://godoc.org/github.com/btcsuite/btcd/database/internal/treap
-
-You can also view the documentation locally once the package is installed with
-the `godoc` tool by running `godoc -http=":6060"` and pointing your browser to
-http://localhost:6060/pkg/github.com/btcsuite/btcd/database/internal/treap
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -214,6 +214,7 @@ configuration necessary, however, there is an optional method to use a
 **3.1.1 bootstrap.dat**
 
 * [Using bootstrap.dat](https://github.com/btcsuite/btcd/tree/master/docs/using_bootstrap_dat.md)
+
 <a name="NetworkConfig" />
 
 **3.1.2 Network Configuration**

--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -16,6 +16,7 @@
 6.2. [Licensing of Contributions](#Licensing)<br />
 
 <a name="Overview" />
+
 ### 1. Overview
 
 Developing cryptocurrencies is an exciting endeavor that touches a wide variety
@@ -38,6 +39,7 @@ We highly encourage code contributions, however it is imperative that you adhere
 to the guidelines established on this page.
 
 <a name="MinSkillset" />
+
 ### 2. Minimum Recommended Skillset
 
 The following list is a set of core competencies that we recommend you possess
@@ -63,6 +65,7 @@ understanding of the various aspects involved with cryptography such as the
 security and performance implications.
 
 <a name="ReqReading" />
+
 ### 3. Required Reading
 
 - [Effective Go](http://golang.org/doc/effective_go.html) - The entire btcd
@@ -72,6 +75,7 @@ security and performance implications.
   foundation to build on will make the code much more comprehensible.
 
 <a name="DevelopmentPractices" />
+
 ### 4. Development Practices
 
 Developers are expected to work in their own trees and submit pull requests when
@@ -79,6 +83,7 @@ they feel their feature or bug fix is ready for integration into the  master
 branch.
 
 <a name="ShareEarly" />
+
 ### 4.1 Share Early, Share Often
 
 We firmly believe in the share early, share often approach.  The basic premise
@@ -101,6 +106,7 @@ This approach has several benefits:
   spend rebasing and otherwise trying to keep up with the main code base
 
 <a name="Testing" />
+
 ### 4.2 Testing
 
 One of the major design goals of all core btcd packages is to aim for complete
@@ -127,6 +133,7 @@ A quick summary of test practices follows:
   to both prove it has been resolved and to prevent future regressions
 
 <a name="CodeDocumentation" />
+
 ### 4.3 Code Documentation and Commenting
 
 - At a minimum every function must be commented with its intended purpose and
@@ -196,6 +203,7 @@ but it was left as a magic number to show how much of a difference a good
 comment can make.
 
 <a name="ModelGitCommitMessages" />
+
 ### 4.4 Model Git Commit Messages
 
 This project prefers to keep a clean commit history with well-formed commit
@@ -248,12 +256,14 @@ a good thing.
   reply indicators without overflow in an 80 column terminal.
 
 <a name="CodeApproval" />
+
 ### 5. Code Approval Process
 
 This section describes the code approval process that is used for code
 contributions.  This is how to get your changes into btcd.
 
 <a name="CodeReview" />
+
 ### 5.1 Code Review
 
 All code which is submitted will need to be reviewed before inclusion into the
@@ -289,6 +299,7 @@ checks which are generally performed as follows:
   consensus
 
 <a name="CodeRework" />
+
 ### 5.2 Rework Code (if needed)
 
 After the code review, the change will be accepted immediately if no issues are
@@ -301,6 +312,7 @@ make the necessary changes.
 This process will continue until the code is finally accepted.
 
 <a name="CodeAcceptance" />
+
 ### 5.3 Acceptance
 
 Once your code is accepted, it will be integrated with the master branch.
@@ -312,9 +324,11 @@ the master branch and the pull request will be closed.
 Rejoice as you will now be listed as a [contributor](https://github.com/btcsuite/btcd/graphs/contributors)!
 
 <a name="Standards" />
+
 ### 6. Contribution Standards
 
 <a name="Checklist" />
+
 ### 6.1. Contribution Checklist
 
 - [&nbsp;&nbsp;] All changes are Go version 1.3 compliant
@@ -333,8 +347,9 @@ Rejoice as you will now be listed as a [contributor](https://github.com/btcsuite
   report any **new** issues that did not already exist
 
 <a name="Licensing" />
+
 ### 6.2. Licensing of Contributions
-****
+
 All contributions must be licensed with the
 [ISC license](https://github.com/btcsuite/btcd/blob/master/LICENSE).  This is
 the same license as all of the code in the btcd suite.

--- a/docs/configuring_tor.md
+++ b/docs/configuring_tor.md
@@ -18,6 +18,7 @@
 5.3 [Config File Example](#TorStreamIsolationFileExample)<br />
 
 <a name="Overview" />
+
 ### 1. Overview
 
 btcd provides full support for anonymous networking via the
@@ -34,9 +35,11 @@ you are connecting to them.  We recommend you take the time to setup a Tor
 hidden service for this reason.
 
 <a name="Client" />
+
 ### 2. Client-Only
 
 <a name="ClientDescription" />
+
 **2.1 Description**<br />
 
 Configuring btcd as a Tor client is straightforward.  The first step is
@@ -56,6 +59,7 @@ not be reachable for inbound connections unless you also configure a Tor
 [hidden service](#HiddenService).
 
 <a name="ClientCLIExample" />
+
 **2.2 Command Line Example**<br />
 
 ```bash
@@ -63,6 +67,7 @@ $ ./btcd --proxy=127.0.0.1:9050
 ```
 
 <a name="ClientConfigFileExample" />
+
 **2.3 Config File Example**<br />
 
 ```text
@@ -72,9 +77,11 @@ proxy=127.0.0.1:9050
 ```
 
 <a name="HiddenService" />
+
 ### 3. Client-Server via Tor Hidden Service
 
 <a name="HiddenServiceDescription" />
+
 **3.1 Description**<br />
 
 The first step is to configure Tor to provide a hidden service.  Documentation
@@ -103,6 +110,7 @@ three flags:
 * `--externalip` to set the .onion address that is advertised to other peers
 
 <a name="HiddenServiceCLIExample" />
+
 **3.2 Command Line Example**<br />
 
 ```bash
@@ -110,6 +118,7 @@ $ ./btcd --proxy=127.0.0.1:9050 --listen=127.0.0.1 --externalip=fooanon.onion
 ```
 
 <a name="HiddenServiceConfigFileExample" />
+
 **3.3 Config File Example**<br />
 
 ```text
@@ -121,9 +130,11 @@ externalip=fooanon.onion
 ```
 
 <a name="Bridge" />
+
 ### 4. Bridge Mode (Not Anonymous)
 
 <a name="BridgeDescription" />
+
 **4.1 Description**<br />
 
 btcd provides support for operating as a bridge between regular nodes and hidden
@@ -144,6 +155,7 @@ mode, you only need to specify your hidden service's .onion address via the
 routed via Tor due to the `--onion` flag.
 
 <a name="BridgeCLIExample" />
+
 **4.2 Command Line Example**<br />
 
 ```bash
@@ -151,6 +163,7 @@ $ ./btcd --onion=127.0.0.1:9050 --externalip=fooanon.onion
 ```
 
 <a name="BridgeConfigFileExample" />
+
 **4.3 Config File Example**<br />
 
 ```text
@@ -161,9 +174,11 @@ externalip=fooanon.onion
 ```
 
 <a name="TorStreamIsolation" />
+
 ### 5. Tor Stream Isolation
 
 <a name="TorStreamIsolationDescription" />
+
 **5.1 Description**<br />
 
 Tor stream isolation forces Tor to build a new circuit for each connection
@@ -173,6 +188,7 @@ btcd provides support for Tor stream isolation by using the `--torisolation`
 flag.  This option requires --proxy or --onionproxy to be set.
 
 <a name="TorStreamIsolationCLIExample" />
+
 **5.2 Command Line Example**<br />
 
 ```bash
@@ -180,6 +196,7 @@ $ ./btcd --proxy=127.0.0.1:9050 --torisolation
 ```
 
 <a name="TorStreamIsolationFileExample" />
+
 **5.3 Config File Example**<br />
 
 ```text

--- a/docs/json_rpc_api.md
+++ b/docs/json_rpc_api.md
@@ -23,6 +23,7 @@
 9.2. [node.js](#ExampleNodeJsCode)<br />
 
 <a name="Overview" />
+
 ### 1. Overview
 
 btcd provides a [JSON-RPC](http://json-rpc.org/wiki/specification) API that is
@@ -59,6 +60,7 @@ progress, incomplete, and susceptible to changes (both additions and removals).
 The original bitcoind/bitcoin-qt JSON-RPC API documentation is available at [https://en.bitcoin.it/wiki/Original_Bitcoin_client/API_Calls_list](https://en.bitcoin.it/wiki/Original_Bitcoin_client/API_Calls_list)
 
 <a name="HttpPostVsWebsockets" />
+
 ### 2. HTTP POST Versus Websockets
 
 The btcd RPC server supports both [HTTP POST](http://en.wikipedia.org/wiki/POST_%28HTTP%29)
@@ -81,9 +83,11 @@ JSON-RPC API are:
 |Scales well with large numbers of requests|No|Yes|
 
 <a name="Authentication" />
+
 ### 3. Authentication
 
 <a name="AuthenticationOverview" />
+
 **3.1 Authentication Overview**<br />
 
 The following authentication details are needed before establishing a connection
@@ -109,6 +113,7 @@ two, mutually exclusive, methods.
 - [Use the JSON-RPC "authenticate" command](#JSONAuth) - Websockets only
 
 <a name="HTTPAuth" />
+
 **3.2 HTTP Basic Access Authentication**<br />
 
 The btcd RPC server uses HTTP [basic access authentication](http://en.wikipedia.org/wiki/Basic_access_authentication) with the **rpcuser**
@@ -116,6 +121,7 @@ and **rpcpass** detailed above.  If the supplied credentials are invalid, you
 will be disconnected immediately upon making the connection.
 
 <a name="JSONAuth" />
+
 **3.3 JSON-RPC Authenticate Command (Websocket-specific)**<br />
 
 While the HTTP basic access authentication method is the preferred method, the
@@ -129,6 +135,7 @@ authenticated will cause the websocket to be closed immediately.
 
 
 <a name="CLIUtil" />
+
 ### 4. Command-line Utility
 
 btcd comes with a separate utility named `btcctl` which can be used to issue
@@ -138,9 +145,11 @@ be used to communicate with any server/daemon/service which provides a JSON-RPC
 API compatible with the original bitcoind/bitcoin-qt client.
 
 <a name="Methods" />
+
 ### 5. Standard Methods
 
 <a name="MethodOverview" />
+
 **5.1 Method Overview**<br />
 
 The following is an overview of the RPC methods and their current status.  Click
@@ -180,6 +189,7 @@ the method name for further details such as parameter and return information.
 |30|[verifychain](#verifychain)|N|Verifies the block chain database.|
 
 <a name="MethodDetails" />
+
 **5.2 Method Details**<br />
 
 <a name="addnode"/>
@@ -552,9 +562,11 @@ Example Return|`{`<br />&nbsp;&nbsp;`"bytes": 310768,`<br />&nbsp;&nbsp;`"size":
 
 
 <a name="ExtensionMethods" />
+
 ### 6. Extension Methods
 
 <a name="ExtMethodOverview" />
+
 **6.1 Method Overview**<br />
 
 The following is an overview of the RPC methods which are implemented by btcd, but not the original bitcoind client. Click the method name for further details such as parameter and return information.
@@ -572,6 +584,7 @@ The following is an overview of the RPC methods which are implemented by btcd, b
 
 
 <a name="ExtMethodDetails" />
+
 **6.2 Method Details**<br />
 
 <a name="debuglevel"/>
@@ -677,9 +690,11 @@ The following is an overview of the RPC methods which are implemented by btcd, b
 ***
 
 <a name="WSExtMethods" />
+
 ### 7. Websocket Extension Methods (Websocket-specific)
 
 <a name="WSExtMethodOverview" />
+
 **7.1 Method Overview**<br />
 
 The following is an overview of the RPC method requests available exclusively to Websocket clients.  All of these RPC methods are available to the limited
@@ -702,6 +717,7 @@ user.  Click the method name for further details such as parameter and return in
 |13|[rescanblocks](#rescanblocks)|Rescan blocks for transactions matching the loaded transaction filter.|None|
 
 <a name="WSExtMethodDetails" />
+
 **7.2 Method Details**<br />
 
 <a name="authenticate"/>
@@ -728,6 +744,7 @@ user.  Click the method name for further details such as parameter and return in
 [Return to Overview](#WSExtMethodOverview)<br />
 
 ***
+
 <a name="stopnotifyblocks"/>
 
 |   |   |
@@ -872,11 +889,13 @@ user.  Click the method name for further details such as parameter and return in
 
 
 <a name="Notifications" />
+
 ### 8. Notifications (Websocket-specific)
 
 btcd uses standard JSON-RPC notifications to notify clients of changes, rather than requiring clients to poll btcd for updates.  JSON-RPC notifications are a subset of requests, but do not contain an ID.  The notification type is categorized by the `method` field and additional details are sent as a JSON array in the `params` field.
 
 <a name="NotificationOverview" />
+
 **8.1 Notification Overview**<br />
 
 The following is an overview of the JSON-RPC notifications used for Websocket connections.  Click the method name for further details of the context(s) in which they are sent and their parameters.
@@ -896,6 +915,7 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 |11|[filteredblockdisconnected](#filteredblockdisconnected)|Block disconnected from the main chain.|[notifyblocks](#notifyblocks), [loadtxfilter](#loadtxfilter)|
 
 <a name="NotificationDetails" />
+
 **8.2 Notification Details**<br />
 
 <a name="blockconnected"/>
@@ -1040,6 +1060,7 @@ The following is an overview of the JSON-RPC notifications used for Websocket co
 
 
 <a name="ExampleCode" />
+
 ### 9. Example Code
 
 This section provides example code for interacting with the JSON-RPC API in
@@ -1049,6 +1070,7 @@ various languages.
 * [node.js](#ExampleNodeJsCode)
 
 <a name="ExampleGoApp" />
+
 **9.1 Go**
 
 This section provides examples of using the RPC interface using Go and the
@@ -1060,6 +1082,7 @@ This section provides examples of using the RPC interface using Go and the
 
 
 <a name="ExampleGetBlockCount" />
+
 **9.1.1 Using getblockcount to Retrieve the Current Block Height**<br />
 
 The following is an example Go application which uses the
@@ -1120,6 +1143,7 @@ Block count: 276978
 ```
 
 <a name="ExampleGetBlock" />
+
 **9.1.2 Using getblock to Retrieve the Genesis Block**<br />
 
 The following is an example Go application which uses the
@@ -1208,6 +1232,7 @@ Num transactions: 1
 ```
 
 <a name="ExampleNotifyBlocks" />
+
 **9.1.3 Using notifyblocks to Receive blockconnected and blockdisconnected
 Notifications (Websocket-specific)**<br />
 
@@ -1298,9 +1323,11 @@ Example output:
 ```
 
 <a name="ExampleNodeJsCode" />
+
 ### 9.2. Example node.js Code
 
 <a name="ExampleNotifyBlocks" />
+
 **9.2.1 Using notifyblocks to be Notified of Block Connects and Disconnects**<br />
 
 The following is example node.js code which uses [ws](https://github.com/einaros/ws)

--- a/docs/using_bootstrap_dat.md
+++ b/docs/using_bootstrap_dat.md
@@ -6,6 +6,7 @@
 5. [How do I use bootstrap.dat with btcd?](#Importing)
 
 <a name="What" />
+
 ### 1. What is bootstrap.dat?
 
 It is a flat, binary file containing bitcoin blockchain data starting from the
@@ -20,6 +21,7 @@ block chain from other peers through the Bitcoin protocol with no extra
 configuration needed.
 
 <a name="ProsCons" />
+
 ### 2. What are the pros and cons of using bootstrap.dat?
 
 Pros:
@@ -36,6 +38,7 @@ Cons:
   well as the imported database
 
 <a name="Obtaining" />
+
 ### 3. Where do I get bootstrap.dat?
 
 The bootstrap.dat file is made available via a torrent.  See
@@ -43,6 +46,7 @@ The bootstrap.dat file is made available via a torrent.  See
 for the torrent download details.
 
 <a name="Trust" />
+
 ### 4. How do I know I can trust the bootstrap.dat I downloaded?
 
 You don't need to trust the file as the `addblock` utility verifies every block
@@ -53,6 +57,7 @@ that not only is it a valid chain, but it is the same chain that everyone else
 is using.
 
 <a name="Importing" />
+
 ### 5. How do I use bootstrap.dat with btcd?
 
 btcd comes with a separate utility named `addblock` which can be used to import

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,9 +1,8 @@
 integration
 ===========
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
-(https://travis-ci.org/btcsuite/btcd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
 
 This contains integration tests which make use of the
 [rpctest](https://github.com/btcsuite/btcd/tree/master/integration/rpctest)

--- a/integration/rpctest/README.md
+++ b/integration/rpctest/README.md
@@ -1,11 +1,9 @@
 rpctest
 =======
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
-(https://travis-ci.org/btcsuite/btcd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/integration/rpctest)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcd/integration/rpctest)
 
 Package rpctest provides a btcd-specific RPC testing harness crafting and
 executing integration tests by driving a `btcd` instance via the `RPC`
@@ -26,7 +24,6 @@ $ go get -u github.com/btcsuite/btcd/integration/rpctest
 ```
 
 ## License
-
 
 Package rpctest is licensed under the [copyfree](http://copyfree.org) ISC
 License.

--- a/mempool/README.md
+++ b/mempool/README.md
@@ -1,11 +1,9 @@
 mempool
 =======
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
-(https://travis-ci.org/btcsuite/btcd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/mempool)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcd/mempool)
 
 Package mempool provides a policy-enforced pool of unmined bitcoin transactions.
 

--- a/mining/README.md
+++ b/mining/README.md
@@ -1,11 +1,9 @@
 mining
 ======
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
-(https://travis-ci.org/btcsuite/btcd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/mining)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcd/mining)
 
 ## Overview
 

--- a/mining/cpuminer/README.md
+++ b/mining/cpuminer/README.md
@@ -1,11 +1,9 @@
 cpuminer
 ========
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
-(https://travis-ci.org/btcsuite/btcd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/mining/cpuminer)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcd/mining/cpuminer)
 
 ## Overview
 

--- a/peer/README.md
+++ b/peer/README.md
@@ -1,11 +1,9 @@
 peer
 ====
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
-(https://travis-ci.org/btcsuite/btcd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/peer)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcd/peer)
 
 Package peer provides a common base for creating and managing bitcoin network
 peers.
@@ -65,8 +63,7 @@ $ go get -u github.com/btcsuite/btcd/peer
 
 ## Examples
 
-* [New Outbound Peer Example]
-  (https://godoc.org/github.com/btcsuite/btcd/peer#example-package--NewOutboundPeer)  
+* [New Outbound Peer Example](https://godoc.org/github.com/btcsuite/btcd/peer#example-package--NewOutboundPeer)  
   Demonstrates the basic process for initializing and creating an outbound peer.
   Peers negotiate by exchanging version and verack messages.  For demonstration,
   a simple handler for the version message is attached to the peer.

--- a/txscript/README.md
+++ b/txscript/README.md
@@ -1,11 +1,9 @@
 txscript
 ========
 
-[![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)]
-(https://travis-ci.org/btcsuite/btcd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://godoc.org/github.com/btcsuite/btcd/txscript?status.png)]
-(http://godoc.org/github.com/btcsuite/btcd/txscript)
+[![Build Status](https://travis-ci.org/btcsuite/btcd.png?branch=master)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://godoc.org/github.com/btcsuite/btcd/txscript?status.png)](http://godoc.org/github.com/btcsuite/btcd/txscript)
 
 Package txscript implements the bitcoin transaction script language.  There is
 a comprehensive test suite.
@@ -28,18 +26,15 @@ $ go get -u github.com/btcsuite/btcd/txscript
 
 ## Examples
 
-* [Standard Pay-to-pubkey-hash Script]
-  (http://godoc.org/github.com/btcsuite/btcd/txscript#example-PayToAddrScript)  
+* [Standard Pay-to-pubkey-hash Script](http://godoc.org/github.com/btcsuite/btcd/txscript#example-PayToAddrScript)  
   Demonstrates creating a script which pays to a bitcoin address.  It also
   prints the created script hex and uses the DisasmString function to display
   the disassembled script.
 
-* [Extracting Details from Standard Scripts]
-  (http://godoc.org/github.com/btcsuite/btcd/txscript#example-ExtractPkScriptAddrs)  
+* [Extracting Details from Standard Scripts](http://godoc.org/github.com/btcsuite/btcd/txscript#example-ExtractPkScriptAddrs)  
   Demonstrates extracting information from a standard public key script.
 
-* [Manually Signing a Transaction Output]
-  (http://godoc.org/github.com/btcsuite/btcd/txscript#example-SignTxOutput)  
+* [Manually Signing a Transaction Output](http://godoc.org/github.com/btcsuite/btcd/txscript#example-SignTxOutput)  
   Demonstrates manually creating and signing a redeem transaction.
 
 ## GPG Verification Key

--- a/wire/README.md
+++ b/wire/README.md
@@ -1,11 +1,9 @@
 wire
 ====
 
-[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)]
-(https://travis-ci.org/btcsuite/btcd) [![ISC License]
-(http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
-[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)]
-(http://godoc.org/github.com/btcsuite/btcd/wire)
+[![Build Status](http://img.shields.io/travis/btcsuite/btcd.svg)](https://travis-ci.org/btcsuite/btcd)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](http://godoc.org/github.com/btcsuite/btcd/wire)
 
 Package wire implements the bitcoin wire protocol.  A comprehensive suite of
 tests with 100% test coverage is provided to ensure proper functionality.


### PR DESCRIPTION
The github markdown interpreter has been changed such that it no longer allows spaces in between the brackets and parenthesis of links and now requires a newline in between anchors and other formatting.  This
updates all of the markdown files accordingly.

While here, it also corrects a couple of inconsistencies in some of the `README.md` files.