### PR TITLE
btcec: Optimize normalize and NAF, correct normalize, and add tests.

### DIFF
--- a/btcec/bench_test.go
+++ b/btcec/bench_test.go
@@ -111,3 +111,13 @@ func BenchmarkSigVerify(b *testing.B) {
 		sig.Verify(msgHash.Bytes(), &pubKey)
 	}
 }
+
+// BenchmarkFieldNormalize benchmarks how long it takes the internal field
+// to perform normalization (which includes modular reduction).
+func BenchmarkFieldNormalize(b *testing.B) {
+	// The normalize function is constant time so default value is fine.
+	f := new(fieldVal)
+	for i := 0; i < b.N; i++ {
+		f.Normalize()
+	}
+}

--- a/btcec/btcec.go
+++ b/btcec/btcec.go
@@ -747,9 +747,9 @@ func NAF(k []byte) ([]byte, []byte) {
 	}
 	if carry {
 		retPos[0] = 1
+		return retPos, retNeg
 	}
-
-	return retPos, retNeg
+	return retPos[1:], retNeg[1:]
 }
 
 // ScalarMult returns k*(Bx, By) where k is a big endian integer.


### PR DESCRIPTION
This modifies the normalize function of the internal field value to both optimize it and address an issue where the reduction could lead to an incorrect result with a small range of values along with some tests to ensure the behavior is correct.

It also contains contributions from @jimmysong to optimize NAF to avoid returning the unneeded bit when there is not a carry and adds a bunch of unit tests.

The following benchmark shows the relative speedups as a result of the optimization on my system.  In particular, the changes result in approximately a 14% speedup in Normalize, which ultimately translates to a 2% speedup in signature verifies.

```
benchmark                        old ns/op     new ns/op     delta
--------------------------------------------------------------------
BenchmarkAddJacobian             1364          1289          -5.50%
BenchmarkAddJacobianNotZOne      3150          3091          -1.87%
BenchmarkScalarBaseMult          134117        132816        -0.97%
BenchmarkScalarBaseMultLarge     135067        132966        -1.56%
BenchmarkScalarMult              411218        402217        -2.19%
BenchmarkSigVerify               671585        657833        -2.05%
BenchmarkFieldNormalize          36.0          31.0          -13.89%
```

Fixes #709.