### PR TITLE
btcec: Constant time field normalization.

### DIFF
--- a/btcec/bench_test.go
+++ b/btcec/bench_test.go
@@ -125,6 +125,16 @@ func BenchmarkFieldNormalize(b *testing.B) {
 	}
 }
 
+// BenchmarkFieldNormalizeWithCarry requires the evaluation of more involved logic in
+// field.Normalize(). We should ensure the runtime is the same as in
+// BenchmarkFieldNormalize
+func BenchmarkFieldNormalizeWithCarry(b *testing.B) {
+	f := &fieldVal{n: [10]uint32{0x148f6, 0x3ffffc0, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x000007}}
+	for i := 0; i < b.N; i++ {
+		f.Normalize()
+	}
+}
+
 // BenchmarkParseCompressedPubKey benchmarks how long it takes to decompress and
 // validate a compressed public key from a byte array.
 func BenchmarkParseCompressedPubKey(b *testing.B) {

--- a/btcec/field.go
+++ b/btcec/field.go
@@ -55,6 +55,7 @@ package btcec
 // counts.
 
 import (
+	"crypto/subtle"
 	"encoding/hex"
 )
 
@@ -319,32 +320,12 @@ func (f *fieldVal) Normalize() *fieldVal {
 	// following determines if either or these conditions are true and does
 	// the final reduction in constant time.
 	//
-	// Note that the if/else statements here intentionally do the bitwise
-	// operators even when it won't change the value to ensure constant time
-	// between the branches.  Also note that 'm' will be zero when neither
-	// of the aforementioned conditions are true and the value will not be
-	// changed when 'm' is zero.
-	m = 1
-	if t9 == fieldMSBMask {
-		m &= 1
-	} else {
-		m &= 0
-	}
-	if t2&t3&t4&t5&t6&t7&t8 == fieldBaseMask {
-		m &= 1
-	} else {
-		m &= 0
-	}
-	if ((t0+977)>>fieldBase + t1 + 64) > fieldBaseMask {
-		m &= 1
-	} else {
-		m &= 0
-	}
-	if t9>>fieldMSBBits != 0 {
-		m |= 1
-	} else {
-		m |= 0
-	}
+	// Note that 'm' will be zero when neither of the aforementioned conditions
+	// are true and the value will not be changed when 'm' is zero.
+	m = uint32(subtle.ConstantTimeEq(int32(t9), fieldMSBMask))
+	m &= uint32(subtle.ConstantTimeEq(int32(t2&t3&t4&t5&t6&t7&t8), fieldBaseMask))
+	m &= uint32(subtle.ConstantTimeLessOrEq(1<<fieldBase, int((t0+977)>>fieldBase+t1+64)))
+	m |= t9 >> fieldMSBBits
 	t0 = t0 + m*977
 	t1 = (t0 >> fieldBase) + t1 + (m << 6)
 	t0 = t0 & fieldBaseMask

--- a/btcec/field_test.go
+++ b/btcec/field_test.go
@@ -309,6 +309,21 @@ func TestNormalize(t *testing.T) {
 			[10]uint32{0x03fffc30, 0x03ffffc0, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x07ffffff, 0x003fffff},
 			[10]uint32{0x00000001, 0x00000001, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000000, 0x00000001},
 		},
+		// Number less than P that satisfies two of the three overflow
+		// conditions for a field value of magnitude of 1 with value greater
+		// than P in all but the last word.
+		{
+			[10]uint32{0x148f6, 0x3ffffc0, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x000007},
+			[10]uint32{0x148f6, 0x3ffffc0, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x3ffffff, 0x000007},
+		},
+		// A test that would fail without the check t2&t3&t4&t5&t6&t7&t8 == fieldBaseMask before normalization
+		// Number less than P that satisfies two of the three overflow
+		// conditions for a field value of magnitude of 1 with value greater
+		// than P in all but the second to last word.
+		{
+			[10]uint32{0x03fffc30, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03fffff0, 0x003fffff},
+			[10]uint32{0x03fffc30, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03ffffff, 0x03fffff0, 0x003fffff},
+		},
 	}
 
 	t.Logf("Running %d tests", len(tests))


### PR DESCRIPTION
The current implementation of `field.Normalize()` has a timing vulnerability exposed in issue #1079. This PR solves that issue by using methods outlined in the crypto/subtle reference library. 

Several constant time comparison operators that return integers for use in further bitwise operations are defined and should be used in place of other branching statements in the btcec library (even if-else statements with equal-time branches are vulnerable to timing attacks based on branch-prediction!). I think this solves #1079, but please comment if you knows of any other place following this same-time branching statements pattern. For details comparing the performance of these functions to their same-time branching counterparts see [my example repo](https://github.com/bmperrea/constant-time-go). For a more full set of constant time functions see [this other branch](https://github.com/bmperrea/btcd/commit/093f4e3a18b05fd3455888ec35acd668d100adbf).

Credits to @stevenroose for questioning this pattern in #621. Also, a plug for everyone to suggest there be a direct `bool2int` conversion function in golang!