### PR TITLE
blockchain: Improve and correct chainview set tip.

### DIFF
--- a/blockchain/chainview.go
+++ b/blockchain/chainview.go
@@ -109,9 +109,15 @@ func (c *chainView) setTip(node *blockNode) {
 	// week.
 	needed := node.height + 1
 	if int32(cap(c.nodes)) < needed {
-		c.nodes = make([]*blockNode, needed, needed+approxNodesPerWeek)
+		nodes := make([]*blockNode, needed, needed+approxNodesPerWeek)
+		copy(nodes, c.nodes)
+		c.nodes = nodes
 	} else {
+		prevLen := int32(len(c.nodes))
 		c.nodes = c.nodes[0:needed]
+		for i := prevLen; i < needed; i++ {
+			c.nodes[i] = nil
+		}
 	}
 
 	for node != nil && c.nodes[node.height] != node {


### PR DESCRIPTION
This modifies the function to set the tip in the new chainview code to bulk copy existing nodes when it needs to expand the cap rather than simply creating a new empty slice and allowing the walk code below it to repopulate it.  This is a nice optimization since, in practice, most of the time expanding the cap is only required when the active chain is being extended after having run for a while which means the end result is that it will be able to bulk copy all the nodes and just add the most recent one versus having to walk them all and add them back.

Also, while here expand the tests for setting the tip to ensure the nodes contained in the resulting view are correct after forcing the resizes and correct a bug they exposed where changing between a longer-shorter-longer chain where the longer chain is the same chain could result in not populating the view correctly.

Finally, update the fake nodes generated by the tests to use a nonce generated by a deterministic prng in order to ensure the hashes of all fake nodes are unique, but reproducible.