### PR TITLE
New RPC command to display the uptime of the server

### DIFF
--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -671,6 +671,14 @@ func NewSubmitBlockCmd(hexBlock string, options *SubmitBlockOptions) *SubmitBloc
 	}
 }
 
+// UptimeCmd defines the uptime JSON-RPC command.
+type UptimeCmd struct{}
+
+// NewUptimeCmd returns a new instance which can be used to issue an uptime JSON-RPC command.
+func NewUptimeCmd() *UptimeCmd {
+	return &UptimeCmd{}
+}
+
 // ValidateAddressCmd defines the validateaddress JSON-RPC command.
 type ValidateAddressCmd struct {
 	Address string
@@ -777,6 +785,7 @@ func init() {
 	MustRegisterCmd("setgenerate", (*SetGenerateCmd)(nil), flags)
 	MustRegisterCmd("stop", (*StopCmd)(nil), flags)
 	MustRegisterCmd("submitblock", (*SubmitBlockCmd)(nil), flags)
+	MustRegisterCmd("uptime", (*UptimeCmd)(nil), flags)
 	MustRegisterCmd("validateaddress", (*ValidateAddressCmd)(nil), flags)
 	MustRegisterCmd("verifychain", (*VerifyChainCmd)(nil), flags)
 	MustRegisterCmd("verifymessage", (*VerifyMessageCmd)(nil), flags)

--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -960,6 +960,17 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 		},
 		{
+			name: "uptime",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("uptime")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewUptimeCmd()
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"uptime","params":[],"id":1}`,
+			unmarshalled: &btcjson.UptimeCmd{},
+		},
+		{
 			name: "validateaddress",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("validateaddress", "1Address")

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -163,6 +163,7 @@ var rpcHandlersBeforeInit = map[string]commandHandler{
 	"setgenerate":           handleSetGenerate,
 	"stop":                  handleStop,
 	"submitblock":           handleSubmitBlock,
+	"uptime":                handleUptime,
 	"validateaddress":       handleValidateAddress,
 	"verifychain":           handleVerifyChain,
 	"verifymessage":         handleVerifyMessage,
@@ -267,6 +268,7 @@ var rpcLimited = map[string]struct{}{
 	"searchrawtransactions": {},
 	"sendrawtransaction":    {},
 	"submitblock":           {},
+	"uptime":                {},
 	"validateaddress":       {},
 	"verifymessage":         {},
 	"version":               {},
@@ -3311,6 +3313,11 @@ func handleSubmitBlock(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 
 	rpcsLog.Infof("Accepted block %s via submitblock", block.Hash())
 	return nil, nil
+}
+
+// handleUptime implements the uptime command.
+func handleUptime(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
+	return time.Now().Unix() - s.server.startupTime, nil
 }
 
 // handleValidateAddress implements the validateaddress command.

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -615,6 +615,10 @@ var helpDescsEnUS = map[string]string{
 	"rescannedblock-hash":         "Hash of the matching block.",
 	"rescannedblock-transactions": "List of matching transactions, serialized and hex-encoded.",
 
+	// Uptime help.
+	"uptime--synopsis": "Returns the total uptime of the server.",
+	"uptime--result0":  "The number of seconds that the server has been running",
+
 	// Version help.
 	"version--synopsis":       "Returns the JSON-RPC API version (semver)",
 	"version--result0--desc":  "Version objects keyed by the program or API name",
@@ -672,6 +676,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"setgenerate":           nil,
 	"stop":                  {(*string)(nil)},
 	"submitblock":           {nil, (*string)(nil)},
+	"uptime":                {(*int64)(nil)},
 	"validateaddress":       {(*btcjson.ValidateAddressChainResult)(nil)},
 	"verifychain":           {(*bool)(nil)},
 	"verifymessage":         {(*bool)(nil)},

--- a/server.go
+++ b/server.go
@@ -167,6 +167,7 @@ type server struct {
 	started       int32
 	shutdown      int32
 	shutdownSched int32
+	startupTime   int64
 
 	chainParams          *chaincfg.Params
 	addrManager          *addrmgr.AddrManager
@@ -2002,6 +2003,9 @@ func (s *server) Start() {
 	}
 
 	srvrLog.Trace("Starting server")
+
+	// Server startup time. Used for the uptime command for uptime calculation.
+	s.startupTime = time.Now().Unix()
 
 	// Start the peer handler which in turn starts the address and block
 	// managers.


### PR DESCRIPTION
Hello,

I have implemented a new RPC command that will be [available on version 0.15.0](https://github.com/bitcoin/bitcoin/commit/1680ee0edf46aa22c4d00c8ff4f3d0bcc235bc68) of the Bitcoin Core client.

The command allows the user to check how long (in seconds) the server has been running for. I have used btcsuite in the past so I decided to implement this change here as well.

Please review this PR and let me know of any changes/improvements required. I will also implement the command in the `btcrpcclient` package at a later date.

Thank you,
Ricardo Velhote