### PR TITLE
integration/rpctest: disable the txindex by default and allow sending txs without change outputs

### DIFF
--- a/integration/csv_fork_test.go
+++ b/integration/csv_fork_test.go
@@ -53,7 +53,7 @@ func makeTestOutput(r *rpctest.Harness, t *testing.T,
 	output := &wire.TxOut{PkScript: selfAddrScript, Value: 1e8}
 
 	// Next, create and broadcast a transaction paying to the output.
-	fundTx, err := r.CreateTransaction([]*wire.TxOut{output}, 10)
+	fundTx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -316,7 +316,7 @@ func createCSVOutput(r *rpctest.Harness, t *testing.T,
 
 	// Finally create a valid transaction which creates the output crafted
 	// above.
-	tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10)
+	tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true)
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/integration/rpctest/node.go
+++ b/integration/rpctest/node.go
@@ -115,10 +115,6 @@ func (n *nodeConfig) arguments() []string {
 	args = append(args, fmt.Sprintf("--rpccert=%s", n.certFile))
 	// --rpckey
 	args = append(args, fmt.Sprintf("--rpckey=%s", n.keyFile))
-	// --txindex
-	args = append(args, "--txindex")
-	// --addrindex
-	args = append(args, "--addrindex")
 	if n.dataDir != "" {
 		// --datadir
 		args = append(args, fmt.Sprintf("--datadir=%s", n.dataDir))

--- a/integration/rpctest/rpc_harness.go
+++ b/integration/rpctest/rpc_harness.go
@@ -356,20 +356,32 @@ func (h *Harness) SendOutputs(targetOutputs []*wire.TxOut,
 	return h.wallet.SendOutputs(targetOutputs, feeRate)
 }
 
+// SendOutputsWithoutChange creates and sends a transaction that pays to the
+// specified outputs while observing the passed fee rate and ignoring a change
+// output. The passed fee rate should be expressed in sat/b.
+//
+// This function is safe for concurrent access.
+func (h *Harness) SendOutputsWithoutChange(targetOutputs []*wire.TxOut,
+	feeRate btcutil.Amount) (*chainhash.Hash, error) {
+
+	return h.wallet.SendOutputsWithoutChange(targetOutputs, feeRate)
+}
+
 // CreateTransaction returns a fully signed transaction paying to the specified
 // outputs while observing the desired fee rate. The passed fee rate should be
-// expressed in satoshis-per-byte. Any unspent outputs selected as inputs for
-// the crafted transaction are marked as unspendable in order to avoid
-// potential double-spends by future calls to this method. If the created
-// transaction is cancelled for any reason then the selected inputs MUST be
-// freed via a call to UnlockOutputs. Otherwise, the locked inputs won't be
+// expressed in satoshis-per-byte. The transaction being created can optionally
+// include a change output indicated by the change boolean. Any unspent outputs
+// selected as inputs for the crafted transaction are marked as unspendable in
+// order to avoid potential double-spends by future calls to this method. If the
+// created transaction is cancelled for any reason then the selected inputs MUST
+// be freed via a call to UnlockOutputs. Otherwise, the locked inputs won't be
 // returned to the pool of spendable outputs.
 //
 // This function is safe for concurrent access.
 func (h *Harness) CreateTransaction(targetOutputs []*wire.TxOut,
-	feeRate btcutil.Amount) (*wire.MsgTx, error) {
+	feeRate btcutil.Amount, change bool) (*wire.MsgTx, error) {
 
-	return h.wallet.CreateTransaction(targetOutputs, feeRate)
+	return h.wallet.CreateTransaction(targetOutputs, feeRate, change)
 }
 
 // UnlockOutputs unlocks any outputs which were previously marked as

--- a/integration/rpctest/rpc_harness_test.go
+++ b/integration/rpctest/rpc_harness_test.go
@@ -206,7 +206,7 @@ func testJoinMempools(r *Harness, t *testing.T) {
 		t.Fatalf("unable to generate pkscript to addr: %v", err)
 	}
 	output := wire.NewTxOut(5e8, addrScript)
-	testTx, err := r.CreateTransaction([]*wire.TxOut{output}, 10)
+	testTx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true)
 	if err != nil {
 		t.Fatalf("coinbase spend failed: %v", err)
 	}
@@ -340,7 +340,7 @@ func testGenerateAndSubmitBlock(r *Harness, t *testing.T) {
 	const numTxns = 5
 	txns := make([]*btcutil.Tx, 0, numTxns)
 	for i := 0; i < numTxns; i++ {
-		tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10)
+		tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true)
 		if err != nil {
 			t.Fatalf("unable to create tx: %v", err)
 		}
@@ -407,7 +407,7 @@ func testGenerateAndSubmitBlockWithCustomCoinbaseOutputs(r *Harness,
 	const numTxns = 5
 	txns := make([]*btcutil.Tx, 0, numTxns)
 	for i := 0; i < numTxns; i++ {
-		tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10)
+		tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true)
 		if err != nil {
 			t.Fatalf("unable to create tx: %v", err)
 		}
@@ -522,7 +522,7 @@ func testMemWalletLockedOutputs(r *Harness, t *testing.T) {
 	}
 	outputAmt := btcutil.Amount(50 * btcutil.SatoshiPerBitcoin)
 	output := wire.NewTxOut(int64(outputAmt), pkScript)
-	tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10)
+	tx, err := r.CreateTransaction([]*wire.TxOut{output}, 10, true)
 	if err != nil {
 		t.Fatalf("unable to create transaction: %v", err)
 	}


### PR DESCRIPTION
In this commit, we disable the txindex by default as the flag cannot be
overwritten by btcd once set.