### PR TITLE
Remove duplicate setting in sample config file

### DIFF
--- a/sample-btcd.conf
+++ b/sample-btcd.conf
@@ -263,16 +263,6 @@
 
 
 ; ------------------------------------------------------------------------------
-; Optional Transaction Indexes
-; ------------------------------------------------------------------------------
-
-; Build and maintain a full address-based transaction index.
-; addrindex=1
-; Delete the entire address index on start up, then exit.
-; dropaddrindex=0
-
-
-; ------------------------------------------------------------------------------
 ; Optional Indexes
 ; ------------------------------------------------------------------------------
 
@@ -283,6 +273,9 @@
 ; Build and maintain a full address-based transaction index which makes the
 ; searchrawtransactions RPC available.
 ; addrindex=1
+
+; Delete the entire address index on start up, then exit.
+; dropaddrindex=0
 
 
 ; ------------------------------------------------------------------------------


### PR DESCRIPTION
`addrindex` was present twice.