### PR TITLE
rpcclient: Update for go1.10 breaking changes.

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -310,6 +310,8 @@ func (c *Client) handleMessage(msg []byte) {
 	// Attempt to unmarshal the message as either a notification or
 	// response.
 	var in inMessage
+	in.rawResponse = new(rawResponse)
+	in.rawNotification = new(rawNotification)
 	err := json.Unmarshal(msg, &in)
 	if err != nil {
 		log.Warnf("Remote server sent invalid message: %v", err)


### PR DESCRIPTION
Go 1.10 made some changes such that `json.Unmarshal` can no longer unmarshal into exported fields that are themselves embedded via an uninitialized unexported pointer.

Since `rpcclient` previously relied on this behavior, this updates the client to create the pointers before unmarshalling into the struct.
