### PR TITLE
add omitempty in json tag for TxRawResult.Hex

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -501,7 +501,7 @@ type InfoChainResult struct {
 
 // TxRawResult models the data from the getrawtransaction command.
 type TxRawResult struct {
-	Hex           string `json:"hex"`
+	Hex           string `json:"hex,omitempty"`
 	Txid          string `json:"txid"`
 	Hash          string `json:"hash,omitempty"`
 	Size          int32  `json:"size,omitempty"`


### PR DESCRIPTION
Currently when running DecodeRawTransaction, an empty string is returned for the "hex" field. This will remove that field in this case and any others when the field is not set and unmarshaling into a TxRawResult struct.