### PR TITLE
TravisCI: Don't run tests with race.

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -5,7 +5,6 @@
 # 3. go vet        (http://golang.org/cmd/vet)
 # 4. gosimple      (https://github.com/dominikh/go-simple)
 # 5. unconvert     (https://github.com/mdempsky/unconvert)
-# 6. race detector (http://blog.golang.org/race-detector)
 #
 # gometalinter (github.com/alecthomas/gometalinter) is used to run each static
 # checker.
@@ -36,4 +35,4 @@ test -z "$(gometalinter -j 4 --disable-all \
 --enable=gosimple \
 --enable=unconvert \
 --deadline=10m $linter_targets 2>&1 | grep -v 'ALL_CAPS\|OP_' 2>&1 | tee /dev/stderr)"
-env GORACE="halt_on_error=1" go test -race -tags rpctest $linter_targets
+go test -tags rpctest $linter_targets


### PR DESCRIPTION
This modifies the `goclean.sh` script that is executed on Travis to only run the tests without the race detector.

While it is nice to run the race detector on the tests, unfortunately there is a limit to the number of goroutines that can be launched while running it.  Since Travis is now much slower than it once was, this
causes a ton of false positive failures.