### PR TITLE
Update deps to pull in additional logging changes.

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 976decfaf173d97d2e4572399490637aa12e217312a7d8b28813780a738e1151
-updated: 2017-08-15T20:07:19.2012575-05:00
+updated: 2017-08-24T17:28:45.8117156-05:00
 imports:
 - name: github.com/btcsuite/btclog
-  version: 96c2a91a67da03552a5e6554fe3ccbfbc7f860be
+  version: 84c8d2346e9fc8c7b947e243b9c24e6df9fd206a
 - name: github.com/btcsuite/btcutil
   version: 501929d3d046174c3d39f0ea54ece471aa17238c
   subpackages:
@@ -47,7 +47,7 @@ imports:
 - name: github.com/jessevdk/go-flags
   version: 1679536dcc895411a9f5848d9a0250be7856448c
 - name: github.com/jrick/logrotate
-  version: 4ed05ed86ef17d10ff99cce77481e0fcf6f2c7b0
+  version: a93b200c26cbae3bb09dd0dc2c7c7fe1468a034a
   subpackages:
   - rotator
 - name: golang.org/x/crypto

--- a/log.go
+++ b/log.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 
@@ -31,7 +30,7 @@ type logWriter struct{}
 
 func (logWriter) Write(p []byte) (n int, err error) {
 	os.Stdout.Write(p)
-	logRotatorPipe.Write(p)
+	logRotator.Write(p)
 	return len(p), nil
 }
 
@@ -52,10 +51,6 @@ var (
 	// logRotator is one of the logging outputs.  It should be closed on
 	// application shutdown.
 	logRotator *rotator.Rotator
-
-	// logRotatorPipe is the write-end pipe for writing to the log rotator.  It
-	// is written to by the Write method of the logWriter type.
-	logRotatorPipe *io.PipeWriter
 
 	adxrLog = backendLog.Logger("ADXR")
 	amgrLog = backendLog.Logger("AMGR")
@@ -117,17 +112,13 @@ func initLogRotator(logFile string) {
 		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
 		os.Exit(1)
 	}
-	pr, pw := io.Pipe()
-	r, err := rotator.New(pr, logFile, 10*1024, false, 3)
+	r, err := rotator.New(logFile, 10*1024, false, 3)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
 		os.Exit(1)
 	}
 
-	go r.Run()
-
 	logRotator = r
-	logRotatorPipe = pw
 }
 
 // setLogLevel sets the logging level for provided subsystem.  Invalid


### PR DESCRIPTION
This update adds additional callsite logging options via `btclog` and fixes an error with the rotator package that caused it to stop running when creating any log messages larger than 4096 bytes.

While here, switch to the new Write method of the Rotator object as this is more efficient than using the Reader interface with a pipe.

Changes from @jrick.

Closes #1026.