### PR TITLE
Validate PKCS7 padding correctly

### DIFF
--- a/btcec/ciphering.go
+++ b/btcec/ciphering.go
@@ -208,9 +208,14 @@ func addPKCSPadding(src []byte) []byte {
 func removePKCSPadding(src []byte) ([]byte, error) {
 	length := len(src)
 	padLength := int(src[length-1])
-	if padLength > aes.BlockSize || length < aes.BlockSize {
+	//The padding length must be between 1 and aes block size (16), else invalid:
+	if padLength > aes.BlockSize || length < aes.BlockSize || padLength == 0 {
 		return nil, errInvalidPadding
 	}
-
+	//The padding must contain the padding length byte, repeated (RFC2315 10.3.2)
+	expectedPadding := bytes.Repeat(src[length-1:], padLength)
+	if !bytes.Equal(src[length-padLength:length], expectedPadding) {
+		return nil, errInvalidPadding
+	}
 	return src[:length-padLength], nil
 }

--- a/btcec/ciphering_test.go
+++ b/btcec/ciphering_test.go
@@ -162,8 +162,25 @@ func TestCipheringErrors(t *testing.T) {
 	tests2 := []struct {
 		in []byte // input data
 	}{
-		{bytes.Repeat([]byte{0x11}, 17)},
-		{bytes.Repeat([]byte{0x07}, 15)},
+		{bytes.Repeat([]byte{0x11}, 17)}, //too long
+		{bytes.Repeat([]byte{0x07}, 15)}, //too short
+		{append(bytes.Repeat([]byte{0x07}, 15),
+			bytes.Repeat([]byte{0x04}, 1)...)}, //invalid padding
+		{append(bytes.Repeat([]byte{0x07}, 9),
+			[]byte{0x01, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07}...)}, //invalid padding
+		{append(bytes.Repeat([]byte{0x07}, 9),
+			[]byte{0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0xfe, 0x10,
+				0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10, 0x10}...)}, //invalid padding
+		{append(bytes.Repeat([]byte{0x07}, 9),
+			[]byte{0x01, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07}...)}, //invalid padding
+		{append(bytes.Repeat([]byte{0x07}, 9),
+			[]byte{0x01, 0x07, 0x07, 0x07, 0x07, 0x07, 0x07}...)}, //invalid padding
+		{append(bytes.Repeat([]byte{0x07}, 15),
+			bytes.Repeat([]byte{0x11}, 1)...)}, //invalid padding length
+		{append(bytes.Repeat([]byte{0x07}, 15),
+			bytes.Repeat([]byte{0x00}, 1)...)}, //invalid padding length
+		{append(bytes.Repeat([]byte{0x07}, 15),
+			bytes.Repeat([]byte{0xff}, 1)...)}, //invalid padding length
 	}
 	for i, test := range tests2 {
 		_, err = removePKCSPadding(test.in)


### PR DESCRIPTION
The removePKCSPadding function did not valide the contents
of the padding; the format is defined in RFC2315.
This commit corrects that and some extra test cases which
trigger padding validation failure are provided.

I realise that this is most likely not important. And I am not aware of anyone using this code right now. And it actually is kind of a corner case as to whether it'd ever matter.

For back-story you might find interesting [this](https://github.com/JoinMarket-Org/joinmarket/pull/191#issuecomment-131111979) example - we were using an old slowaes.py module which likewise did not verify padding; and it turned out that because of the way we were using it, there was indeed a corner case here where it led to something bad happening. I think that'd be rare.