### PR TITLE
main: Reduce shared state between server and blockManager.

### DIFF
--- a/server.go
+++ b/server.go
@@ -506,7 +506,7 @@ func (sp *serverPeer) OnTx(_ *peer.Peer, msg *wire.MsgTx) {
 	// processed and known good or bad.  This helps prevent a malicious peer
 	// from queuing up a bunch of bad transactions before disconnecting (or
 	// being disconnected) and wasting memory.
-	sp.server.blockManager.QueueTx(tx, sp)
+	sp.server.blockManager.QueueTx(tx, sp, sp.txProcessed)
 	<-sp.txProcessed
 }
 
@@ -532,7 +532,7 @@ func (sp *serverPeer) OnBlock(_ *peer.Peer, msg *wire.MsgBlock, buf []byte) {
 	// reference implementation processes blocks in the same
 	// thread and therefore blocks further messages until
 	// the bitcoin block has been fully processed.
-	sp.server.blockManager.QueueBlock(block, sp)
+	sp.server.blockManager.QueueBlock(block, sp, sp.blockProcessed)
 	<-sp.blockProcessed
 }
 


### PR DESCRIPTION
Instead of having both server and blockManager be aware of the txProcessed and blockProcessed channels, now the server passed them as method arguments to blockProcessor.

Works towards https://github.com/btcsuite/btcd/issues/978.