### PR TITLE
netsync: Remove unnecessary buffered channel

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1176,6 +1176,7 @@ out:
 						isOrphan: false,
 						err:      err,
 					}
+					continue out
 				}
 
 				msg.reply <- processBlockResponse{
@@ -1399,7 +1400,7 @@ func (sm *SyncManager) SyncPeerID() int32 {
 // ProcessBlock makes use of ProcessBlock on an internal instance of a block
 // chain.
 func (sm *SyncManager) ProcessBlock(block *btcutil.Block, flags blockchain.BehaviorFlags) (bool, error) {
-	reply := make(chan processBlockResponse, 1)
+	reply := make(chan processBlockResponse)
 	sm.msgChan <- processBlockMsg{block: block, flags: flags, reply: reply}
 	response := <-reply
 	return response.isOrphan, response.err


### PR DESCRIPTION
Somehow it was a buffered channel to not have the continue statement.