### PR TITLE
rpcserver: Refactor listener logic to server.

### DIFF
--- a/server.go
+++ b/server.go
@@ -8,6 +8,7 @@ package main
 import (
 	"bytes"
 	"crypto/rand"
+	"crypto/tls"
 	"encoding/binary"
 	"errors"
 	"fmt"
@@ -2192,6 +2193,65 @@ out:
 	s.wg.Done()
 }
 
+// setupRPCListeners returns a slice of listners that are configured for use
+// with the RPC server depending on the configuration settings for listen
+// addresses and TLS.
+func setupRPCListeners() ([]net.Listener, error) {
+	// Setup TLS if not disabled.
+	listenFunc := net.Listen
+	if !cfg.DisableTLS {
+		// Generate the TLS cert and key file if both don't already
+		// exist.
+		if !fileExists(cfg.RPCKey) && !fileExists(cfg.RPCCert) {
+			err := genCertPair(cfg.RPCCert, cfg.RPCKey)
+			if err != nil {
+				return nil, err
+			}
+		}
+		keypair, err := tls.LoadX509KeyPair(cfg.RPCCert, cfg.RPCKey)
+		if err != nil {
+			return nil, err
+		}
+
+		tlsConfig := tls.Config{
+			Certificates: []tls.Certificate{keypair},
+			MinVersion:   tls.VersionTLS12,
+		}
+
+		// Change the standard net.Listen function to the tls one.
+		listenFunc = func(net string, laddr string) (net.Listener, error) {
+			return tls.Listen(net, laddr, &tlsConfig)
+		}
+	}
+
+	// TODO: This code is similar to the peer listener code.  It should be
+	// factored into something shared.
+	ipv4Addrs, ipv6Addrs, _, err := parseListeners(cfg.RPCListeners)
+	if err != nil {
+		return nil, err
+	}
+	listeners := make([]net.Listener, 0, len(ipv4Addrs)+len(ipv4Addrs))
+	for _, addr := range ipv4Addrs {
+		listener, err := listenFunc("tcp4", addr)
+		if err != nil {
+			rpcsLog.Warnf("Can't listen on %s: %v", addr, err)
+			continue
+		}
+		listeners = append(listeners, listener)
+	}
+
+	for _, addr := range ipv6Addrs {
+		listener, err := listenFunc("tcp6", addr)
+		if err != nil {
+			rpcsLog.Warnf("Can't listen on %s: %v", addr, err)
+			continue
+		}
+		listeners = append(listeners, listener)
+	}
+
+	return listeners, nil
+}
+
 // newServer returns a new btcd server configured to listen on addr for the
 // bitcoin network type specified by chainParams.  Use start to begin accepting
 // connections from peers.
@@ -2543,8 +2603,18 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	}
 
 	if !cfg.DisableRPC {
+		// Setup listeners for the configured RPC listen addresses and
+		// TLS settings.
+		rpcListeners, err := setupRPCListeners()
+		if err != nil {
+			return nil, err
+		}
+		if len(rpcListeners) == 0 {
+			return nil, errors.New("RPCS: No valid listen address")
+		}
+
 		s.rpcServer, err = newRPCServer(&rpcserverConfig{
-			ListenAddrs: cfg.RPCListeners,
+			Listeners:   rpcListeners,
 			StartupTime: s.startupTime,
 			ConnMgr:     &rpcConnManager{&s},
 			SyncMgr:     &rpcSyncMgr{&s, s.blockManager},


### PR DESCRIPTION
**This PR requires on #981 and is currently rebased on top of #982**.

This refactors the RPC server to accept and take ownership of already configured listeners and refactors the logic to setup those listeners to the server.  This mirrors the logic used by the connection manager and is desirable since it is another step closer to being able to split the RPC server code out into a separate package and will make it much easier to internally test since it allows creating mock listeners.
