### PR TITLE
blockchain: in initChainState mark ancestors of best tip as valid if …

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1158,6 +1158,14 @@ func (b *BlockChain) connectBestChain(node *blockNode, block *btcutil.Block, fla
 			return false, err
 		}
 
+		// If this is fast add, or this block node isn't yet marked as
+		// valid, then we'll update its status and flush the state to
+		// disk again.
+		if fastAdd || !b.index.NodeStatus(node).KnownValid() {
+			b.index.SetStatusFlags(node, statusValid)
+			flushIndexState()
+		}
+
 		return true, nil
 	}
 	if fastAdd {

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1144,6 +1144,17 @@ func (b *BlockChain) connectBestChain(node *blockNode, block *btcutil.Block, fla
 		// Connect the block to the main chain.
 		err := b.connectBlock(node, block, view, stxos)
 		if err != nil {
+			// If we got hit with a rule error, then we'll mark
+			// that status of the block as invalid and flush the
+			// index state to disk before returning with the error.
+			if _, ok := err.(RuleError); ok {
+				b.index.SetStatusFlags(
+					node, statusValidateFailed,
+				)
+			}
+
+			flushIndexState()
+
 			return false, err
 		}
 


### PR DESCRIPTION
…not marked

In this commit, we add an additional consistency check within the
`initChainState` method.  It has been observed that at times, a block
wil lbe written to disk (as it's valid), but then the block index isn't
updated to reflect this. This can cause btcd to fail to do things like
serve cfheaders for valid blocks.

To partially remedy this, when we're loading in the index, we assume
that all ancestors of the current chain tip are valid, and mark them as
such. At the very end, we'll flush the index to ensure the state is
fully consistent. Typically this will be a noop, as only dirty elements
are flushed.