### PR TITLE
Wrong BOLT11 prefix in regtest

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -379,7 +379,7 @@ var RegressionNetParams = Params{
 
 	// Human-readable part for Bech32 encoded segwit addresses, as defined in
 	// BIP 173.
-	Bech32HRPSegwit: "tb", // always tb for test net
+	Bech32HRPSegwit: "bcrt", // always bcrt for reg test net
 
 	// Address encoding magics
 	PubKeyHashAddrID: 0x6f, // starts with m or n


### PR DESCRIPTION
Initially was observed in `lnd` project for this issue https://github.com/lightningnetwork/lnd/issues/882

if to try to generate invoice for `regtest` net, we get encoded invoice with wrong prefix in human readable part