### PR TITLE
blockchain: Initialize database with genesis block.

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1125,6 +1125,12 @@ func (b *BlockChain) createChainState() error {
 			return err
 		}
 
+		// Save the genesis block to the block index database.
+		err = dbStoreBlockNode(dbTx, node)
+		if err != nil {
+			return err
+		}
+
 		// Add the genesis block hash to height and height to hash
 		// mappings to the index.
 		err = dbPutBlockIndex(dbTx, &node.hash, node.height)


### PR DESCRIPTION
This fixes a bug introduced by #1066 where newly initialized database are missing the genesis block. Databases migrated from a btcd version before that change are fine.

@davecgh 