### PR TITLE
Add progress percentage to sync log, based on timestamps

### DIFF
--- a/netsync/blocklogger.go
+++ b/netsync/blocklogger.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btclog"
 	"github.com/btcsuite/btcutil"
 )
@@ -19,6 +20,7 @@ type blockProgressLogger struct {
 	receivedLogBlocks int64
 	receivedLogTx     int64
 	lastBlockLogTime  time.Time
+	firstBlockTime    time.Time
 
 	subsystemLogger btclog.Logger
 	progressAction  string
@@ -29,12 +31,18 @@ type blockProgressLogger struct {
 // The progress message is templated as follows:
 //  {progressAction} {numProcessed} {blocks|block} in the last {timePeriod}
 //  ({numTxs}, height {lastBlockHeight}, {lastBlockTimeStamp})
-func newBlockProgressLogger(progressMessage string, logger btclog.Logger) *blockProgressLogger {
+func newBlockProgressLogger(progressMessage string, logger btclog.Logger, chain *blockchain.BlockChain) (*blockProgressLogger, error) {
+	firstBlock, err := chain.BlockByHeight(0)
+	if err != nil {
+		return nil, err
+	}
+
 	return &blockProgressLogger{
 		lastBlockLogTime: time.Now(),
+		firstBlockTime:   firstBlock.MsgBlock().Header.Timestamp,
 		progressAction:   progressMessage,
 		subsystemLogger:  logger,
-	}
+	}, nil
 }
 
 // LogBlockHeight logs a new block height as an information message to show
@@ -66,9 +74,13 @@ func (b *blockProgressLogger) LogBlockHeight(block *btcutil.Block) {
 	if b.receivedLogTx == 1 {
 		txStr = "transaction"
 	}
-	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, height %d, %s)",
+
+	lastBlockTime := block.MsgBlock().Header.Timestamp
+	progress := 100 - (float64(now.Sub(lastBlockTime)) / float64(now.Sub(b.firstBlockTime)) * 100)
+
+	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, height %d, progress %.2f%%, %s)",
 		b.progressAction, b.receivedLogBlocks, blockStr, tDuration, b.receivedLogTx,
-		txStr, block.Height(), block.MsgBlock().Header.Timestamp)
+		txStr, block.Height(), progress, lastBlockTime)
 
 	b.receivedLogBlocks = 0
 	b.receivedLogTx = 0

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1404,6 +1404,10 @@ func (sm *SyncManager) Pause() chan<- struct{} {
 // New constructs a new SyncManager. Use Start to begin processing asynchronous
 // block, tx, and inv updates.
 func New(config *Config) (*SyncManager, error) {
+	progressLogger, err := newBlockProgressLogger("Processed", log, config.Chain)
+	if err != nil {
+		return nil, err
+	}
 	sm := SyncManager{
 		peerNotifier:    config.PeerNotifier,
 		chain:           config.Chain,
@@ -1413,7 +1417,7 @@ func New(config *Config) (*SyncManager, error) {
 		requestedTxns:   make(map[chainhash.Hash]struct{}),
 		requestedBlocks: make(map[chainhash.Hash]struct{}),
 		peerStates:      make(map[*peerpkg.Peer]*peerSyncState),
-		progressLogger:  newBlockProgressLogger("Processed", log),
+		progressLogger:  progressLogger,
 		msgChan:         make(chan interface{}, config.MaxPeers*3),
 		headerList:      list.New(),
 		quit:            make(chan struct{}),


### PR DESCRIPTION
This adds `progress xx.xx%` clause to the SYNC log messages, making it a bit clearer how long will sync take.
Bases the calculation on time differences between now, first block and current block. It is not perfect, but I'm not sure a better approach exists and is easily achievable.

This fixes #1092.