### PR TITLE
rpcclient: add DisableTLSVerify to allow easy testing

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -1071,6 +1071,11 @@ type ConnConfig struct {
 	// the wire in cleartext.
 	DisableTLS bool
 
+	// DisableTLSVerify specifies whether TLS certificates should be checked.
+	// Disabling the check will allow potential man-in-the-middle attack. For
+	// testing only
+	DisableTLSVerify bool
+
 	// Certificates are the bytes for a PEM-encoded certificate chain used
 	// for the TLS connection.  It has no effect if the DisableTLS parameter
 	// is true.
@@ -1135,6 +1140,10 @@ func newHTTPClient(config *ConnConfig) (*http.Client, error) {
 			tlsConfig = &tls.Config{
 				RootCAs: pool,
 			}
+		} else {
+			tlsConfig = &tls.Config{
+				InsecureSkipVerify: config.DisableTLSVerify,
+			}
 		}
 	}
 
@@ -1162,6 +1171,8 @@ func dial(config *ConnConfig) (*websocket.Conn, error) {
 			pool := x509.NewCertPool()
 			pool.AppendCertsFromPEM(config.Certificates)
 			tlsConfig.RootCAs = pool
+		} else {
+			tlsConfig.InsecureSkipVerify = config.DisableTLSVerify
 		}
 		scheme = "wss"
 	}


### PR DESCRIPTION
In testing environments we usually use self-generated certificates on servers (default settings), which must be shared beforehand to allow clients to connect properly. This is cumbersome sometimes. Adding this option (essentially tlsConfig.InsecureSkipVerify) allows some degree of security (no cleartext user/pass) without extra effort in setting up. It could be useful in dev and testing environments.