### PR TITLE
blockchain: Track block validation status in block index.

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -29,7 +29,7 @@ func (b *BlockChain) maybeAcceptBlock(block *btcutil.Block, flags BehaviorFlags)
 	if prevNode == nil {
 		str := fmt.Sprintf("previous block %s is unknown", prevHash)
 		return false, ruleError(ErrPreviousBlockUnknown, str)
-	} else if prevNode.KnownInvalid() {
+	} else if b.index.NodeStatus(prevNode).KnownInvalid() {
 		str := fmt.Sprintf("previous block %s is known to be invalid", prevHash)
 		return false, ruleError(ErrInvalidAncestorBlock, str)
 	}
@@ -64,7 +64,7 @@ func (b *BlockChain) maybeAcceptBlock(block *btcutil.Block, flags BehaviorFlags)
 	// block chain (could be either a side chain or the main chain).
 	blockHeader := &block.MsgBlock().Header
 	newNode := newBlockNode(blockHeader, blockHeight)
-	newNode.status |= statusDataStored
+	newNode.status = statusDataStored
 	if prevNode != nil {
 		newNode.parent = prevNode
 		newNode.height = blockHeight

--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -39,6 +39,27 @@ const (
 	statusNone blockStatus = 0
 )
 
+// HaveData returns whether the full block data is stored in the database. This
+// will return false for a block node where only the header is downloaded or
+// kept.
+func (status blockStatus) HaveData() bool {
+	return status&statusDataStored != 0
+}
+
+// KnownValid returns whether the block is known to be valid. This will return
+// false for a valid block that has not been fully validated yet.
+func (status blockStatus) KnownValid() bool {
+	return status&statusValid != 0
+}
+
+// KnownInvalid returns whether the block is known to be invalid. This may be
+// because the block itself failed validation or any of its ancestors is
+// invalid. This will return false for invalid blocks that have not been proven
+// invalid yet.
+func (status blockStatus) KnownInvalid() bool {
+	return status&(statusValidateFailed|statusInvalidAncestor) != 0
+}
+
 // blockNode represents a block within the block chain and is primarily used to
 // aid in selecting the best chain to be the main chain.  The main chain is
 // stored into the block database.
@@ -73,7 +94,10 @@ type blockNode struct {
 	timestamp  int64
 	merkleRoot chainhash.Hash
 
-	// status is a bitfield representing the validation state of the block
+	// status is a bitfield representing the validation state of the block. The
+	// status field, unlike the other fields, may be written to and so should
+	// only be accessed using the concurrent-safe NodeStatus method on
+	// blockIndex once the node has been added to the global index.
 	status blockStatus
 }
 
@@ -193,20 +217,6 @@ func (node *blockNode) CalcPastMedianTime() time.Time {
 	return time.Unix(medianTimestamp, 0)
 }
 
-// KnownValid returns whether the block is known to be valid. This will return
-// false for a valid block that has not been fully validated yet.
-func (node *blockNode) KnownValid() bool {
-	return node.status&statusValid != 0
-}
-
-// KnownInvalid returns whether the block is known to be invalid. This may be
-// because the block itself failed validation or any of its ancestors is
-// invalid. This will return false for invalid blocks that have not been proven
-// invalid yet.
-func (node *blockNode) KnownInvalid() bool {
-	return node.status&(statusValidateFailed|statusInvalidAncestor) != 0
-}
-
 // blockIndex provides facilities for keeping track of an in-memory index of the
 // block chain.  Although the name block chain suggests a single chain of
 // blocks, it is actually a tree-shaped structure where any node can have
@@ -265,13 +275,33 @@ func (bi *blockIndex) AddNode(node *blockNode) {
 	bi.Unlock()
 }
 
-// RemoveNode removes the provided node from the block index.  There is no check
-// whether another node in the index depends on this one, so it is up to caller
-// to avoid that situation.
+// NodeStatus provides concurrent-safe access to the status field of a node.
 //
 // This function is safe for concurrent access.
-func (bi *blockIndex) RemoveNode(node *blockNode) {
+func (bi *blockIndex) NodeStatus(node *blockNode) blockStatus {
+	bi.RLock()
+	status := node.status
+	bi.RUnlock()
+	return status
+}
+
+// SetStatusFlags flips the provided status flags on the block node to on,
+// regardless of whether they were on or off previously. This does not unset any
+// flags currently on.
+//
+// This function is safe for concurrent access.
+func (bi *blockIndex) SetStatusFlags(node *blockNode, flags blockStatus) {
 	bi.Lock()
-	delete(bi.index, node.hash)
+	node.status |= flags
+	bi.Unlock()
+}
+
+// UnsetStatusFlags flips the provided status flags on the block node to off,
+// regardless of whether they were on or off previously.
+//
+// This function is safe for concurrent access.
+func (bi *blockIndex) UnsetStatusFlags(node *blockNode, flags blockStatus) {
+	bi.Lock()
+	node.status &^= flags
 	bi.Unlock()
 }

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1060,6 +1060,7 @@ func (b *BlockChain) createChainState() error {
 	genesisBlock := btcutil.NewBlock(b.chainParams.GenesisBlock)
 	header := &genesisBlock.MsgBlock().Header
 	node := newBlockNode(header, 0)
+	node.status |= statusDataStored | statusValid
 	b.bestChain.SetTip(node)
 
 	// Add the new node to the index which is used for faster lookups.
@@ -1164,6 +1165,7 @@ func (b *BlockChain) initChainState() error {
 			// and add it to the block index.
 			node := &blockNodes[height]
 			initBlockNode(node, header, height)
+			node.status |= statusDataStored | statusValid
 			if tip != nil {
 				node.parent = tip
 				node.workSum = node.workSum.Add(tip.workSum,

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1060,7 +1060,7 @@ func (b *BlockChain) createChainState() error {
 	genesisBlock := btcutil.NewBlock(b.chainParams.GenesisBlock)
 	header := &genesisBlock.MsgBlock().Header
 	node := newBlockNode(header, 0)
-	node.status |= statusDataStored | statusValid
+	node.status = statusDataStored | statusValid
 	b.bestChain.SetTip(node)
 
 	// Add the new node to the index which is used for faster lookups.
@@ -1165,7 +1165,7 @@ func (b *BlockChain) initChainState() error {
 			// and add it to the block index.
 			node := &blockNodes[height]
 			initBlockNode(node, header, height)
-			node.status |= statusDataStored | statusValid
+			node.status = statusDataStored | statusValid
 			if tip != nil {
 				node.parent = tip
 				node.workSum = node.workSum.Add(tip.workSum,

--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -99,10 +99,6 @@ const (
 	// transaction.
 	ErrNoTransactions
 
-	// ErrTooManyTransactions indicates the block has more transactions than
-	// are allowed.
-	ErrTooManyTransactions
-
 	// ErrNoTxInputs indicates a transaction does not have any inputs.  A
 	// valid transaction must have at least one input.
 	ErrNoTxInputs
@@ -213,6 +209,13 @@ const (
 	// manually computed witness commitment.
 	ErrWitnessCommitmentMismatch
 
+	// ErrPreviousBlockUnknown indicates that the previous block is not known.
+	ErrPreviousBlockUnknown
+
+	// ErrInvalidAncestorBlock indicates that an ancestor of this block has
+	// already failed validation.
+	ErrInvalidAncestorBlock
+
 	// ErrPrevBlockNotBest indicates that the block's previous block is not the
 	// current chain tip. This is not a block validation rule, but is required
 	// for block proposals submitted via getblocktemplate RPC.
@@ -236,7 +239,6 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrForkTooOld:                "ErrForkTooOld",
 	ErrCheckpointTimeTooOld:      "ErrCheckpointTimeTooOld",
 	ErrNoTransactions:            "ErrNoTransactions",
-	ErrTooManyTransactions:       "ErrTooManyTransactions",
 	ErrNoTxInputs:                "ErrNoTxInputs",
 	ErrNoTxOutputs:               "ErrNoTxOutputs",
 	ErrTxTooBig:                  "ErrTxTooBig",
@@ -262,6 +264,8 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrUnexpectedWitness:         "ErrUnexpectedWitness",
 	ErrInvalidWitnessCommitment:  "ErrInvalidWitnessCommitment",
 	ErrWitnessCommitmentMismatch: "ErrWitnessCommitmentMismatch",
+	ErrPreviousBlockUnknown:      "ErrPreviousBlockUnknown",
+	ErrInvalidAncestorBlock:      "ErrInvalidAncestorBlock",
 	ErrPrevBlockNotBest:          "ErrPrevBlockNotBest",
 }
 

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -16,6 +16,7 @@ func TestErrorCodeStringer(t *testing.T) {
 	}{
 		{ErrDuplicateBlock, "ErrDuplicateBlock"},
 		{ErrBlockTooBig, "ErrBlockTooBig"},
+		{ErrBlockWeightTooHigh, "ErrBlockWeightTooHigh"},
 		{ErrBlockVersionTooOld, "ErrBlockVersionTooOld"},
 		{ErrInvalidTime, "ErrInvalidTime"},
 		{ErrTimeTooOld, "ErrTimeTooOld"},
@@ -28,7 +29,6 @@ func TestErrorCodeStringer(t *testing.T) {
 		{ErrForkTooOld, "ErrForkTooOld"},
 		{ErrCheckpointTimeTooOld, "ErrCheckpointTimeTooOld"},
 		{ErrNoTransactions, "ErrNoTransactions"},
-		{ErrTooManyTransactions, "ErrTooManyTransactions"},
 		{ErrNoTxInputs, "ErrNoTxInputs"},
 		{ErrNoTxOutputs, "ErrNoTxOutputs"},
 		{ErrTxTooBig, "ErrTxTooBig"},
@@ -52,6 +52,11 @@ func TestErrorCodeStringer(t *testing.T) {
 		{ErrBadCoinbaseHeight, "ErrBadCoinbaseHeight"},
 		{ErrScriptMalformed, "ErrScriptMalformed"},
 		{ErrScriptValidation, "ErrScriptValidation"},
+		{ErrUnexpectedWitness, "ErrUnexpectedWitness"},
+		{ErrInvalidWitnessCommitment, "ErrInvalidWitnessCommitment"},
+		{ErrWitnessCommitmentMismatch, "ErrWitnessCommitmentMismatch"},
+		{ErrPreviousBlockUnknown, "ErrPreviousBlockUnknown"},
+		{ErrInvalidAncestorBlock, "ErrInvalidAncestorBlock"},
 		{ErrPrevBlockNotBest, "ErrPrevBlockNotBest"},
 		{0xffff, "Unknown ErrorCode (65535)"},
 	}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1969,7 +1969,9 @@ func chainErrToGBTErrString(err error) string {
 	case blockchain.ErrDuplicateBlock:
 		return "duplicate"
 	case blockchain.ErrBlockTooBig:
-		return "bad-block-size"
+		return "bad-blk-length"
+	case blockchain.ErrBlockWeightTooHigh:
+		return "bad-blk-weight"
 	case blockchain.ErrBlockVersionTooOld:
 		return "bad-version"
 	case blockchain.ErrInvalidTime:
@@ -1994,8 +1996,6 @@ func chainErrToGBTErrString(err error) string {
 		return "checkpoint-time-too-old"
 	case blockchain.ErrNoTransactions:
 		return "bad-txns-none"
-	case blockchain.ErrTooManyTransactions:
-		return "bad-txns-toomany"
 	case blockchain.ErrNoTxInputs:
 		return "bad-txns-noinputs"
 	case blockchain.ErrNoTxOutputs:
@@ -2040,6 +2040,16 @@ func chainErrToGBTErrString(err error) string {
 		return "bad-script-malformed"
 	case blockchain.ErrScriptValidation:
 		return "bad-script-validate"
+	case blockchain.ErrUnexpectedWitness:
+		return "unexpected-witness"
+	case blockchain.ErrInvalidWitnessCommitment:
+		return "bad-witness-nonce-size"
+	case blockchain.ErrWitnessCommitmentMismatch:
+		return "bad-witness-merkle-match"
+	case blockchain.ErrPreviousBlockUnknown:
+		return "prev-blk-not-found"
+	case blockchain.ErrInvalidAncestorBlock:
+		return "bad-prevblk"
 	case blockchain.ErrPrevBlockNotBest:
 		return "inconclusive-not-best-prvblk"
 	}


### PR DESCRIPTION
Each node in the block index records some flags about its validation state. This is just stored in memory for now, but can save effort if attempting to reconnect a block that failed validation or was
disconnected. In a subsequent change, we will store this in the block index bucket created by https://github.com/btcsuite/btcd/pull/1049.

This field provides little value now, is required for headers-first syncing.