### PR TITLE
blockchain: Correct invalid assertion.

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -321,8 +321,6 @@ func (b *BlockChain) addOrphanBlock(block *btcutil.Block) {
 	// Add to previous hash lookup index for faster dependency lookups.
 	prevHash := &block.MsgBlock().Header.PrevBlock
 	b.prevOrphans[*prevHash] = append(b.prevOrphans[*prevHash], oBlock)
-
-	return
 }
 
 // SequenceLock represents the converted relative lock-time in seconds, and

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -298,7 +298,7 @@ func decodeSpentTxOut(serialized []byte, stxo *spentTxOut, txVersion int32) (int
 		// it.  This should never happen unless there is database
 		// corruption or this function is being called without the
 		// proper state.
-		if txVersion == 0 {
+		if txVersion == -1 {
 			return offset, AssertError("decodeSpentTxOut called " +
 				"without a containing tx version when the " +
 				"serialized stxo that does not encode the " +
@@ -382,7 +382,7 @@ func deserializeSpendJournalEntry(serialized []byte, txns []*wire.MsgTx, view *U
 			// to detect this case and pull the tx version from the
 			// entry that contains the version information as just
 			// described.
-			var txVersion int32
+			txVersion := int32(-1)
 			originHash := &txIn.PreviousOutPoint.Hash
 			entry := view.LookupEntry(originHash)
 			if entry != nil {

--- a/blockchain/chainio_test.go
+++ b/blockchain/chainio_test.go
@@ -194,8 +194,9 @@ func TestStxoDecodeErrors(t *testing.T) {
 			bytesRead:  2,
 		},
 		{
-			name:       "no serialized tx version and passed 0",
+			name:       "no serialized tx version and passed -1",
 			stxo:       spentTxOut{},
+			txVersion:  -1,
 			serialized: hexToBytes("003205"),
 			errType:    AssertError(""),
 			bytesRead:  1,

--- a/blockchain/reorganization_test.go
+++ b/blockchain/reorganization_test.go
@@ -68,8 +68,6 @@ func TestReorganization(t *testing.T) {
 				"is an orphan\n", i)
 		}
 	}
-
-	return
 }
 
 // loadBlocks reads files containing bitcoin block data (gzipped but otherwise

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -105,7 +105,6 @@ func (entry *UtxoEntry) SpendOutput(outputIndex uint32) {
 
 	entry.modified = true
 	output.spent = true
-	return
 }
 
 // IsFullySpent returns whether or not the transaction the utxo entry represents
@@ -269,7 +268,6 @@ func (view *UtxoViewpoint) AddTxOuts(tx *btcutil.Tx, blockHeight int32) {
 			pkScript:   txOut.PkScript,
 		}
 	}
-	return
 }
 
 // connectTransaction updates the view by adding all new utxos created by the

--- a/btcjson/cmdparse.go
+++ b/btcjson/cmdparse.go
@@ -49,7 +49,7 @@ func MarshalCmd(id interface{}, cmd interface{}) ([]byte, error) {
 	// The provided command must not be nil.
 	rv := reflect.ValueOf(cmd)
 	if rv.IsNil() {
-		str := fmt.Sprint("the specified command is nil")
+		str := "the specified command is nil"
 		return nil, makeError(ErrInvalidType, str)
 	}
 

--- a/database/ffldb/blockio.go
+++ b/database/ffldb/blockio.go
@@ -710,7 +710,6 @@ func (s *blockStore) handleRollback(oldBlockFileNum, oldBlockOffset uint32) {
 			wc.curFileNum, err)
 		return
 	}
-	return
 }
 
 // scanBlockFiles searches the database directory for all flat block files to

--- a/peer/mruinvmap.go
+++ b/peer/mruinvmap.go
@@ -99,7 +99,6 @@ func (m *mruInventoryMap) Add(iv *wire.InvVect) {
 	// The limit hasn't been reached yet, so just add the new item.
 	node := m.invList.PushFront(iv)
 	m.invMap[*iv] = node
-	return
 }
 
 // Delete deletes the passed inventory item from the map (if it exists).

--- a/peer/mrunoncemap.go
+++ b/peer/mrunoncemap.go
@@ -97,7 +97,6 @@ func (m *mruNonceMap) Add(nonce uint64) {
 	// The limit hasn't been reached yet, so just add the new item.
 	node := m.nonceList.PushFront(nonce)
 	m.nonceMap[nonce] = node
-	return
 }
 
 // Delete deletes the passed nonce from the map (if it exists).

--- a/wire/msgaddr_test.go
+++ b/wire/msgaddr_test.go
@@ -95,8 +95,6 @@ func TestAddr(t *testing.T) {
 			"protocol version %d - got %v, want %v", pver,
 			maxPayload, wantPayload)
 	}
