### PR TITLE
Fix warnings from ineffassign

### DIFF
--- a/addrmgr/knownaddress.go
+++ b/addrmgr/knownaddress.go
@@ -38,12 +38,8 @@ func (ka *KnownAddress) LastAttempt() time.Time {
 // attempted and how often attempts to connect to it have failed.
 func (ka *KnownAddress) chance() float64 {
 	now := time.Now()
-	lastSeen := now.Sub(ka.na.Timestamp)
 	lastAttempt := now.Sub(ka.lastattempt)
 
-	if lastSeen < 0 {
-		lastSeen = 0
-	}
 	if lastAttempt < 0 {
 		lastAttempt = 0
 	}

--- a/connmgr/tor.go
+++ b/connmgr/tor.go
@@ -99,7 +99,7 @@ func TorLookupIP(host, proxy string) ([]net.IP, error) {
 		return nil, ErrTorInvalidProxyResponse
 	}
 	if buf[1] != 0 {
-		if int(buf[1]) > len(torStatusErrors) {
+		if int(buf[1]) >= len(torStatusErrors) {
 			return nil, ErrTorInvalidProxyResponse
 		} else if err := torStatusErrors[buf[1]]; err != nil {
 			return nil, err

--- a/connmgr/tor.go
+++ b/connmgr/tor.go
@@ -100,14 +100,11 @@ func TorLookupIP(host, proxy string) ([]net.IP, error) {
 	}
 	if buf[1] != 0 {
 		if int(buf[1]) > len(torStatusErrors) {
-			err = ErrTorInvalidProxyResponse
-		} else {
-			err = torStatusErrors[buf[1]]
-			if err == nil {
-				err = ErrTorInvalidProxyResponse
-			}
+			return nil, ErrTorInvalidProxyResponse
+		} else if err := torStatusErrors[buf[1]]; err != nil {
+			return nil, err
 		}
-		return nil, err
+		return nil, ErrTorInvalidProxyResponse
 	}
 	if buf[3] != 1 {
 		err := torStatusErrors[torGeneralError]

--- a/server.go
+++ b/server.go
@@ -2260,7 +2260,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 					amgrLog.Warnf("Skipping specified external IP: %v", err)
 				}
 			}
-		} else if discover && cfg.Upnp {
+		} else if cfg.Upnp {
 			nat, err = Discover()
 			if err != nil {
 				srvrLog.Warnf("Can't discover upnp: %v", err)

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -362,7 +362,6 @@ func calcSignatureHash(script []parsedOpcode, hashType SigHashType, tx *wire.Msg
 	}
 	if hashType&SigHashAnyOneCanPay != 0 {
 		txCopy.TxIn = txCopy.TxIn[idx : idx+1]
-		idx = 0
 	}
 
 	// The final hash is the double sha256 of both the serialized modified

--- a/txscript/sign.go
+++ b/txscript/sign.go
@@ -190,7 +190,7 @@ func mergeScripts(chainParams *chaincfg.Params, tx *wire.MsgTx, idx int,
 		script := sigPops[len(sigPops)-1].data
 
 		// We already know this information somewhere up the stack.
-		class, addresses, nrequired, err :=
+		class, addresses, nrequired, _ :=
 			ExtractPkScriptAddrs(script, chainParams)
 
 		// regenerate scripts.


### PR DESCRIPTION
Some suggestions by [ineffassign](https://github.com/gordonklaus/ineffassign) that looks for unnecessary assignments.

I left two at the end of fullblocktest, since I suspected the unused
variable assignments there were set for the possibility of extending the
tests.

```
btcd/connmgr/tor.go
Line 107: warning: err assigned and not used (ineffassign)
btcd/server.go
Line 2227: warning: err assigned and not used (ineffassign)
btcd/txscript/script.go
Line 352: warning: idx assigned and not used (ineffassign)
btcd/txscript/sign.go
Line 193: warning: err assigned and not used (ineffassign)
btcd/addrmgr/knownaddress.go
Line 45: warning: lastSeen assigned and not used (ineffassign)
btcd/blockchain/fullblocktests/generate.go
Line 2131: warning: chain1TipName assigned and not used (ineffassign)
```