### PR TITLE
Fix sub packages links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -268,9 +268,9 @@ information.
 <a name="GoPackages" />
 
 * The btcsuite Bitcoin-related Go Packages:
-    * [btcrpcclient](https://github.com/btcsuite/btcrpcclient) - Implements a
+    * [btcrpcclient](https://github.com/btcsuite/btcd/tree/master/rpcclient) - Implements a
       robust and easy to use Websocket-enabled Bitcoin JSON-RPC client
-    * [btcjson](https://github.com/btcsuite/btcjson) - Provides an extensive API
+    * [btcjson](https://github.com/btcsuite/btcd/tree/master/btcjson) - Provides an extensive API
       for the underlying JSON-RPC command and return values
     * [wire](https://github.com/btcsuite/btcd/tree/master/wire) - Implements the
       Bitcoin wire protocol


### PR DESCRIPTION
btcjson and btcrpcclient sub-packages already merged into btcd repo.