### PR TITLE
blockchain: Remove BFDryRun behaviour flag.

### DIFF
--- a/blockchain/error.go
+++ b/blockchain/error.go
@@ -212,6 +212,11 @@ const (
 	// included in the block's coinbase transaction doesn't match the
 	// manually computed witness commitment.
 	ErrWitnessCommitmentMismatch
+
+	// ErrPrevBlockNotBest indicates that the block's previous block is not the
+	// current chain tip. This is not a block validation rule, but is required
+	// for block proposals submitted via getblocktemplate RPC.
+	ErrPrevBlockNotBest
 )
 
 // Map of ErrorCode values back to their constant names for pretty printing.
@@ -257,6 +262,7 @@ var errorCodeStrings = map[ErrorCode]string{
 	ErrUnexpectedWitness:         "ErrUnexpectedWitness",
 	ErrInvalidWitnessCommitment:  "ErrInvalidWitnessCommitment",
 	ErrWitnessCommitmentMismatch: "ErrWitnessCommitmentMismatch",
+	ErrPrevBlockNotBest:          "ErrPrevBlockNotBest",
 }
 
 // String returns the ErrorCode as a human-readable name.

--- a/blockchain/error_test.go
+++ b/blockchain/error_test.go
@@ -52,6 +52,7 @@ func TestErrorCodeStringer(t *testing.T) {
 		{ErrBadCoinbaseHeight, "ErrBadCoinbaseHeight"},
 		{ErrScriptMalformed, "ErrScriptMalformed"},
 		{ErrScriptValidation, "ErrScriptValidation"},
+		{ErrPrevBlockNotBest, "ErrPrevBlockNotBest"},
 		{0xffff, "Unknown ErrorCode (65535)"},
 	}
 

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1248,8 +1248,8 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *btcutil.Block, vi
 }
 
 // CheckConnectBlockTemplate fully validates that connecting the passed block to
-// the main chain does not violate any rules, aside from the proof of work
-// requirement. The block must connect to the current tip of the main chain.
+// the main chain does not violate any consensus rules, aside from the proof of
+// work requirement. The block must connect to the current tip of the main chain.
 //
 // This function is safe for concurrent access.
 func (b *BlockChain) CheckConnectBlockTemplate(block *btcutil.Block) error {

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -63,8 +63,8 @@ func TestSequenceLocksActive(t *testing.T) {
 	}
 }
 
-// TestCheckConnectBlock tests the CheckConnectBlockTemplate function to ensure
-// it fails.
+// TestCheckConnectBlockTemplate tests the CheckConnectBlockTemplate function to
+// ensure it fails.
 func TestCheckConnectBlockTemplate(t *testing.T) {
 	// Create a new database and chain instance to run tests against.
 	chain, teardownFunc, err := chainSetup("checkconnectblocktemplate",
@@ -108,7 +108,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 		}
 	}
 
