### PR TITLE
blockchain: Load all block headers into the block index on init.

### DIFF
--- a/database/error.go
+++ b/database/error.go
@@ -117,6 +117,10 @@ const (
 	// ErrBlockNotFound instead.
 	ErrBlockRegionInvalid
 
+	// ErrBlockHeightUnknown indicates there was an attempt to persist a block
+	// without a known height.
+	ErrBlockHeightUnknown
+
 	// ***********************************
 	// Support for driver-specific errors.
 	// ***********************************
@@ -153,6 +157,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrBlockNotFound:      "ErrBlockNotFound",
 	ErrBlockExists:        "ErrBlockExists",
 	ErrBlockRegionInvalid: "ErrBlockRegionInvalid",
+	ErrBlockHeightUnknown: "ErrBlockHeightUnknown",
 	ErrDriverSpecific:     "ErrDriverSpecific",
 }
 

--- a/database/error_test.go
+++ b/database/error_test.go
@@ -37,6 +37,7 @@ func TestErrorCodeStringer(t *testing.T) {
 		{database.ErrBlockNotFound, "ErrBlockNotFound"},
 		{database.ErrBlockExists, "ErrBlockExists"},
 		{database.ErrBlockRegionInvalid, "ErrBlockRegionInvalid"},
+		{database.ErrBlockHeightUnknown, "ErrBlockHeightUnknown"},
 		{database.ErrDriverSpecific, "ErrDriverSpecific"},
 
 		{0xffff, "Unknown ErrorCode (65535)"},

--- a/database/example_test.go
+++ b/database/example_test.go
@@ -135,8 +135,9 @@ func Example_blockStorageAndRetrieval() {
 	// read-write transaction and store a genesis block in the database as
 	// and example.
 	err = db.Update(func(tx database.Tx) error {
-		genesisBlock := chaincfg.MainNetParams.GenesisBlock
-		return tx.StoreBlock(btcutil.NewBlock(genesisBlock))
+		genesisBlock := btcutil.NewBlock(chaincfg.MainNetParams.GenesisBlock)
+		genesisBlock.SetHeight(0)
+		return tx.StoreBlock(genesisBlock)
 	})
 	if err != nil {
 		fmt.Println(err)

--- a/database/ffldb/db.go
+++ b/database/ffldb/db.go
@@ -74,6 +74,10 @@ var (
 	// writeLocKeyName is the key used to store the current write file
 	// location.
 	writeLocKeyName = []byte("ffldb-writeloc")
+
+	// blockIdxBucketName is the bucket used internally to track block
+	// metadata.
+	blockIdx2BucketName = []byte("ffldb-blockidx-v2")
 )
 
 // Common error strings.
@@ -945,21 +949,23 @@ func (b *bucket) Delete(key []byte) error {
 // pendingBlock houses a block that will be written to disk when the database
 // transaction is committed.
 type pendingBlock struct {
-	hash  *chainhash.Hash
-	bytes []byte
+	hash   *chainhash.Hash
+	bytes  []byte
+	height uint32
 }
 
 // transaction represents a database transaction.  It can either be read-only or
 // read-write and implements the database.Bucket interface.  The transaction
 // provides a root bucket against which all read and writes occur.
 type transaction struct {
-	managed        bool             // Is the transaction managed?
-	closed         bool             // Is the transaction closed?
-	writable       bool             // Is the transaction writable?
-	db             *db              // DB instance the tx was created from.
-	snapshot       *dbCacheSnapshot // Underlying snapshot for txns.
-	metaBucket     *bucket          // The root metadata bucket.
-	blockIdxBucket *bucket          // The block index bucket.
+	managed         bool             // Is the transaction managed?
+	closed          bool             // Is the transaction closed?
+	writable        bool             // Is the transaction writable?
+	db              *db              // DB instance the tx was created from.
+	snapshot        *dbCacheSnapshot // Underlying snapshot for txns.
+	metaBucket      *bucket          // The root metadata bucket.
+	blockIdxBucket  *bucket          // The v1 block index bucket.
+	blockIdx2Bucket *bucket          // The v2 block index bucket.
 
 	// Blocks that need to be stored on commit.  The pendingBlocks map is
 	// kept to allow quick lookups of pending data by block hash.
@@ -1132,7 +1138,7 @@ func (tx *transaction) hasBlock(hash *chainhash.Hash) bool {
 		return true
 	}
 
-	return tx.hasKey(bucketizedKey(blockIdxBucketID, hash[:]))
+	return tx.hasKey(bucketizedKey(tx.blockIdxBucket.id, hash[:]))
 }
 
 // StoreBlock stores the provided block into the database.  There are no checks
@@ -1172,6 +1178,12 @@ func (tx *transaction) StoreBlock(block *btcutil.Block) error {
 		return makeDbErr(database.ErrDriverSpecific, str, err)
 	}
 
+	if block.Height() == btcutil.BlockHeightUnknown {
+		str := fmt.Sprintf("cannot store block %s with unknown height",
+			blockHash)
+		return makeDbErr(database.ErrBlockHeightUnknown, str, err)
+	}
+
 	// Add the block to be stored to the list of pending blocks to store
 	// when the transaction is committed.  Also, add it to pending blocks
 	// map so it is easy to determine the block is pending based on the
@@ -1181,8 +1193,9 @@ func (tx *transaction) StoreBlock(block *btcutil.Block) error {
 	}
 	tx.pendingBlocks[*blockHash] = len(tx.pendingBlockData)
 	tx.pendingBlockData = append(tx.pendingBlockData, pendingBlock{
-		hash:  blockHash,
-		bytes: blockBytes,
+		hash:   blockHash,
+		bytes:  blockBytes,
+		height: uint32(block.Height()),
 	})
 	log.Tracef("Added block %s to pending blocks", blockHash)
 
@@ -1329,6 +1342,99 @@ func (tx *transaction) FetchBlockHeaders(hashes []chainhash.Hash) ([][]byte, err
 	}
 
 	return headers, nil
+}
+
+// GetBlockCount counts all blocks stored in the database. This function has to
+// iterate a cursor over all blocks and thus is relatively slow.
+//
+// The interface contract guarantees at least the following errors will
+// be returned (other implementation-specific errors are possible):
+//   - ErrTxClosed if the transaction has already been closed
+//
+// This function is part of the database.Tx interface implementation.
+func (tx *transaction) GetBlockCount() (uint32, error) {
+	// Ensure transaction state is valid.
+	if err := tx.checkClosed(); err != nil {
+		return 0, err
+	}
+
+	count := uint32(len(tx.pendingBlockData))
+	cursor := tx.blockIdx2Bucket.Cursor()
+	for ok := cursor.First(); ok; ok = cursor.Next() {
+		count++
+	}
+	return count, nil
+}
+
+// ForEachBlockHeader iterates through each stored block header and invokes
+// the passed function with the raw serialized bytes for each one.  The raw
+// bytes are in the format returned by Serialize on a wire.BlockHeader.  The
+// function is called with block headers ordered ascending by height from
+// the genesis block, so it is guaranteed to be called with a parent block
+// before any child blocks.
+//
+// WARNING: It is not safe to mutate data while iterating with this
+// method.  Doing so may cause the underlying cursor to be invalidated
+// and return unexpected keys and/or values.
+//
+// The interface contract guarantees at least the following errors will
+// be returned (other implementation-specific errors are possible):
+//   - ErrTxClosed if the transaction has already been closed
+//
+// NOTE: The slices returned by this function are only valid during a
+// transaction.  Attempting to access them after a transaction has ended
+// results in undefined behavior.  Additionally, the slices must NOT
+// be modified by the caller.  These constraints prevent additional data
+// copies and allows support for memory-mapped database implementations.
+//
+// This function is part of the database.Tx interface implementation.
+func (tx *transaction) ForEachBlockHeader(fn func(headerBytes []byte) error) error {
+	// Ensure transaction state is valid.
+	if err := tx.checkClosed(); err != nil {
+		return err
+	}
+
+	bucket := tx.blockIdx2Bucket
+	c := newCursor(bucket, bucket.id[:], ctKeys)
+	defer cursorFinalizer(c)
+
+	// Callback must be called with headers in ascending order by height, so we
+	// need to iterate through the pending blocks and stored blocks in parallel.
+	cursorValid := c.First()
+	pendingIdx := 0
+	cursorBlkHeight := -1
+	pendingBlkHeight := -1
+	for cursorValid || pendingIdx < len(tx.pendingBlockData) {
+		if cursorValid && cursorBlkHeight == -1 {
+			cursorBlkHeight = int(binary.BigEndian.Uint32(c.Key()))
+		}
+		if pendingIdx < len(tx.pendingBlockData) && pendingBlkHeight == -1 {
+			pendingBlkHeight = int(tx.pendingBlockData[pendingIdx].height)
+		}
+
+		// Determine whether the next stored block or pending block has a lesser
+		// height, then invoke callback with that one and increment pointer.
+		var headerBytes []byte
+		useCursorData := (pendingBlkHeight == -1) ||
+			(cursorBlkHeight != -1 && cursorBlkHeight < pendingBlkHeight)
+		if useCursorData {
+			endOffset := blockLocSize + blockHdrSize
+			headerBytes = c.Value()[blockLocSize:endOffset:endOffset]
+			cursorValid = c.Next()
+			cursorBlkHeight = -1
+		} else {
+			block := tx.pendingBlockData[pendingIdx]
+			headerBytes = block.bytes[0:blockHdrSize:blockHdrSize]
+			pendingIdx++
+			pendingBlkHeight = -1
+		}
+
+		if err := fn(headerBytes); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // FetchBlock returns the raw serialized bytes for the block identified by the
@@ -1669,6 +1775,16 @@ func serializeBlockRow(blockLoc blockLocation, blockHdr []byte) []byte {
 	return serializedRow
 }
 
+// blockIndexKey generates the binary key for an entry in the block index v2
+// bucket. The key is composed of the block height encoded as a big-endian
+// 32-bit unsigned int followed by the 32 byte block hash.
+func blockIndexKey(blockHash *chainhash.Hash, blockHeight uint32) []byte {
+	indexKey := make([]byte, chainhash.HashSize+4)
+	binary.BigEndian.PutUint32(indexKey[0:4], blockHeight)
+	copy(indexKey[4:chainhash.HashSize+4], blockHash[:])
+	return indexKey
+}
+
 // writePendingAndCommit writes pending block data to the flat block files,
 // updates the metadata with their locations as well as the new current write
 // location, and commits the metadata to the memory database cache.  It also
@@ -1708,7 +1824,15 @@ func (tx *transaction) writePendingAndCommit() error {
 		// so commonly needed.
 		blockHdr := blockData.bytes[0:blockHdrSize]
 		blockRow := serializeBlockRow(location, blockHdr)
+
 		err = tx.blockIdxBucket.Put(blockData.hash[:], blockRow)
+		if err != nil {
+			rollback()
+			return err
+		}
+
+		blockIdxKey := blockIndexKey(blockData.hash, blockData.height)
+		err = tx.blockIdx2Bucket.Put(blockIdxKey, blockRow)
 		if err != nil {
 			rollback()
 			return err
@@ -1790,6 +1914,9 @@ type db struct {
 	closed    bool         // Is the database closed?
 	store     *blockStore  // Handles read/writing blocks to flat files.
 	cache     *dbCache     // Cache layer which wraps underlying leveldb DB.
+
+	// Stored IDs of internal buckets
+	blockIdx2BucketID [4]byte
 }
 
 // Enforce db implements the database.DB interface.
@@ -1855,6 +1982,12 @@ func (db *db) begin(writable bool) (*transaction, error) {
 	}
 	tx.metaBucket = &bucket{tx: tx, id: metadataBucketID}
 	tx.blockIdxBucket = &bucket{tx: tx, id: blockIdxBucketID}
+
+	// This should be set for all transactions created after openDB completes
+	if metadataBucketID != db.blockIdx2BucketID {
+		tx.blockIdx2Bucket = &bucket{tx: tx, id: db.blockIdx2BucketID}
+	}
+
 	return tx, nil
 }
 
@@ -2024,9 +2157,21 @@ func initDB(ldb *leveldb.DB) error {
 	// there is no need to store the bucket index data for the metadata
 	// bucket in the database.  However, the first bucket ID to use does
 	// need to account for it to ensure there are no key collisions.
-	batch.Put(bucketIndexKey(metadataBucketID, blockIdxBucketName),
-		blockIdxBucketID[:])
-	batch.Put(curBucketIDKeyName, blockIdxBucketID[:])
+	//
+	// NOTE: Also note that blockIdxBucketName must be the first entry because
+	// its ID is hardcoded to 0x01. This can be removed when the bucket is
+	// permanently deprecated.
+	var currentBucketNum uint32
+	var currentBucketID [4]byte
+
+	initialBuckets := [][]byte{blockIdxBucketName, blockIdx2BucketName}
+	for _, bucketName := range initialBuckets {
+		currentBucketNum++
+		binary.BigEndian.PutUint32(currentBucketID[:], currentBucketNum)
+		batch.Put(bucketIndexKey(metadataBucketID, bucketName),
+			currentBucketID[:])
+	}
+	batch.Put(curBucketIDKeyName, currentBucketID[:])
 
 	// Write everything as a single batch.
 	if err := ldb.Write(batch, nil); err != nil {
@@ -2080,5 +2225,34 @@ func openDB(dbPath string, network wire.BitcoinNet, create bool) (database.DB, e
 
 	// Perform any reconciliation needed between the block and metadata as
 	// well as database initialization, if needed.
-	return reconcileDB(pdb, create)
+	if _, err := reconcileDB(pdb, create); err != nil {
+		return nil, err
+	}
+
+	if !create {
+		// Run all required data migrations
+		if err := migrateBlockIndex(pdb); err != nil {
+			return nil, err
+		}
+	}
+
+	// Lookup bucket IDs for internal buckets
+	err = pdb.View(func(dbTxUncast database.Tx) error {
+		dbTx := dbTxUncast.(*transaction)
+
+		bucketKey := bucketIndexKey(metadataBucketID, blockIdx2BucketName)
+		bucketID := dbTx.fetchKey(bucketKey)
+		if bucketID == nil {
+			message := "Database is missing internal bucket: blockIdx2Bucket"
+			return makeDbErr(database.ErrBucketNotFound, message, nil)
+		}
+		copy(pdb.blockIdx2BucketID[:], bucketID)
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return pdb, nil
 }

--- a/database/ffldb/driver_test.go
+++ b/database/ffldb/driver_test.go
@@ -172,6 +172,7 @@ func TestPersistence(t *testing.T) {
 		"b1key3": "foo3",
 	}
 	genesisBlock := btcutil.NewBlock(chaincfg.MainNetParams.GenesisBlock)
+	genesisBlock.SetHeight(0)
 	genesisHash := chaincfg.MainNetParams.GenesisHash
 	err = db.Update(func(tx database.Tx) error {
 		metadataBucket := tx.Metadata()

--- a/database/ffldb/migrate.go
+++ b/database/ffldb/migrate.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2015-2017 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package ffldb
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/database"
+	"github.com/btcsuite/btcd/wire"
+)
+
+const (
+	// migrationSuccessVal is the single-byte value stored with a migration key
+	// after the migration successfully completes.
+	migrationSuccessVal = 0x01
+)
+
+var (
+	// blockIdxMigrationKey is a special key stored in the blockIdxBucket after
+	// all entries have been migrated to the new blockIdx2Bucket.
+	blockIdxMigrationKey = []byte("migration-complete")
+)
+
+// zeroHash is the zero value hash (all zeros).  It is defined as a convenience.
+var zeroHash chainhash.Hash
+
+// migrateBlockIndex migrates all block entries from the v1 block index bucket
+// to the v2 bucket. The v1 bucket stores all block entries keyed by block hash,
+// whereas the v2 bucket stores the exact same values, but keyed instead by
+// block height + hash.
+func migrateBlockIndex(db *db) error {
+	migrated := false
+	err := db.Update(func(dbTx database.Tx) error {
+		oldBlockIdxBucket := dbTx.Metadata().Bucket(blockIdxBucketName)
+		if oldBlockIdxBucket == nil {
+			return makeDbErr(database.ErrBucketNotFound, "Block index bucket does not exist", nil)
+		}
+
+		migrationStatus := oldBlockIdxBucket.Get(blockIdxMigrationKey)
+		if migrationComplete(migrationStatus) {
+			return nil
+		}
+
+		log.Info("Re-indexing block information in the database. This might take a while...")
+		migrated = true
+
+		newBlockIdxBucket, err := dbTx.Metadata().CreateBucketIfNotExists(
+			blockIdx2BucketName)
+		if err != nil {
+			return err
+		}
+
+		// Scan the old block index bucket and construct a mapping of each block
+		// to all child blocks.
+		childBlocksMap, err := readBlockTree(oldBlockIdxBucket)
+		if err != nil {
+			return err
+		}
+
+		// Use the block graph to calculate the height of each block.
+		blockHeights := determineBlockHeights(childBlocksMap)
+
+		// Now that we have heights for all blocks, scan the old block index
+		// bucket and insert all rows into the new one.
+		err = oldBlockIdxBucket.ForEach(func(hashBytes, blockRow []byte) error {
+			var hash chainhash.Hash
+			copy(hash[:], hashBytes[0:chainhash.HashSize])
+			height, exists := blockHeights[hash]
+			if !exists {
+				message := fmt.Sprintf("Unable to calculate chain height for stored block %s", hash)
+				return makeDbErr(database.ErrCorruption, message, nil)
+			}
+
+			key := blockIndexKey(&hash, height)
+			return newBlockIdxBucket.Put(key, blockRow)
+		})
+		if err != nil {
+			return err
+		}
+
+		// Set migration status to success
+		err = oldBlockIdxBucket.Put(blockIdxMigrationKey,
+			[]byte{migrationSuccessVal})
+		return err
+	})
+
+	if err != nil {
+		return err
+	}
+
+	if migrated {
+		log.Infof("Block database upgrade complete")
+	}
+	return nil
+}
+
+// readBlockTree reads the old block index bucket and constructs a mapping of
+// each block to all child blocks. This mapping represents the full tree of
+// blocks.
+func readBlockTree(oldBlockIdxBucket database.Bucket) (map[chainhash.Hash][]*chainhash.Hash, error) {
+	childBlocksMap := make(map[chainhash.Hash][]*chainhash.Hash)
+	err := oldBlockIdxBucket.ForEach(func(_, blockRow []byte) error {
+		var header wire.BlockHeader
+		endOffset := blockLocSize + blockHdrSize
+		headerBytes := blockRow[blockLocSize:endOffset:endOffset]
+		err := header.Deserialize(bytes.NewReader(headerBytes))
+		if err != nil {
+			return err
+		}
+
+		blockHash := header.BlockHash()
+		childBlocksMap[header.PrevBlock] =
+			append(childBlocksMap[header.PrevBlock], &blockHash)
+		return nil
+	})
+	return childBlocksMap, err
+}
+
+// determineBlockHeights takes a map of block hashes to a slice of child hashes
+// and uses it to compute the height for each block. The function assigns a
+// height of 0 to the genesis hash and explores the tree of blocks
+// breadth-first, assigning a height to every block with a path back to the
+// genesis block.
+func determineBlockHeights(childBlocksMap map[chainhash.Hash][]*chainhash.Hash) map[chainhash.Hash]uint32 {
+	blockHeights := make(map[chainhash.Hash]uint32)
+	queue := list.New()
+
+	// The genesis block is included in childBlocksMap as a child of the zero
+	// hash because that is the value of the PrevBlock field in the genesis
+	// header.
+	for _, genesisHash := range childBlocksMap[zeroHash] {
+		blockHeights[*genesisHash] = 0
+		queue.PushBack(genesisHash)
+	}
+
+	for e := queue.Front(); e != nil; e = queue.Front() {
+		queue.Remove(e)
+		hash := e.Value.(*chainhash.Hash)
+		height := blockHeights[*hash]
+
+		// For each block with this one as a parent, assign it a height and
+		// push to queue for future processing.
+		for _, childHash := range childBlocksMap[*hash] {
+			blockHeights[*childHash] = height + 1
+			queue.PushBack(childHash)
+		}
+	}
+	return blockHeights
+}
+
+// migrationComplete takes a value from the database indicating the status of a
+// migration and returns whether the migration has already completed.
+func migrationComplete(status []byte) bool {
+	return len(status) == 1 && status[0] == migrationSuccessVal
+}

--- a/database/ffldb/whitebox_test.go
+++ b/database/ffldb/whitebox_test.go
@@ -285,6 +285,11 @@ func resetDatabase(tc *testContext) bool {
 		}
 
 		_, err = tx.Metadata().CreateBucket(blockIdx2BucketName)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.Metadata().CreateBucket(blockHashBucketName)
 		return err
 	})
 	if err != nil {

--- a/database/ffldb/whitebox_test.go
+++ b/database/ffldb/whitebox_test.go
@@ -57,10 +57,11 @@ func loadBlocks(t *testing.T, dataFile string, network wire.BitcoinNet) ([]*btcu
 	// Set the first block as the genesis block.
 	blocks := make([]*btcutil.Block, 0, 256)
 	genesis := btcutil.NewBlock(chaincfg.MainNetParams.GenesisBlock)
+	genesis.SetHeight(0)
 	blocks = append(blocks, genesis)
 
 	// Load the remaining blocks.
-	for height := 1; ; height++ {
+	for height := int32(1); ; height++ {
 		var net uint32
 		err := binary.Read(dr, binary.LittleEndian, &net)
 		if err == io.EOF {
@@ -96,6 +97,7 @@ func loadBlocks(t *testing.T, dataFile string, network wire.BitcoinNet) ([]*btcu
 
 		// Deserialize and store the block.
 		block, err := btcutil.NewBlockFromBytes(blockBytes)
+		block.SetHeight(height)
 		if err != nil {
 			t.Errorf("Failed to parse block %v: %v", height, err)
 			return nil, err
@@ -278,6 +280,11 @@ func resetDatabase(tc *testContext) bool {
 		}
 
 		_, err := tx.Metadata().CreateBucket(blockIdxBucketName)
+		if err != nil {
+			return err
+		}
+
+		_, err = tx.Metadata().CreateBucket(blockIdx2BucketName)
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
Currently only the blocks in the active chain are loaded into the block index on initialization. This instead iterates over the entire block index bucket in LevelDB and loads all nodes.

In order to do so efficiently, we switch the key format for the blocks in LevelDB to be prefixed with the block height encoded as big-endian, so when iterating over keys, we always see blocks in order of height.

This adds a database migration at startup to sync the old block index bucket with the new experimental one.