### PR TITLE
Fix a ton of typos accumulated over time

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -681,15 +681,15 @@ func (a *AddrManager) reset() {
 	}
 }
 
-// HostToNetAddress returns a netaddress given a host address. If the address is
-// a tor .onion address this will be taken care of. else if the host is not an
-// IP address it will be resolved (via tor if required).
+// HostToNetAddress returns a netaddress given a host address.  If the address
+// is a Tor .onion address this will be taken care of.  Else if the host is
+// not an IP address it will be resolved (via Tor if required).
 func (a *AddrManager) HostToNetAddress(host string, port uint16, services wire.ServiceFlag) (*wire.NetAddress, error) {
-	// tor address is 16 char base32 + ".onion"
+	// Tor address is 16 char base32 + ".onion"
 	var ip net.IP
 	if len(host) == 22 && host[16:] == ".onion" {
 		// go base32 encoding uses capitals (as does the rfc
-		// but tor and bitcoind tend to user lowercase, so we switch
+		// but Tor and bitcoind tend to user lowercase, so we switch
 		// case here.
 		data, err := base32.StdEncoding.DecodeString(
 			strings.ToUpper(host[:16]))
@@ -713,11 +713,11 @@ func (a *AddrManager) HostToNetAddress(host string, port uint16, services wire.S
 }
 
 // ipString returns a string for the ip from the provided NetAddress. If the
-// ip is in the range used for tor addresses then it will be transformed into
+// ip is in the range used for Tor addresses then it will be transformed into
 // the relevant .onion address.
 func ipString(na *wire.NetAddress) string {
 	if IsOnionCatTor(na) {
-		// We know now that na.IP is long enogh.
+		// We know now that na.IP is long enough.
 		base32 := base32.StdEncoding.EncodeToString(na.IP[6:])
 		return strings.ToLower(base32) + ".onion"
 	}

--- a/addrmgr/addrmanager_test.go
+++ b/addrmgr/addrmanager_test.go
@@ -441,7 +441,7 @@ func TestGetBestLocalAddress(t *testing.T) {
 		}
 	}
 	/*
-		// Add a tor generated IP address
+		// Add a Tor generated IP address
 		localAddr = wire.NetAddress{IP: net.ParseIP("fd87:d87e:eb43:25::1")}
 		amgr.AddLocalAddress(&localAddr, addrmgr.ManualPrio)
 

--- a/addrmgr/doc.go
+++ b/addrmgr/doc.go
@@ -28,11 +28,11 @@ generally helps provide greater peer diversity, and perhaps more importantly,
 drastically reduces the chances an attacker is able to coerce your peer into
 only connecting to nodes they control.
 
-The address manager also understands routability and tor addresses and tries
+The address manager also understands routability and Tor addresses and tries
 hard to only return routable addresses.  In addition, it uses the information
 provided by the caller about connected, known good, and attempted addresses to
 periodically purge peers which no longer appear to be good peers as well as
 bias the selection toward known good peers.  The general idea is to make a best
-effort at only providing usuable addresses.
+effort at only providing usable addresses.
 */
 package addrmgr

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -232,7 +232,7 @@ func IsRoutable(na *wire.NetAddress) bool {
 // GroupKey returns a string representing the network group an address is part
 // of.  This is the /16 for IPv4, the /32 (/36 for he.net) for IPv6, the string
 // "local" for a local address, the string "tor:key" where key is the /4 of the
-// onion address for tor address, and the string "unroutable" for an unroutable
+// onion address for Tor address, and the string "unroutable" for an unroutable
 // address.
 func GroupKey(na *wire.NetAddress) string {
 	if IsLocal(na) {

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -20,7 +20,7 @@ type ThresholdState byte
 // since these values are serialized and must be stable for long-term storage.
 const (
 	// ThresholdDefined is the first state for each deployment and is the
-	// state for the genesis block has by defintion for all deployments.
+	// state for the genesis block has by definition for all deployments.
 	ThresholdDefined ThresholdState = 0
 
 	// ThresholdStarted is the state for a deployment once its start time

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -638,7 +638,7 @@ func checkSerializedHeight(coinbaseTx *btcutil.Tx, wantHeight int32) error {
 	return nil
 }
 
-// checkBlockHeaderContext peforms several validation checks on the block header
+// checkBlockHeaderContext performs several validation checks on the block header
 // which depend on its position within the block chain.
 //
 // The flags modify the behavior of this function as follows:

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -225,7 +225,7 @@ func (b *blockManager) startSync(peers *list.List) {
 
 		// Remove sync candidate peers that are no longer candidates due
 		// to passing their latest known block.  NOTE: The < is
-		// intentional as opposed to <=.  While techcnically the peer
+		// intentional as opposed to <=.  While technically the peer
 		// doesn't have a later block when it's equal, it will likely
 		// have one soon so it is a reasonable choice.  It also allows
 		// the case where both are at 0 such as during regression test.

--- a/btcjson/help.go
+++ b/btcjson/help.go
@@ -536,7 +536,7 @@ func GenerateHelp(method string, descs map[string]string, resultTypes ...interfa
 	}
 
 	// Create a closure for the description lookup function which falls back
-	// to the base help descritptions map for unrecognized keys and tracks
+	// to the base help descriptions map for unrecognized keys and tracks
 	// and missing keys.
 	var missingKey string
 	xT := func(key string) string {

--- a/config.go
+++ b/config.go
@@ -723,7 +723,7 @@ func loadConfig() (*config, []string, error) {
 		return nil, nil, err
 	}
 
-	// Limit the max orphan count to a sane vlue.
+	// Limit the max orphan count to a sane value.
 	if cfg.MaxOrphanTxs < 0 {
 		str := "%s: The maxorphantx option may not be less than 0 " +
 			"-- parsed [%d]"

--- a/database/driver.go
+++ b/database/driver.go
@@ -35,7 +35,7 @@ type Driver struct {
 var drivers = make(map[string]*Driver)
 
 // RegisterDriver adds a backend database driver to available interfaces.
-// ErrDbTypeRegistered will be retruned if the database type for the driver has
+// ErrDbTypeRegistered will be returned if the database type for the driver has
 // already been registered.
 func RegisterDriver(driver Driver) error {
 	if _, exists := drivers[driver.DbType]; exists {

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -88,7 +88,7 @@ var (
 // MessageListeners defines callback function pointers to invoke with message
 // listeners for a peer. Any listener which is not set to a concrete callback
 // during peer initialization is ignored. Execution of multiple message
-// listeners occurs serially, so one callback blocks the excution of the next.
+// listeners occurs serially, so one callback blocks the execution of the next.
 //
 // NOTE: Unless otherwise documented, these listeners must NOT directly call any
 // blocking calls (such as WaitForShutdown) on the peer instance since the input

--- a/server.go
+++ b/server.go
@@ -791,7 +791,7 @@ func (sp *serverPeer) enforceNodeBloomFlag(cmd string) bool {
 		if sp.ProtocolVersion() >= wire.BIP0111Version &&
 			!cfg.DisableBanning {
 
-			// Disonnect the peer regardless of whether it was
+			// Disconnect the peer regardless of whether it was
 			// banned.
 			sp.addBanScore(100, 0, cmd)
 			sp.Disconnect()
@@ -1527,7 +1527,7 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 		}
 	// Request a list of the persistent (added) peers.
 	case getAddedNodesMsg:
-		// Respond with a slice of the relavent peers.
+		// Respond with a slice of the relevant peers.
 		peers := make([]*serverPeer, 0, len(state.persistentPeers))
 		for _, sp := range state.persistentPeers {
 			peers = append(peers, sp)
@@ -1565,7 +1565,7 @@ func (s *server) handleQuery(state *peerState, querymsg interface{}) {
 	}
 }
 
-// disconnectPeer attempts to drop the connection of a tageted peer in the
+// disconnectPeer attempts to drop the connection of a targeted peer in the
 // passed peer list. Targets are identified via usage of the passed
 // `compareFunc`, which should return `true` if the passed peer is the target
 // peer. This function returns true on success and false if the peer is unable

--- a/upnp.go
+++ b/upnp.go
@@ -50,10 +50,10 @@ import (
 type NAT interface {
 	// Get the external address from outside the NAT.
 	GetExternalAddress() (addr net.IP, err error)
-	// Add a port mapping for protocol ("udp" or "tcp") from externalport to
+	// Add a port mapping for protocol ("udp" or "tcp") from external port to
 	// internal port with description lasting for timeout.
 	AddPortMapping(protocol string, externalPort, internalPort int, description string, timeout int) (mappedExternalPort int, err error)
-	// Remove a previously added port mapping from externalport to
+	// Remove a previously added port mapping from external port to
 	// internal port.
 	DeletePortMapping(protocol string, externalPort, internalPort int) (err error)
 }

--- a/wire/protocol.go
+++ b/wire/protocol.go
@@ -63,7 +63,7 @@ const (
 	// getutxos and utxos commands (BIP0064).
 	SFNodeGetUTXO
 
-	// SFNodeBloom is a flag used to indiciate a peer supports bloom
+	// SFNodeBloom is a flag used to indicate a peer supports bloom
 	// filtering.
 	SFNodeBloom
 )


### PR DESCRIPTION
There's no typos in variables, so it should be just comments.