### PR TITLE
blockchain: Fix typo in generate.go

### DIFF
--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -1513,7 +1513,7 @@ func Generate(includeLargeReorg bool) (tests [][]TestInstance, err error) {
 
 	// Create block with duplicate transactions.
 	//
-	// This test relies on the shape of the shape of the merkle tree to test
+	// This test relies on the shape of the merkle tree to test
 	// the intended condition and thus is asserted below.
 	//
 	//   ... -> b43(13)

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -291,7 +291,7 @@ func (view *UtxoViewpoint) connectTransaction(tx *btcutil.Tx, blockHeight int32,
 		entry := view.entries[txIn.PreviousOutPoint.Hash]
 
 		// Ensure the referenced utxo exists in the view.  This should
-		// never happen unless there is a bug is introduced in the code.
+		// never happen unless a bug is introduced in the code.
 		if entry == nil {
 			return AssertError(fmt.Sprintf("view missing input %v",
 				txIn.PreviousOutPoint))


### PR DESCRIPTION
Fix some typos I came across in `blockchain`. 
