### PR TITLE
blockmanager: Remove serverPeer references.

### DIFF
--- a/rpcadaptors.go
+++ b/rpcadaptors.go
@@ -258,12 +258,13 @@ func (b *rpcSyncMgr) Pause() chan<- struct{} {
 	return b.blockMgr.Pause()
 }
 
-// SyncPeer returns the peer that is currently the peer being used to sync from.
+// SyncPeerID returns the peer that is currently the peer being used to sync
+// from.
 //
 // This function is safe for concurrent access and is part of the
 // rpcserverSyncManager interface implementation.
-func (b *rpcSyncMgr) SyncPeer() rpcserverPeer {
-	return (*rpcPeer)(b.blockMgr.SyncPeer())
+func (b *rpcSyncMgr) SyncPeerID() int32 {
+	return b.blockMgr.SyncPeerID()
 }
 
 // LocateBlocks returns the hashes of the blocks after the first known block in

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2402,7 +2402,7 @@ func handleGetNetworkHashPS(s *rpcServer, cmd interface{}, closeChan <-chan stru
 // handleGetPeerInfo implements the getpeerinfo command.
 func handleGetPeerInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
 	peers := s.cfg.ConnMgr.ConnectedPeers()
-	syncPeer := s.cfg.SyncMgr.SyncPeer().ToPeer()
+	syncPeerID := s.cfg.SyncMgr.SyncPeerID()
 	infos := make([]*btcjson.GetPeerInfoResult, 0, len(peers))
 	for _, p := range peers {
 		statsSnap := p.ToPeer().StatsSnapshot()
@@ -2426,7 +2426,7 @@ func handleGetPeerInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{})
 			CurrentHeight:  statsSnap.LastBlock,
 			BanScore:       int32(p.BanScore()),
 			FeeFilter:      p.FeeFilter(),
-			SyncNode:       p.ToPeer() == syncPeer,
+			SyncNode:       statsSnap.ID == syncPeerID,
 		}
 		if p.ToPeer().LastPingNonce() != 0 {
 			wait := float64(time.Since(statsSnap.LastPingTime).Nanoseconds())
@@ -4139,9 +4139,9 @@ type rpcserverSyncManager interface {
 	// Pause pauses the sync manager until the returned channel is closed.
 	Pause() chan<- struct{}
 
-	// SyncPeer returns the peer that is currently the peer being used to
-	// sync from.
-	SyncPeer() rpcserverPeer
+	// SyncPeerID returns the ID of the peer that is currently the peer being
+	// used to sync from or 0 if there is none.
+	SyncPeerID() int32
 
 	// LocateBlocks returns the hashes of the blocks after the first known
 	// block in the provided locators until the provided stop hash or the


### PR DESCRIPTION
The purpose is to remove the dependency of blockmanager on serverPeer, which is defined in the main package. Instead, we split out some of the fields from serverPeer into a separate struct called peerSyncState in blockmanager.go. While they are in the same package now, this change makes it easier to move blockManager into its own package along with peerSyncState. The blockManager tracks a map of Peer pointers to the peer state and keeps it updated as peers connect and disconnect.

This further decouples blockManager from server on the path to https://github.com/btcsuite/btcd/issues/978.