### PR TITLE
logic error for OnFilterAdd

### DIFF
--- a/server.go
+++ b/server.go
@@ -1056,7 +1056,7 @@ func (sp *serverPeer) OnFilterAdd(_ *peer.Peer, msg *wire.MsgFilterAdd) {
 		return
 	}
 
-	if sp.filter.IsLoaded() {
+	if !sp.filter.IsLoaded() {
 		peerLog.Debugf("%s sent a filteradd request with no filter "+
 			"loaded -- disconnecting", sp)
 		sp.Disconnect()


### PR DESCRIPTION
according to the logic And errors news, when no fileteradd request, this peer should be closed. According to the current logic(	sp.filter.Add(msg.Data) )，in the following code snippet, it will not do anything but exit directly.