-
-	return
 }
 
 // TestAddrWire tests the MsgAddr wire encode and decode for various numbers

--- a/wire/msgblock_test.go
+++ b/wire/msgblock_test.go
@@ -65,8 +65,6 @@ func TestBlock(t *testing.T) {
 		t.Errorf("ClearTransactions: wrong transactions - got %v, want %v",
 			len(msg.Transactions), 0)
 	}
-
-	return
 }
 
 // TestBlockTxHashes tests the ability to generate a slice of all transaction

--- a/wire/msgfeefilter_test.go
+++ b/wire/msgfeefilter_test.go
@@ -59,8 +59,6 @@ func TestFeeFilterLatest(t *testing.T) {
 	if msg.MinFee != readmsg.MinFee {
 		t.Errorf("Should get same minfee for protocol version %d", pver)
 	}
-
-	return
 }
 
 // TestFeeFilterWire tests the MsgFeeFilter wire encode and decode for various protocol

--- a/wire/msgfilteradd_test.go
+++ b/wire/msgfilteradd_test.go
@@ -48,8 +48,6 @@ func TestFilterAddLatest(t *testing.T) {
 	if err != nil {
 		t.Errorf("decode of MsgFilterAdd failed [%v] err <%v>", buf, err)
 	}
-
-	return
 }
 
 // TestFilterAddCrossProtocol tests the MsgFilterAdd API when encoding with the

--- a/wire/msgfilterclear_test.go
+++ b/wire/msgfilterclear_test.go
@@ -34,8 +34,6 @@ func TestFilterClearLatest(t *testing.T) {
 			"protocol version %d - got %v, want %v", pver,
 			maxPayload, wantPayload)
 	}
-
-	return
 }
 
 // TestFilterClearCrossProtocol tests the MsgFilterClear API when encoding with

--- a/wire/msgfilterload_test.go
+++ b/wire/msgfilterload_test.go
@@ -48,8 +48,6 @@ func TestFilterLoadLatest(t *testing.T) {
 	if err != nil {
 		t.Errorf("decode of MsgFilterLoad failed [%v] err <%v>", buf, err)
 	}
-
-	return
 }
 
 // TestFilterLoadCrossProtocol tests the MsgFilterLoad API when encoding with

--- a/wire/msggetaddr_test.go
+++ b/wire/msggetaddr_test.go
@@ -33,8 +33,6 @@ func TestGetAddr(t *testing.T) {
 			"protocol version %d - got %v, want %v", pver,
 			maxPayload, wantPayload)
 	}
-
-	return
 }
 
 // TestGetAddrWire tests the MsgGetAddr wire encode and decode for various

--- a/wire/msggetblocks_test.go
+++ b/wire/msggetblocks_test.go
@@ -78,8 +78,6 @@ func TestGetBlocks(t *testing.T) {
 		t.Errorf("AddBlockLocatorHash: expected error on too many " +
 			"block locator hashes not received")
 	}
-
-	return
 }
 
 // TestGetBlocksWire tests the MsgGetBlocks wire encode and decode for various

--- a/wire/msggetdata_test.go
+++ b/wire/msggetdata_test.go
@@ -66,8 +66,6 @@ func TestGetData(t *testing.T) {
 		t.Errorf("NewMsgGetDataSizeHint: wrong cap for size hint - "+
 			"got %v, want %v", cap(msg.InvList), wantCap)
 	}
-
-	return
 }
 
 // TestGetDataWire tests the MsgGetData wire encode and decode for various

--- a/wire/msggetheaders_test.go
+++ b/wire/msggetheaders_test.go
@@ -65,8 +65,6 @@ func TestGetHeaders(t *testing.T) {
 		t.Errorf("AddBlockLocatorHash: expected error on too many " +
 			"block locator hashes not received")
 	}
-
-	return
 }
 
 // TestGetHeadersWire tests the MsgGetHeaders wire encode and decode for various

--- a/wire/msgheaders_test.go
+++ b/wire/msgheaders_test.go
@@ -55,8 +55,6 @@ func TestHeaders(t *testing.T) {
 		t.Errorf("AddBlockHeader: expected error on too many headers " +
 			"not received")
 	}
-
-	return
 }
 
 // TestHeadersWire tests the MsgHeaders wire encode and decode for various

--- a/wire/msginv_test.go
+++ b/wire/msginv_test.go
@@ -66,8 +66,6 @@ func TestInv(t *testing.T) {
 		t.Errorf("NewMsgInvSizeHint: wrong cap for size hint - "+
 			"got %v, want %v", cap(msg.InvList), wantCap)
 	}
