### PR TITLE
peer: Improve address sampling in PushAddrMsg.

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -846,21 +846,22 @@ func (p *Peer) localVersionMsg() (*wire.MsgVersion, error) {
 //
 // This function is safe for concurrent access.
 func (p *Peer) PushAddrMsg(addresses []*wire.NetAddress) ([]*wire.NetAddress, error) {
+	addressCount := len(addresses)
 
 	// Nothing to send.
-	if len(addresses) == 0 {
+	if addressCount == 0 {
 		return nil, nil
 	}
 
 	msg := wire.NewMsgAddr()
-	msg.AddrList = make([]*wire.NetAddress, len(addresses))
+	msg.AddrList = make([]*wire.NetAddress, addressCount)
 	copy(msg.AddrList, addresses)
 
 	// Randomize the addresses sent if there are more than the maximum allowed.
-	if len(msg.AddrList) > wire.MaxAddrPerMsg {
+	if addressCount > wire.MaxAddrPerMsg {
 		// Shuffle the address list.
-		for i := range msg.AddrList {
-			j := rand.Intn(i + 1)
+		for i := 0; i < wire.MaxAddrPerMsg; i++ {
+			j := i + rand.Intn(addressCount-i)
 			msg.AddrList[i], msg.AddrList[j] = msg.AddrList[j], msg.AddrList[i]
 		}
 


### PR DESCRIPTION
This changes fixes shuffling algorithm in PushAddrMsg to select a uniformly random subset of the given addresses using Fisher-Yates. As currently implemented, I'm pretty sure it does not produce a uniformly sampled permutation.