### PR TITLE
blockmanager: Decouple from server.

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4095,9 +4095,13 @@ func newRPCServer(listenAddrs []string, generator *mining.BlkTmplGenerator, s *s
 
 	rpc.listeners = listeners
 
+	s.chain.Subscribe(rpc.handleBlockchainNotification)
+
 	return &rpc, nil
 }
 
+// Callback for notifications from blockchain.  It notifies clients that are
+// long polling for changes or subscribed to websockets notifications.
 func (s *rpcServer) handleBlockchainNotification(notification *blockchain.Notification) {
 	switch notification.Type {
 	case blockchain.NTBlockAccepted:


### PR DESCRIPTION
This PR removes some unnecessary references from blockManager to server.

The blockManager uses the server to obtain a reference to the txMemPool, which it interacts with many times. Since one of the responsibilities of the blockManager is to keep the mempool in sync, it should have store its own reference. 

The blockManager also sends notifications to the RPC server, in response to chain events. I don't think the blockManager should know anything about the RPC server, so instead the RPC server will listen directly to notifications emitted from the BlockChain.

https://github.com/btcsuite/btcd/issues/978