### PR TITLE
blockchain/indexers: fix bug in indexer re-org catch up

### DIFF
--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -309,7 +309,7 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 				if err != nil {
 					return err
 				}
-				block, err := btcutil.NewBlockFromBytes(blockBytes)
+				block, err = btcutil.NewBlockFromBytes(blockBytes)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
In this commit, we fix an existing bug in the re-org catch up logic for
the `IndexManager`. Before this commit, we would assign the block to the
_local_ scope rather than the outer scope. As a result, we would never
properly bisect the chain to find the fork point to be able to reconcile
the index state to the main chain only after a re-org occurs.

Fixes #1261