### PR TITLE
blockchain: Load all block headers into the block index on init.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -46,7 +46,7 @@ func (b *BlockChain) maybeAcceptBlock(block *btcutil.Block, flags BehaviorFlags)
 	// such as making blocks that never become part of the main chain or
 	// blocks that fail to connect available for further analysis.
 	err = b.db.Update(func(dbTx database.Tx) error {
-		return dbMaybeStoreBlock(dbTx, block)
+		return dbStoreBlock(dbTx, block)
 	})
 	if err != nil {
 		return false, err

--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -55,12 +55,7 @@ func (b *BlockChain) maybeAcceptBlock(block *btcutil.Block, flags BehaviorFlags)
 	// Create a new block node for the block and add it to the in-memory
 	// block chain (could be either a side chain or the main chain).
 	blockHeader := &block.MsgBlock().Header
-	newNode := newBlockNode(blockHeader, blockHeight)
-	if prevNode != nil {
-		newNode.parent = prevNode
-		newNode.height = blockHeight
-		newNode.workSum.Add(prevNode.workSum, newNode.workSum)
-	}
+	newNode := newBlockNode(blockHeader, prevNode)
 	b.index.AddNode(newNode)
 
 	// Connect the passed block to the chain while respecting proper chain

--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -86,7 +86,7 @@ func newBlockNode(blockHeader *wire.BlockHeader, height int32) *blockNode {
 // This function is safe for concurrent access.
 func (node *blockNode) Header() wire.BlockHeader {
 	// No lock is needed because all accessed fields are immutable.
-	prevHash := zeroHash
+	prevHash := &zeroHash
 	if node.parent != nil {
 		prevHash = &node.parent.hash
 	}

--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -51,33 +51,33 @@ type blockNode struct {
 	merkleRoot chainhash.Hash
 }
 
-// initBlockNode initializes a block node from the given header and height.  The
-// node is completely disconnected from the chain and the workSum value is just
-// the work for the passed block.  The work sum must be updated accordingly when
-// the node is inserted into a chain.
-//
+// initBlockNode initializes a block node from the given header and parent node,
+// calculating the height and workSum from the respective fields on the parent.
 // This function is NOT safe for concurrent access.  It must only be called when
 // initially creating a node.
-func initBlockNode(node *blockNode, blockHeader *wire.BlockHeader, height int32) {
+func initBlockNode(node *blockNode, blockHeader *wire.BlockHeader, parent *blockNode) {
 	*node = blockNode{
 		hash:       blockHeader.BlockHash(),
 		workSum:    CalcWork(blockHeader.Bits),
-		height:     height,
 		version:    blockHeader.Version,
 		bits:       blockHeader.Bits,
 		nonce:      blockHeader.Nonce,
 		timestamp:  blockHeader.Timestamp.Unix(),
 		merkleRoot: blockHeader.MerkleRoot,
 	}
+	if parent != nil {
+		node.parent = parent
+		node.height = parent.height + 1
+		node.workSum = node.workSum.Add(parent.workSum, node.workSum)
+	}
 }
 
-// newBlockNode returns a new block node for the given block header.  It is
-// completely disconnected from the chain and the workSum value is just the work
-// for the passed block.  The work sum must be updated accordingly when the node
-// is inserted into a chain.
-func newBlockNode(blockHeader *wire.BlockHeader, height int32) *blockNode {
+// newBlockNode returns a new block node for the given block header and parent
+// node, calculating the height and workSum from the respective fields on the
+// parent. This function is NOT safe for concurrent access.
+func newBlockNode(blockHeader *wire.BlockHeader, parent *blockNode) *blockNode {
 	var node blockNode
-	initBlockNode(&node, blockHeader, height)
+	initBlockNode(&node, blockHeader, parent)
 	return &node
 }
 

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -523,20 +523,6 @@ func (b *BlockChain) getReorganizeNodes(node *blockNode) (*list.List, *list.List
 	return detachNodes, attachNodes
 }
 
-// dbMaybeStoreBlock stores the provided block in the database if it's not
-// already there.
-func dbMaybeStoreBlock(dbTx database.Tx, block *btcutil.Block) error {
-	hasBlock, err := dbTx.HasBlock(block.Hash())
-	if err != nil {
-		return err
-	}
-	if hasBlock {
-		return nil
-	}
-
-	return dbTx.StoreBlock(block)
-}
-
 // connectBlock handles connecting the passed node/block to the end of the main
 // (best) chain.
 //

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1191,7 +1191,7 @@ func (b *BlockChain) initChainState() error {
 		// number of nodes are already known, perform a single alloc
 		// for them versus a whole bunch of little ones to reduce
 		// pressure on the GC.
-		log.Infof("Loading block index.  This might take a while...")
+		log.Infof("Loading block index...")
 
 		blockIndexBucket := dbTx.Metadata().Bucket(blockIndexBucketName)
 

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1071,7 +1071,7 @@ func (b *BlockChain) createChainState() error {
 	genesisBlock := btcutil.NewBlock(b.chainParams.GenesisBlock)
 	genesisBlock.SetHeight(0)
 	header := &genesisBlock.MsgBlock().Header
-	node := newBlockNode(header, 0)
+	node := newBlockNode(header, nil)
 	b.bestChain.SetTip(node)
 
 	// Add the new node to the index which is used for faster lookups.
@@ -1215,35 +1215,36 @@ func (b *BlockChain) initChainState() error {
 				return err
 			}
 
-			// Initialize the block node for the block, connect it,
-			// and add it to the block index.
-			node := &blockNodes[i]
-			initBlockNode(node, &header, 0)
+			// Determine the parent block node. Since we iterate block headers
+			// in order of height, if the blocks are mostly linear there is a
+			// very good chance the previous header processed is the parent.
+			var parent *blockNode
 			if lastNode == nil {
-				if node.hash != *b.chainParams.GenesisHash {
+				blockHash := header.BlockHash()
+				if !blockHash.IsEqual(b.chainParams.GenesisHash) {
 					return AssertError(fmt.Sprintf("initChainState: Expected "+
 						"first entry in block index to be genesis block, "+
-						"found %s", header.BlockHash()))
+						"found %s", blockHash))
 				}
-			} else {
+			} else if header.PrevBlock == lastNode.hash {
 				// Since we iterate block headers in order of height, if the
 				// blocks are mostly linear there is a very good chance the
 				// previous header processed is the parent.
-				parent := lastNode
-				if header.PrevBlock != parent.hash {
-					parent = b.index.LookupNode(&header.PrevBlock)
-				}
+				parent = lastNode
+			} else {
+				parent = b.index.LookupNode(&header.PrevBlock)
 				if parent == nil {
 					return AssertError(fmt.Sprintf("initChainState: Could "+
 						"not find parent for block %s", header.BlockHash()))
 				}
-
-				node.parent = parent
-				node.height = parent.height + 1
-				node.workSum = node.workSum.Add(parent.workSum, node.workSum)
 			}
 
+			// Initialize the block node for the block, connect it,
+			// and add it to the block index.
+			node := &blockNodes[i]
+			initBlockNode(node, &header, parent)
 			b.index.AddNode(node)
+
 			lastNode = node
 			i++
 		}

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1147,17 +1147,39 @@ func (b *BlockChain) createChainState() error {
 // database.  When the db does not yet contain any chain state, both it and the
 // chain state are initialized to the genesis block.
 func (b *BlockChain) initChainState() error {
-	// Attempt to load the chain state from the database.
-	var isStateInitialized bool
+	// Determine the state of the chain database. We may need to initialize
+	// everything from scratch or upgrade certain buckets.
+	var initialized bool
+	var hasBlockIndex bool
 	err := b.db.View(func(dbTx database.Tx) error {
+		initialized = dbTx.Metadata().Get(chainStateKeyName) != nil
+		hasBlockIndex = dbTx.Metadata().Bucket(blockIndexBucketName) != nil
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if !initialized {
+		// At this point the database has not already been initialized, so
+		// initialize both it and the chain state to the genesis block.
+		return b.createChainState()
+	}
+
+	if !hasBlockIndex {
+		err := migrateBlockIndex(b.db)
+		if err != nil {
+			return nil
+		}
+	}
+
+	// Attempt to load the chain state from the database.
+	return b.db.View(func(dbTx database.Tx) error {
 		// Fetch the stored chain state from the database metadata.
 		// When it doesn't exist, it means the database hasn't been
 		// initialized for use with chain yet, so break out now to allow
 		// that to happen under a writable database transaction.
 		serializedData := dbTx.Metadata().Get(chainStateKeyName)
-		if serializedData == nil {
-			return nil
-		}
 		log.Tracef("Serialized chain state: %x", serializedData)
 		state, err := deserializeBestChainState(serializedData)
 		if err != nil {
@@ -1251,22 +1273,9 @@ func (b *BlockChain) initChainState() error {
 		numTxns := uint64(len(block.Transactions))
 		b.stateSnapshot = newBestState(tip, blockSize, blockWeight,
 			numTxns, state.totalTxns, tip.CalcPastMedianTime())
-		isStateInitialized = true
 
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	// There is nothing more to do if the chain state was initialized.
-	if isStateInitialized {
-		return nil
-	}
-
-	// At this point the database has not already been initialized, so
-	// initialize both it and the chain state to the genesis block.
-	return b.createChainState()
 }
 
 // dbFetchHeaderByHash uses an existing database transaction to retrieve the

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -18,7 +18,18 @@ import (
 	"github.com/btcsuite/btcutil"
 )
 
+const (
+	// blockHdrSize is the size of a block header.  This is simply the
+	// constant from wire and is only provided here for convenience since
+	// wire.MaxBlockHeaderPayload is quite long.
+	blockHdrSize = wire.MaxBlockHeaderPayload
+)
+
 var (
+	// blockIndexBucketName is the name of the db bucket used to house to the
+	// block headers and contextual information.
+	blockIndexBucketName = []byte("blockheaderidx")
+
 	// hashIndexBucketName is the name of the db bucket used to house to the
 	// block hash -> block height index.
 	hashIndexBucketName = []byte("hashidx")
@@ -1058,6 +1069,7 @@ func dbPutBestState(dbTx database.Tx, snapshot *BestState, workSum *big.Int) err
 func (b *BlockChain) createChainState() error {
 	// Create a new node from the genesis block and set it as the best node.
 	genesisBlock := btcutil.NewBlock(b.chainParams.GenesisBlock)
+	genesisBlock.SetHeight(0)
 	header := &genesisBlock.MsgBlock().Header
 	node := newBlockNode(header, 0)
 	b.bestChain.SetTip(node)
@@ -1076,10 +1088,17 @@ func (b *BlockChain) createChainState() error {
 	// Create the initial the database chain state including creating the
 	// necessary index buckets and inserting the genesis block.
 	err := b.db.Update(func(dbTx database.Tx) error {
+		meta := dbTx.Metadata()
+
+		// Create the bucket that houses the block index data.
+		_, err := meta.CreateBucket(blockIndexBucketName)
+		if err != nil {
+			return err
+		}
+
 		// Create the bucket that houses the chain block hash to height
 		// index.
-		meta := dbTx.Metadata()
-		_, err := meta.CreateBucket(hashIndexBucketName)
+		_, err = meta.CreateBucket(hashIndexBucketName)
 		if err != nil {
 			return err
 		}
@@ -1119,7 +1138,7 @@ func (b *BlockChain) createChainState() error {
 		}
 
 		// Store the genesis block into the database.
-		return dbTx.StoreBlock(genesisBlock)
+		return dbStoreBlock(dbTx, genesisBlock)
 	})
 	return err
 }
@@ -1269,6 +1288,60 @@ func dbFetchBlockByNode(dbTx database.Tx, node *blockNode) (*btcutil.Block, erro
 	block.SetHeight(node.height)
 
 	return block, nil
+}
+
+// dbStoreBlock stores the provided block in the database. The block header is
+// written to the block index bucket and full block data is written to ffldb.
+func dbStoreBlockHeader(dbTx database.Tx, blockHeader *wire.BlockHeader, height uint32) error {
+	// Serialize block data to be stored. This is just the serialized header.
+	w := bytes.NewBuffer(make([]byte, 0, blockHdrSize))
+	err := blockHeader.Serialize(w)
+	if err != nil {
+		return err
+	}
+	value := w.Bytes()
+
+	// Write block header data to block index bucket.
+	blockHash := blockHeader.BlockHash()
+	blockIndexBucket := dbTx.Metadata().Bucket(blockIndexBucketName)
+	key := blockIndexKey(&blockHash, height)
+	return blockIndexBucket.Put(key, value)
+}
+
+// dbStoreBlock stores the provided block in the database. The block header is
+// written to the block index bucket and full block data is written to ffldb.
+func dbStoreBlock(dbTx database.Tx, block *btcutil.Block) error {
+	if block.Height() == btcutil.BlockHeightUnknown {
+		return fmt.Errorf("cannot store block %s with unknown height",
+			block.Hash())
+	}
+
+	// First store block header in the block index bucket.
+	err := dbStoreBlockHeader(dbTx, &block.MsgBlock().Header,
+		uint32(block.Height()))
+	if err != nil {
+		return err
+	}
+
+	// Then store block data in ffldb if we haven't already.
+	hasBlock, err := dbTx.HasBlock(block.Hash())
+	if err != nil {
+		return err
+	}
+	if hasBlock {
+		return nil
+	}
+	return dbTx.StoreBlock(block)
+}
+
+// blockIndexKey generates the binary key for an entry in the block index
+// bucket. The key is composed of the block height encoded as a big-endian
+// 32-bit unsigned int followed by the 32 byte block hash.
+func blockIndexKey(blockHash *chainhash.Hash, blockHeight uint32) []byte {
+	indexKey := make([]byte, chainhash.HashSize+4)
+	binary.BigEndian.PutUint32(indexKey[0:4], blockHeight)
+	copy(indexKey[4:chainhash.HashSize+4], blockHash[:])
+	return indexKey
 }
 
 // BlockByHeight returns the block at the given height in the main chain.

--- a/blockchain/chainview_test.go
+++ b/blockchain/chainview_test.go
@@ -27,16 +27,11 @@ func chainedNodes(parent *blockNode, numNodes int) []*blockNode {
 		// This is invalid, but all that is needed is enough to get the
 		// synthetic tests to work.
 		header := wire.BlockHeader{Nonce: testNoncePrng.Uint32()}
-		height := int32(0)
 		if tip != nil {
 			header.PrevBlock = tip.hash
-			height = tip.height + 1
 		}
-		node := newBlockNode(&header, height)
-		node.parent = tip
-		tip = node
-
-		nodes[i] = node
+		nodes[i] = newBlockNode(&header, tip)
+		tip = nodes[i]
 	}
 	return nodes
 }

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -261,7 +261,7 @@ func (b *BlockChain) TstSetCoinbaseMaturity(maturity uint16) {
 func newFakeChain(params *chaincfg.Params) *BlockChain {
 	// Create a genesis block node and block index index populated with it
 	// for use when creating the fake chain below.
-	node := newBlockNode(&params.GenesisBlock.Header, 0)
+	node := newBlockNode(&params.GenesisBlock.Header, nil)
 	index := newBlockIndex(nil, params)
 	index.AddNode(node)
 
@@ -291,8 +291,5 @@ func newFakeNode(parent *blockNode, blockVersion int32, bits uint32, timestamp t
 		Bits:      bits,
 		Timestamp: timestamp,
 	}
-	node := newBlockNode(header, parent.height+1)
-	node.parent = parent
-	node.workSum.Add(parent.workSum, node.workSum)
-	return node
+	return newBlockNode(header, parent)
 }

--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2017 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"bytes"
+	"container/list"
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/database"
+	"github.com/btcsuite/btcd/wire"
+)
+
+const (
+	// blockHdrOffset defines the offsets into a v1 block index row for the
+	// block header.
+	//
+	// The serialized block index row format is:
+	//   <blocklocation><blockheader>
+	blockHdrOffset = 12
+)
+
+// migrateBlockIndex migrates all block entries from the v1 block index bucket
+// to the v2 bucket. The v1 bucket stores all block entries keyed by block hash,
+// whereas the v2 bucket stores the exact same values, but keyed instead by
+// block height + hash.
+func migrateBlockIndex(db database.DB) error {
+	// Hardcoded bucket names so updates to the global values do not affect
+	// old upgrades.
+	v1BucketName := []byte("ffldb-blockidx")
+	v2BucketName := []byte("blockheaderidx")
+
+	err := db.Update(func(dbTx database.Tx) error {
+		v1BlockIdxBucket := dbTx.Metadata().Bucket(v1BucketName)
+		if v1BlockIdxBucket == nil {
+			return fmt.Errorf("Bucket %s does not exist", v1BucketName)
+		}
+
+		log.Info("Re-indexing block information in the database. This might take a while...")
+
+		v2BlockIdxBucket, err :=
+			dbTx.Metadata().CreateBucketIfNotExists(v2BucketName)
+		if err != nil {
+			return err
+		}
+
+		// Scan the old block index bucket and construct a mapping of each block
+		// to all child blocks.
+		childBlocksMap, err := readBlockTree(v1BlockIdxBucket)
+		if err != nil {
+			return err
+		}
+
+		// Use the block graph to calculate the height of each block.
+		blockHeights := determineBlockHeights(childBlocksMap)
+
+		// Now that we have heights for all blocks, scan the old block index
+		// bucket and insert all rows into the new one.
+		return v1BlockIdxBucket.ForEach(func(hashBytes, blockRow []byte) error {
+			endOffset := blockHdrOffset + blockHdrSize
+			headerBytes := blockRow[blockHdrOffset:endOffset:endOffset]
+
+			var hash chainhash.Hash
+			copy(hash[:], hashBytes[0:chainhash.HashSize])
+
+			height, exists := blockHeights[hash]
+			if !exists {
+				return fmt.Errorf("Unable to calculate chain height for "+
+					"stored block %s", hash)
+			}
+
+			key := blockIndexKey(&hash, height)
+			return v2BlockIdxBucket.Put(key, headerBytes)
+		})
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Infof("Block database migration complete")
+	return nil
+}
+
+// readBlockTree reads the old block index bucket and constructs a mapping of
+// each block to all child blocks. This mapping represents the full tree of
+// blocks.
+func readBlockTree(v1BlockIdxBucket database.Bucket) (map[chainhash.Hash][]*chainhash.Hash, error) {
+	childBlocksMap := make(map[chainhash.Hash][]*chainhash.Hash)
+	err := v1BlockIdxBucket.ForEach(func(_, blockRow []byte) error {
+		var header wire.BlockHeader
+		endOffset := blockHdrOffset + blockHdrSize
+		headerBytes := blockRow[blockHdrOffset:endOffset:endOffset]
+		err := header.Deserialize(bytes.NewReader(headerBytes))
+		if err != nil {
+			return err
+		}
+
+		blockHash := header.BlockHash()
+		childBlocksMap[header.PrevBlock] =
+			append(childBlocksMap[header.PrevBlock], &blockHash)
+		return nil
+	})
+	return childBlocksMap, err
+}
+
+// determineBlockHeights takes a map of block hashes to a slice of child hashes
+// and uses it to compute the height for each block. The function assigns a
+// height of 0 to the genesis hash and explores the tree of blocks
+// breadth-first, assigning a height to every block with a path back to the
+// genesis block.
+func determineBlockHeights(childBlocksMap map[chainhash.Hash][]*chainhash.Hash) map[chainhash.Hash]uint32 {
+	blockHeights := make(map[chainhash.Hash]uint32)
+	queue := list.New()
+
+	// The genesis block is included in childBlocksMap as a child of the zero
+	// hash because that is the value of the PrevBlock field in the genesis
+	// header.
+	for _, genesisHash := range childBlocksMap[zeroHash] {
+		blockHeights[*genesisHash] = 0
+		queue.PushBack(genesisHash)
+	}
+
+	for e := queue.Front(); e != nil; e = queue.Front() {
+		queue.Remove(e)
+		hash := e.Value.(*chainhash.Hash)
+		height := blockHeights[*hash]
+
+		// For each block with this one as a parent, assign it a height and
+		// push to queue for future processing.
+		for _, childHash := range childBlocksMap[*hash] {
+			blockHeights[*childHash] = height + 1
+			queue.PushBack(childHash)
+		}
+	}
+	return blockHeights
+}

--- a/blockchain/upgrade.go
+++ b/blockchain/upgrade.go
@@ -72,8 +72,16 @@ func migrateBlockIndex(db database.DB) error {
 					"stored block %s", hash)
 			}
 
+			// Write header to v2 bucket
 			key := blockIndexKey(&hash, height)
-			return v2BlockIdxBucket.Put(key, headerBytes)
+			err := v2BlockIdxBucket.Put(key, headerBytes)
+			if err != nil {
+				return err
+			}
+
+			// Delete header from v1 bucket
+			truncatedRow := blockRow[0:blockHdrOffset:blockHdrOffset]
+			return v1BlockIdxBucket.Put(hashBytes, truncatedRow)
 		})
 	})
 	if err != nil {

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -47,7 +47,7 @@ var (
 	// zeroHash is the zero value for a chainhash.Hash and is defined as
 	// a package level variable to avoid the need to create a new instance
 	// every time a check is needed.
-	zeroHash = &chainhash.Hash{}
+	zeroHash chainhash.Hash
 
 	// block91842Hash is one of the two nodes which violate the rules
 	// set forth in BIP0030.  It is defined as a package level variable to
@@ -63,7 +63,7 @@ var (
 // isNullOutpoint determines whether or not a previous transaction output point
 // is set.
 func isNullOutpoint(outpoint *wire.OutPoint) bool {
-	if outpoint.Index == math.MaxUint32 && outpoint.Hash.IsEqual(zeroHash) {
+	if outpoint.Index == math.MaxUint32 && outpoint.Hash == zeroHash {
 		return true
 	}
 	return false
@@ -95,7 +95,7 @@ func IsCoinBaseTx(msgTx *wire.MsgTx) bool {
 	// The previous output of a coin base must have a max value index and
 	// a zero hash.
 	prevOut := &msgTx.TxIn[0].PreviousOutPoint
-	if prevOut.Index != math.MaxUint32 || !prevOut.Hash.IsEqual(zeroHash) {
+	if prevOut.Index != math.MaxUint32 || prevOut.Hash != zeroHash {
 		return false
 	}
 

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1283,8 +1283,6 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *btcutil.Block) error {
 	// is not needed and thus extra work can be avoided.
 	view := NewUtxoViewpoint()
 	view.SetBestHash(&tip.hash)
-	newNode := newBlockNode(&header, tip.height+1)
-	newNode.parent = tip
-	newNode.workSum = newNode.workSum.Add(tip.workSum, newNode.workSum)
+	newNode := newBlockNode(&header, tip)
 	return b.checkConnectBlock(newNode, block, view, nil)
 }


### PR DESCRIPTION
This is a replacement for https://github.com/btcsuite/btcd/pull/1034.

As discussed in https://github.com/btcsuite/btcd/issues/1048, we create a new database bucket managed by the blockchain package storing all block headers in a way that that are able to quickly be loaded into memory by initChainState. Once all headers are in the in-memory block index, there is no reason to keep the headers in the LevelDB rows of ffldb, so this also deletes that redundant data.

To avoid modifying the database interface, this reimplements FetchBlockHeader(s) to use header data stored in flat files. This can be trivially implemented by delegating to FetchBlockRegion.