### PR TITLE
#1024 This small change fixes the stalling issue with the sync. In my instance the sync has not stalled for last 2 days and no restart of the process required.

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1476,6 +1476,7 @@ out:
 				// command.
 				p.PushRejectMsg("malformed", wire.RejectMalformed, errMsg, nil,
 					true)
+				p.Disconnect()
 			}
 			break out
 		}


### PR DESCRIPTION
This change has no impact on sync speed though which is still very slow. Also, the assumption here is the service has 3-4K peer's in the cache and it's ok to disconnect from one problematic peer for the time being although the same can be added back by syncmanager and peer discovery flow.