### PR TITLE
btcjson: Implement addwitnessaddress functionality.

### DIFF
--- a/btcjson/walletsvrcmds.go
+++ b/btcjson/walletsvrcmds.go
@@ -27,6 +27,19 @@ func NewAddMultisigAddressCmd(nRequired int, keys []string, account *string) *Ad
 	}
 }
 
+// AddWitnessAddressCmd defines the addwitnessaddress JSON-RPC command.
+type AddWitnessAddressCmd struct {
+	Address string
+}
+
+// NewAddWitnessAddressCmd returns a new instance which can be used to issue a
+// addwitnessaddress JSON-RPC command.
+func NewAddWitnessAddressCmd(address string) *AddWitnessAddressCmd {
+	return &AddWitnessAddressCmd{
+		Address: address,
+	}
+}
+
 // CreateMultisigCmd defines the createmultisig JSON-RPC command.
 type CreateMultisigCmd struct {
 	NRequired int
@@ -645,6 +658,7 @@ func init() {
 	flags := UFWalletOnly
 
 	MustRegisterCmd("addmultisigaddress", (*AddMultisigAddressCmd)(nil), flags)
+	MustRegisterCmd("addwitnessaddress", (*AddWitnessAddressCmd)(nil), flags)
 	MustRegisterCmd("createmultisig", (*CreateMultisigCmd)(nil), flags)
 	MustRegisterCmd("dumpprivkey", (*DumpPrivKeyCmd)(nil), flags)
 	MustRegisterCmd("encryptwallet", (*EncryptWalletCmd)(nil), flags)

--- a/btcjson/walletsvrcmds_test.go
+++ b/btcjson/walletsvrcmds_test.go
@@ -62,6 +62,19 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 		},
 		{
+			name: "addwitnessaddress",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("addwitnessaddress", "1address")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewAddWitnessAddressCmd("1address")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"addwitnessaddress","params":["1address"],"id":1}`,
+			unmarshalled: &btcjson.AddWitnessAddressCmd{
+				Address: "1address",
+			},
+		},
+		{
 			name: "createmultisig",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("createmultisig", 2, []string{"031234", "035678"})


### PR DESCRIPTION
These commits implement objects and functions to build addwitnessaddress JSON-RPC commands within the btcjson package.  I have added a test to prove out the marshalling of the object.