-
-	return
 }
 
 // TestInvWire tests the MsgInv wire encode and decode for various numbers

--- a/wire/msgmempool_test.go
+++ b/wire/msgmempool_test.go
@@ -59,6 +59,4 @@ func TestMemPool(t *testing.T) {
 		s := "decode of MsgMemPool passed for old protocol version %v err <%v>"
 		t.Errorf(s, msg, err)
 	}
-
-	return
 }

--- a/wire/msgnotfound_test.go
+++ b/wire/msgnotfound_test.go
@@ -57,8 +57,6 @@ func TestNotFound(t *testing.T) {
 		t.Errorf("AddInvVect: expected error on too many inventory " +
 			"vectors not received")
 	}
-
-	return
 }
 
 // TestNotFoundWire tests the MsgNotFound wire encode and decode for various

--- a/wire/msgping_test.go
+++ b/wire/msgping_test.go
@@ -43,8 +43,6 @@ func TestPing(t *testing.T) {
 			"protocol version %d - got %v, want %v", pver,
 			maxPayload, wantPayload)
 	}
-
-	return
 }
 
 // TestPingBIP0031 tests the MsgPing API against the protocol version
@@ -91,8 +89,6 @@ func TestPingBIP0031(t *testing.T) {
 	if msg.Nonce == readmsg.Nonce {
 		t.Errorf("Should not get same nonce for protocol version %d", pver)
 	}
-
-	return
 }
 
 // TestPingCrossProtocol tests the MsgPing API when encoding with the latest

--- a/wire/msgpong_test.go
+++ b/wire/msgpong_test.go
@@ -61,8 +61,6 @@ func TestPongLatest(t *testing.T) {
 	if msg.Nonce != readmsg.Nonce {
 		t.Errorf("Should get same nonce for protocol version %d", pver)
 	}
-
-	return
 }
 
 // TestPongBIP0031 tests the MsgPong API against the protocol version
@@ -108,8 +106,6 @@ func TestPongBIP0031(t *testing.T) {
 	if msg.Nonce == readmsg.Nonce {
 		t.Errorf("Should not get same nonce for protocol version %d", pver)
 	}
-
-	return
 }
 
 // TestPongCrossProtocol tests the MsgPong API when encoding with the latest

--- a/wire/msgsendheaders_test.go
+++ b/wire/msgsendheaders_test.go
@@ -68,8 +68,6 @@ func TestSendHeaders(t *testing.T) {
 			"version %v err <%v>"
 		t.Errorf(s, msg, err)
 	}
-
-	return
 }
 
 // TestSendHeadersBIP0130 tests the MsgSendHeaders API against the protocol
@@ -95,8 +93,6 @@ func TestSendHeadersBIP0130(t *testing.T) {
 		t.Errorf("decode of MsgSendHeaders succeeded when it should " +
 			"have failed")
 	}
-
-	return
 }
 
 // TestSendHeadersCrossProtocol tests the MsgSendHeaders API when encoding with

--- a/wire/msgtx_test.go
+++ b/wire/msgtx_test.go
@@ -124,8 +124,6 @@ func TestTx(t *testing.T) {
 		t.Errorf("Copy: mismatched tx messages - got %v, want %v",
 			spew.Sdump(newMsg), spew.Sdump(msg))
 	}
-
-	return
 }
 
 // TestTxHash tests the ability to generate the hash of a transaction accurately.

--- a/wire/msgverack_test.go
+++ b/wire/msgverack_test.go
@@ -32,8 +32,6 @@ func TestVerAck(t *testing.T) {
 			"protocol version %d - got %v, want %v", pver,
 			maxPayload, wantPayload)
 	}
-
-	return
 }
 
 // TestVerAckWire tests the MsgVerAck wire encode and decode for various

--- a/wire/msgversion_test.go
+++ b/wire/msgversion_test.go
@@ -124,8 +124,6 @@ func TestVersion(t *testing.T) {
 	if !msg.HasService(SFNodeNetwork) {
 		t.Errorf("HasService: SFNodeNetwork service not set")
 	}
-
-	return
 }
 
 // TestVersionWire tests the MsgVersion wire encode and decode for various


### PR DESCRIPTION
**This PR builds on #964**

This corrects the assertion in the `decodeSpentTxOut` function so it does not improperly cause a panic when unwinding transactions during a reorg under certain circumstances.  In particular, the provided transaction
version that is passed when a stxo entry does not exist is now -1 in order to properly distinguish it from the zero value.

It also updates the tests accordingly.

This was discovered by the reorg on testnet from block `00000000000018c58c2d2816f03dac327d975a18af6edf1a369df67ecddaf816` to `0000000000001c1161a367156465cc6226e9f862d9c585f94db5779fdf5455ff`.