-	// The block 3 should fail to connect since it's already inserted.
+	// Block 3 should fail to connect since it's already inserted.
 	err = chain.CheckConnectBlockTemplate(blocks[3])
 	if err == nil {
 		t.Fatal("CheckConnectBlockTemplate: Did not received expected error " +
@@ -122,7 +122,7 @@ func TestCheckConnectBlockTemplate(t *testing.T) {
 			"block 4: %v", err)
 	}
 
-	// The block 3a should fail to connect since does not build on chain tip.
+	// Block 3a should fail to connect since does not build on chain tip.
 	err = chain.CheckConnectBlockTemplate(blocks[5])
 	if err == nil {
 		t.Fatal("CheckConnectBlockTemplate: Did not received expected error " +

--- a/blockchain/validate_test.go
+++ b/blockchain/validate_test.go
@@ -63,11 +63,11 @@ func TestSequenceLocksActive(t *testing.T) {
 	}
 }
 
-// TestCheckConnectBlock tests the CheckConnectBlock function to ensure it
-// fails.
-func TestCheckConnectBlock(t *testing.T) {
+// TestCheckConnectBlock tests the CheckConnectBlockTemplate function to ensure
+// it fails.
+func TestCheckConnectBlockTemplate(t *testing.T) {
 	// Create a new database and chain instance to run tests against.
-	chain, teardownFunc, err := chainSetup("checkconnectblock",
+	chain, teardownFunc, err := chainSetup("checkconnectblocktemplate",
 		&chaincfg.MainNetParams)
 	if err != nil {
 		t.Errorf("Failed to setup chain instance: %v", err)
@@ -75,11 +75,76 @@ func TestCheckConnectBlock(t *testing.T) {
 	}
 	defer teardownFunc()
 
-	// The genesis block should fail to connect since it's already inserted.
-	genesisBlock := chaincfg.MainNetParams.GenesisBlock
-	err = chain.CheckConnectBlock(btcutil.NewBlock(genesisBlock))
+	// Since we're not dealing with the real block chain, set the coinbase
+	// maturity to 1.
+	chain.TstSetCoinbaseMaturity(1)
+
+	// Load up blocks such that there is a side chain.
+	// (genesis block) -> 1 -> 2 -> 3 -> 4
+	//                          \-> 3a
+	testFiles := []string{
+		"blk_0_to_4.dat.bz2",
+		"blk_3A.dat.bz2",
+	}
+
+	var blocks []*btcutil.Block
+	for _, file := range testFiles {
+		blockTmp, err := loadBlocks(file)
+		if err != nil {
+			t.Fatalf("Error loading file: %v\n", err)
+		}
+		blocks = append(blocks, blockTmp...)
+	}
+
+	for i := 1; i <= 3; i++ {
+		isMainChain, _, err := chain.ProcessBlock(blocks[i], BFNone)
+		if err != nil {
+			t.Fatalf("CheckConnectBlockTemplate: Received unexpected error "+
+				"processing block %d: %v", i, err)
+		}
+		if !isMainChain {
+			t.Fatalf("CheckConnectBlockTemplate: Expected block %d to connect "+
+				"to main chain", i)
+		}
+	}
+
+	// The block 3 should fail to connect since it's already inserted.
+	err = chain.CheckConnectBlockTemplate(blocks[3])
 	if err == nil {
-		t.Errorf("CheckConnectBlock: Did not received expected error")
+		t.Fatal("CheckConnectBlockTemplate: Did not received expected error " +
+			"on block 3")
+	}
+
+	// Block 4 should connect successfully to tip of chain.
+	err = chain.CheckConnectBlockTemplate(blocks[4])
+	if err != nil {
+		t.Fatalf("CheckConnectBlockTemplate: Received unexpected error on "+
+			"block 4: %v", err)
+	}
+
+	// The block 3a should fail to connect since does not build on chain tip.
+	err = chain.CheckConnectBlockTemplate(blocks[5])
+	if err == nil {
+		t.Fatal("CheckConnectBlockTemplate: Did not received expected error " +
+			"on block 3a")
+	}
+
+	// Block 4 should connect even if proof of work is invalid.
+	invalidPowBlock := *blocks[4].MsgBlock()
+	invalidPowBlock.Header.Nonce++
+	err = chain.CheckConnectBlockTemplate(btcutil.NewBlock(&invalidPowBlock))
+	if err != nil {
+		t.Fatalf("CheckConnectBlockTemplate: Received unexpected error on "+
+			"block 4 with bad nonce: %v", err)
+	}
+
+	// Invalid block building on chain tip should fail to connect.
+	invalidBlock := *blocks[4].MsgBlock()
+	invalidBlock.Header.Bits--
+	err = chain.CheckConnectBlockTemplate(btcutil.NewBlock(&invalidBlock))
+	if err == nil {
+		t.Fatal("CheckConnectBlockTemplate: Did not received expected error " +
+			"on block 4 with invalid difficulty bits")
 	}
 }
 

--- a/mining/mining.go
+++ b/mining/mining.go
@@ -879,7 +879,7 @@ mempoolLoop:
 	// chain with no issues.
 	block := btcutil.NewBlock(&msgBlock)
 	block.SetHeight(nextBlockHeight)
-	if err := g.chain.CheckConnectBlock(block); err != nil {
+	if err := g.chain.CheckConnectBlockTemplate(block); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This is only used to test block proposals. That has been changed to instead use a new(ish) CheckConnectBlockTemplate function in the blockchain package. The flag complicated the implementation of some chain processing routines and would be difficult to implement with headers-first syncing. Block proposals now may only connect to the tip of the main chain, which is the behavior implemented in Bitcoin Core, bcoin, and possibly other implementations of getblocktemplate.