### PR TITLE
goclean: Nit that made go vet complain

### DIFF
--- a/server.go
+++ b/server.go
@@ -901,7 +901,7 @@ func (sp *serverPeer) OnAddr(_ *peer.Peer, msg *wire.MsgAddr) {
 
 	// A message that has no addresses is invalid.
 	if len(msg.AddrList) == 0 {
-		peerLog.Errorf("Command [%s] from %s does not contain any addresses",
+		peerLog.Errorf("Command [%s] from %v does not contain any addresses",
 			msg.Command(), sp)
 		sp.Disconnect()
 		return


### PR DESCRIPTION
I know it's silly to make a 1-character PR, but `go vet` in `goclean.sh` complains about this (I guess with new Go version).