### PR TITLE
replace buffer channel pool with sync.Pool

### DIFF
--- a/wire/common.go
+++ b/wire/common.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -45,131 +46,138 @@ var (
 // integers that automatically obtain a buffer from the free list, perform the
 // necessary binary conversion, read from or write to the given io.Reader or
 // io.Writer, and return the buffer to the free list.
-type binaryFreeList chan []byte
+type binaryFreeList struct {
+	sync.Pool
+}
 
 // Borrow returns a byte slice from the free list with a length of 8.  A new
 // buffer is allocated if there are not any available on the free list.
-func (l binaryFreeList) Borrow() []byte {
-	var buf []byte
-	select {
-	case buf = <-l:
-	default:
-		buf = make([]byte, 8)
-	}
-	return buf[:8]
+func (l *binaryFreeList) Borrow() *[]byte {
+	return l.Get().(*[]byte)
 }
 
 // Return puts the provided byte slice back on the free list.  The buffer MUST
 // have been obtained via the Borrow function and therefore have a cap of 8.
-func (l binaryFreeList) Return(buf []byte) {
-	select {
-	case l <- buf:
-	default:
-		// Let it go to the garbage collector.
-	}
+func (l *binaryFreeList) Return(bufp *[]byte) {
+	l.Put(bufp)
 }
 
 // Uint8 reads a single byte from the provided reader using a buffer from the
 // free list and returns it as a uint8.
-func (l binaryFreeList) Uint8(r io.Reader) (uint8, error) {
-	buf := l.Borrow()[:1]
+func (l *binaryFreeList) Uint8(r io.Reader) (uint8, error) {
+	bufp := l.Borrow()
+	buf := (*bufp)[:1]
 	if _, err := io.ReadFull(r, buf); err != nil {
-		l.Return(buf)
+		l.Return(bufp)
 		return 0, err
 	}
 	rv := buf[0]
-	l.Return(buf)
+	l.Return(bufp)
 	return rv, nil
 }
 
 // Uint16 reads two bytes from the provided reader using a buffer from the
 // free list, converts it to a number using the provided byte order, and returns
 // the resulting uint16.
-func (l binaryFreeList) Uint16(r io.Reader, byteOrder binary.ByteOrder) (uint16, error) {
-	buf := l.Borrow()[:2]
+func (l *binaryFreeList) Uint16(r io.Reader, byteOrder binary.ByteOrder) (uint16, error) {
+	bufp := l.Borrow()
+	buf := (*bufp)[:2]
 	if _, err := io.ReadFull(r, buf); err != nil {
-		l.Return(buf)
+		l.Return(bufp)
 		return 0, err
 	}
 	rv := byteOrder.Uint16(buf)
-	l.Return(buf)
+	l.Return(bufp)
 	return rv, nil
 }
 
 // Uint32 reads four bytes from the provided reader using a buffer from the
 // free list, converts it to a number using the provided byte order, and returns
 // the resulting uint32.
-func (l binaryFreeList) Uint32(r io.Reader, byteOrder binary.ByteOrder) (uint32, error) {
-	buf := l.Borrow()[:4]
+func (l *binaryFreeList) Uint32(r io.Reader, byteOrder binary.ByteOrder) (uint32, error) {
+	bufp := l.Borrow()
+	buf := (*bufp)[:4]
 	if _, err := io.ReadFull(r, buf); err != nil {
-		l.Return(buf)
+		l.Return(bufp)
 		return 0, err
 	}
 	rv := byteOrder.Uint32(buf)
-	l.Return(buf)
+	l.Return(bufp)
 	return rv, nil
 }
 
 // Uint64 reads eight bytes from the provided reader using a buffer from the
 // free list, converts it to a number using the provided byte order, and returns
 // the resulting uint64.
-func (l binaryFreeList) Uint64(r io.Reader, byteOrder binary.ByteOrder) (uint64, error) {
-	buf := l.Borrow()[:8]
+func (l *binaryFreeList) Uint64(r io.Reader, byteOrder binary.ByteOrder) (uint64, error) {
+	bufp := l.Borrow()
+	buf := (*bufp)[:8]
 	if _, err := io.ReadFull(r, buf); err != nil {
-		l.Return(buf)
+		l.Return(bufp)
 		return 0, err
 	}
 	rv := byteOrder.Uint64(buf)
-	l.Return(buf)
+	l.Return(bufp)
 	return rv, nil
 }
 
 // PutUint8 copies the provided uint8 into a buffer from the free list and
 // writes the resulting byte to the given writer.
-func (l binaryFreeList) PutUint8(w io.Writer, val uint8) error {
-	buf := l.Borrow()[:1]
+func (l *binaryFreeList) PutUint8(w io.Writer, val uint8) error {
+	bufp := l.Borrow()
+	buf := (*bufp)[:1]
 	buf[0] = val
 	_, err := w.Write(buf)
-	l.Return(buf)
+	l.Return(bufp)
 	return err
 }
 
 // PutUint16 serializes the provided uint16 using the given byte order into a
 // buffer from the free list and writes the resulting two bytes to the given
 // writer.
-func (l binaryFreeList) PutUint16(w io.Writer, byteOrder binary.ByteOrder, val uint16) error {
-	buf := l.Borrow()[:2]
+func (l *binaryFreeList) PutUint16(w io.Writer, byteOrder binary.ByteOrder, val uint16) error {
+	bufp := l.Borrow()
+	buf := (*bufp)[:2]
 	byteOrder.PutUint16(buf, val)
 	_, err := w.Write(buf)
-	l.Return(buf)
+	l.Return(bufp)
 	return err
 }
 
 // PutUint32 serializes the provided uint32 using the given byte order into a
 // buffer from the free list and writes the resulting four bytes to the given
 // writer.
-func (l binaryFreeList) PutUint32(w io.Writer, byteOrder binary.ByteOrder, val uint32) error {
-	buf := l.Borrow()[:4]
+func (l *binaryFreeList) PutUint32(w io.Writer, byteOrder binary.ByteOrder, val uint32) error {
+	bufp := l.Borrow()
+	buf := (*bufp)[:4]
 	byteOrder.PutUint32(buf, val)
 	_, err := w.Write(buf)
-	l.Return(buf)
+	l.Return(bufp)
 	return err
 }
 
 // PutUint64 serializes the provided uint64 using the given byte order into a
 // buffer from the free list and writes the resulting eight bytes to the given
 // writer.
-func (l binaryFreeList) PutUint64(w io.Writer, byteOrder binary.ByteOrder, val uint64) error {
-	buf := l.Borrow()[:8]
+func (l *binaryFreeList) PutUint64(w io.Writer, byteOrder binary.ByteOrder, val uint64) error {
+	bufp := l.Borrow()
+	buf := (*bufp)[:8]
 	byteOrder.PutUint64(buf, val)
 	_, err := w.Write(buf)
-	l.Return(buf)
+	l.Return(bufp)
 	return err
 }
 
 // binarySerializer provides a free list of buffers to use for serializing and
 // deserializing primitive integer values to and from io.Readers and io.Writers.
-var binarySerializer binaryFreeList = make(chan []byte, binaryFreeListMaxItems)
+var binarySerializer = &binaryFreeList{
+	Pool: sync.Pool{
+		New: func() interface{} {
+			b := make([]byte, 8)
+			return &b
+		},
+	},
+}
 
 // errNonCanonicalVarInt is the common format string used for non-canonically
 // encoded variable length integer errors.


### PR DESCRIPTION
@davecgh ,    according bench result ,  impove most of benchmark  cpu time.
but syn.Pool doc says :
>Any item stored in the Pool may be removed automatically at any time without notification. If the Pool holds the only reference when this happens, the item might be deallocated.

so, feel free  ignore this  pr.
```
benchmark                         old ns/op     new ns/op     delta
BenchmarkWriteVarInt1-4           75.2          31.9          -57.58%
BenchmarkWriteVarInt3-4           150           62.5          -58.33%
BenchmarkWriteVarInt5-4           151           65.3          -56.75%
BenchmarkWriteVarInt9-4           150           62.4          -58.40%
BenchmarkReadVarInt1-4            85.5          39.4          -53.92%
BenchmarkReadVarInt3-4            170           76.0          -55.29%
BenchmarkReadVarInt5-4            171           75.8          -55.67%
BenchmarkReadVarInt9-4            171           76.8          -55.09%
BenchmarkReadVarStr4-4            134           84.2          -37.16%
BenchmarkReadVarStr10-4           156           109           -30.13%
BenchmarkWriteVarStr4-4           112           56.9          -49.20%
BenchmarkWriteVarStr10-4          117           66.5          -43.16%
BenchmarkReadOutPoint-4           101           57.9          -42.67%
BenchmarkWriteOutPoint-4          84.0          38.1          -54.64%
BenchmarkReadTxOut-4              271           128           -52.77%
BenchmarkWriteTxOut-4             160           68.6          -57.12%
BenchmarkReadTxIn-4               365           186           -49.04%
BenchmarkWriteTxIn-4              243           104           -57.20%
BenchmarkDeserializeTxSmall-4     1283          813           -36.63%
BenchmarkDeserializeTxLarge-4     2921178       2677194       -8.35%
BenchmarkSerializeTx-4            723           305           -57.81%
BenchmarkReadBlockHeader-4        403           221           -45.16%
BenchmarkWriteBlockHeader-4       394           214           -45.69%
BenchmarkDecodeGetHeaders-4       18663         21530         +15.36%
BenchmarkDecodeHeaders-4          1082005       630068        -41.77%
BenchmarkDecodeGetBlocks-4        16139         17562         +8.82%
BenchmarkDecodeAddr-4             360040        217044        -39.72%
BenchmarkDecodeInv-4              7228404       4389623       -39.27%
BenchmarkDecodeNotFound-4         6762588       4391769       -35.06%
BenchmarkDecodeMerkleBlock-4      4670          3703          -20.71%
BenchmarkTxHash-4                 2161          1593          -26.28%
BenchmarkDoubleHashB-4            1066          1046          -1.88%
BenchmarkDoubleHashH-4            1024          1027          +0.29%

benchmark                         old allocs     new allocs     delta
BenchmarkWriteVarInt1-4           0              0              +0.00%
BenchmarkWriteVarInt3-4           0              0              +0.00%
BenchmarkWriteVarInt5-4           0              0              +0.00%
BenchmarkWriteVarInt9-4           0              0              +0.00%
BenchmarkReadVarInt1-4            0              0              +0.00%
BenchmarkReadVarInt3-4            0              0              +0.00%
BenchmarkReadVarInt5-4            0              0              +0.00%
BenchmarkReadVarInt9-4            0              0              +0.00%
BenchmarkReadVarStr4-4            2              2              +0.00%
BenchmarkReadVarStr10-4           2              2              +0.00%
BenchmarkWriteVarStr4-4           1              1              +0.00%
BenchmarkWriteVarStr10-4          1              1              +0.00%
BenchmarkReadOutPoint-4           0              0              +0.00%
BenchmarkWriteOutPoint-4          0              0              +0.00%
BenchmarkReadTxOut-4              0              0              +0.00%
BenchmarkWriteTxOut-4             0              0              +0.00%
BenchmarkReadTxIn-4               0              0              +0.00%
BenchmarkWriteTxIn-4              0              0              +0.00%
BenchmarkDeserializeTxSmall-4     6              6              +0.00%
BenchmarkDeserializeTxLarge-4     6              954            +15800.00%
BenchmarkSerializeTx-4            0              0              +0.00%
BenchmarkReadBlockHeader-4        0              0              +0.00%
BenchmarkWriteBlockHeader-4       4              4              +0.00%
BenchmarkDecodeGetHeaders-4       2              2              +0.00%
BenchmarkDecodeHeaders-4          2              2              +0.00%
BenchmarkDecodeGetBlocks-4        2              2              +0.00%
BenchmarkDecodeAddr-4             1002           1002           +0.00%
BenchmarkDecodeInv-4              2              3              +50.00%
BenchmarkDecodeNotFound-4         2              3              +50.00%
BenchmarkDecodeMerkleBlock-4      3              3              +0.00%
BenchmarkTxHash-4                 2              2              +0.00%
BenchmarkDoubleHashB-4            1              1              +0.00%
BenchmarkDoubleHashH-4            0              0              +0.00%

benchmark                         old bytes     new bytes     delta
BenchmarkWriteVarInt1-4           0             0             +0.00%
BenchmarkWriteVarInt3-4           0             0             +0.00%
BenchmarkWriteVarInt5-4           0             0             +0.00%
BenchmarkWriteVarInt9-4           0             0             +0.00%
BenchmarkReadVarInt1-4            0             0             +0.00%
BenchmarkReadVarInt3-4            0             0             +0.00%
BenchmarkReadVarInt5-4            0             0             +0.00%
BenchmarkReadVarInt9-4            0             0             +0.00%
BenchmarkReadVarStr4-4            8             8             +0.00%
BenchmarkReadVarStr10-4           32            32            +0.00%
BenchmarkWriteVarStr4-4           8             8             +0.00%
BenchmarkWriteVarStr10-4          16            16            +0.00%
BenchmarkReadOutPoint-4           0             0             +0.00%
BenchmarkWriteOutPoint-4          0             0             +0.00%
BenchmarkReadTxOut-4              0             0             +0.00%
BenchmarkWriteTxOut-4             0             0             +0.00%
BenchmarkReadTxIn-4               0             0             +0.00%
BenchmarkWriteTxIn-4              0             0             +0.00%
BenchmarkDeserializeTxSmall-4     225           225           +0.00%
BenchmarkDeserializeTxLarge-4     1379686       1969106       +42.72%
BenchmarkSerializeTx-4            0             0             +0.00%
BenchmarkReadBlockHeader-4        0             0             +0.00%
BenchmarkWriteBlockHeader-4       16            16            +0.00%
BenchmarkDecodeGetHeaders-4       20480         20482         +0.01%
BenchmarkDecodeHeaders-4          229376        229417        +0.02%
BenchmarkDecodeGetBlocks-4        20480         20482         +0.01%
BenchmarkDecodeAddr-4             89728         89742         +0.02%
BenchmarkDecodeInv-4              2203648       2203775       +0.01%
BenchmarkDecodeNotFound-4         2203648       2203775       +0.01%
BenchmarkDecodeMerkleBlock-4      4368          4368          +0.00%
BenchmarkTxHash-4                 320           320           +0.00%
BenchmarkDoubleHashB-4            32            32            +0.00%
BenchmarkDoubleHashH-4            0             0             +0.00%
```