### PR TITLE
travis: Update to go 1.8 and 1.9.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.6.x
-  - 1.7.x
+  - 1.8.x
+  - 1.9.x
 sudo: false
 install:
   - GLIDE_TAG=v0.12.3

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ which are both under active development.
 
 ## Requirements
 
-[Go](http://golang.org) 1.6 or newer.
+[Go](http://golang.org) 1.8 or newer.
 
 ## Installation
 

--- a/server.go
+++ b/server.go
@@ -1202,7 +1202,7 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 	if banEnd, ok := state.banned[host]; ok {
 		if time.Now().Before(banEnd) {
 			srvrLog.Debugf("Peer %s is banned for another %v - disconnecting",
-				host, banEnd.Sub(time.Now()))
+				host, time.Until(banEnd))
 			sp.Disconnect()
 			return false
 		}


### PR DESCRIPTION
Also, make the `gosimple` linter happy while here, and update `README.md` to call out the Go 1.8 minimum version requirement.