### PR TITLE
chain: remove checking status for fetching cfheaders

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1336,9 +1336,6 @@ func (b *BlockChain) HeightToHashRange(startHeight int32,
 	if endNode == nil {
 		return nil, fmt.Errorf("no known block header with hash %v", endHash)
 	}
-	if !b.index.NodeStatus(endNode).KnownValid() {
-		return nil, fmt.Errorf("block %v is not yet validated", endHash)
-	}
 	endHeight := endNode.height
 
 	if startHeight < 0 {
@@ -1375,9 +1372,6 @@ func (b *BlockChain) IntervalBlockHashes(endHash *chainhash.Hash, interval int,
 	endNode := b.index.LookupNode(endHash)
 	if endNode == nil {
 		return nil, fmt.Errorf("no known block header with hash %v", endHash)
-	}
-	if !b.index.NodeStatus(endNode).KnownValid() {
-		return nil, fmt.Errorf("block %v is not yet validated", endHash)
 	}
 	endHeight := endNode.height
 

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -868,13 +868,6 @@ func TestHeightToHashRange(t *testing.T) {
 			maxResults:  10,
 			expectError: true,
 		},
-		{
-			name:        "unvalidated block",
-			startHeight: 15,
-			endHash:     branch1Nodes[2].hash,
-			maxResults:  10,
-			expectError: true,
-		},
 	}
 	for _, test := range tests {
 		hashes, err := chain.HeightToHashRange(test.startHeight, &test.endHash,
@@ -941,12 +934,6 @@ func TestIntervalBlockHashes(t *testing.T) {
 			endHash:  branch0Nodes[17].hash,
 			interval: 20,
 			hashes:   []chainhash.Hash{},
-		},
-		{
-			name:        "unvalidated block",
-			endHash:     branch1Nodes[2].hash,
-			interval:    8,
-			expectError: true,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Should be related to this issue: https://github.com/lightningnetwork/lnd/issues/511, in case of `neutrino` when we reach this error  -`btcd` sends nothing by request `getcfheaders` and then it breaks sequence of synced `headers` and `cfheaders`, by status command `getinfo` we see that it almost synced but actually we have no `cfheaders` on the filesystem

In our case after intensive load of btcd, it stops sending `cfheaders` because of status of the node, which is not `statusValid` but `statusDataStored`, somehow this status changes for many blocks, in my second case it even happened with block height 1. 

Probably this validation shouldn't be there, because for instance when we send block headers we don't do this kind of validation, only when we accept new blocks for best height.

I didn't investigate how it could that happened with switching statuses, might be some issue with flushing db. But anyway this fix the issue with sync of https://github.com/lightninglabs/neutrino 

cc @jimpo