### PR TITLE
blockchain: Convert seq lock tests to synthetic.

### DIFF
--- a/blockchain/internal_test.go
+++ b/blockchain/internal_test.go
@@ -14,6 +14,10 @@ package blockchain
 
 import (
 	"sort"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/wire"
 )
 
 // TstSetCoinbaseMaturity makes the ability to set the coinbase maturity
@@ -45,3 +49,51 @@ var TstCheckBlockScripts = checkBlockScripts
 // TstDeserializeUtxoEntry makes the internal deserializeUtxoEntry function
 // available to the test package.
 var TstDeserializeUtxoEntry = deserializeUtxoEntry
+
+// TstNewFakeChain returns a chain that is usable for syntetic tests.  It is
+// important to note that this chain has no database associated with it, so
+// it is not usable with all functions and the tests must take care when making
+// use of it.
+func TstNewFakeChain(params *chaincfg.Params) (*BlockChain, *blockNode) {
+	// Create a genesis block node and block index index populated with it
+	// for use when creating the fake chain below.
+	node := newBlockNode(&params.GenesisBlock.Header, 0)
+	node.inMainChain = true
+	index := newBlockIndex(nil, params)
+	index.AddNode(node)
+
+	targetTimespan := int64(params.TargetTimespan / time.Second)
+	targetTimePerBlock := int64(params.TargetTimePerBlock / time.Second)
+	adjustmentFactor := params.RetargetAdjustmentFactor
+	return &BlockChain{
+		chainParams:         params,
+		timeSource:          NewMedianTime(),
+		minRetargetTimespan: targetTimespan / adjustmentFactor,
+		maxRetargetTimespan: targetTimespan * adjustmentFactor,
+		blocksPerRetarget:   int32(targetTimespan / targetTimePerBlock),
+		index:               index,
+		warningCaches:       newThresholdCaches(vbNumBits),
+		deploymentCaches:    newThresholdCaches(chaincfg.DefinedDeployments),
+		bestNode:            node,
+	}, node
+}
+
+// TstNewFakeNode creates a block node connected to the passed parent with the
+// provided fields populated and fake values for the other fields and adds it
+// to the blockchain's index as well as makes it the best node.
+func (b *BlockChain) TstNewFakeNode(parent *blockNode, blockVersion int32, bits uint32, timestamp time.Time) *blockNode {
+	// Make up a header and create a block node from it.
+	header := &wire.BlockHeader{
+		Version:   blockVersion,
+		PrevBlock: parent.hash,
+		Bits:      bits,
+		Timestamp: timestamp,
+	}
+	node := newBlockNode(header, parent.height+1)
+	node.parent = parent
+	node.workSum.Add(parent.workSum, node.workSum)
+
+	b.index.AddNode(node)
+	b.bestNode = node
+	return node
+}


### PR DESCRIPTION
**NOTE: The linter error is resolved by #1018.  It can be ignored.**

This introduces the concept of a synthetic block chain that can be used in the tests to avoid needing setup a full blown chain instance with a database and generate valid blocks and converts the sequence lock tests in `TestCalcSequenceLock` to use it.

Not only does this speed up the test execution time, but it allows the dependency on `rpctest` to be removed which will allow the sequence locks tests to be consolidated into the main package without creating a circular dependency.