### PR TITLE
server: allow for read concurrency when serving cf checkpoints, fix bug in checkpoint serving 

### DIFF
--- a/server.go
+++ b/server.go
@@ -1011,7 +1011,7 @@ func (sp *serverPeer) OnGetCFCheckpt(_ *peer.Peer, msg *wire.MsgGetCFCheckpt) {
 	// a re-org has occurred so items in the db are now in the main china
 	// while the cache has been partially invalidated.
 	var forkIdx int
-	for forkIdx = len(checkptCache); forkIdx > 0; forkIdx-- {
+	for forkIdx = len(blockHashes); forkIdx > 0; forkIdx-- {
 		if checkptCache[forkIdx-1].blockHash == blockHashes[forkIdx-1] {
 			break
 		}


### PR DESCRIPTION
In this commit, we modify the locking scheme when serving cf checkpoints
for peers to allow the server to serve multiple peers at the same time.
Before this commit, we would first grab the write lock, check to see for
expansion, then release the read lock. In this commit we reverse this
and instead will grab the read lock, and upgrade to the write lock if we
need to actually expand the size of the cache.

We also fix a panic bug that can arise when we attempt to
process a cf checkpoint message from a remote peer. Before this commit,
if the size of the checkpoint cache was large than the number of
checkpoints requested by the peer, we would panic with an out of bounds
error. In order to prevent, this we'll now use the size of the requested
set of hashes as our bound to ensure that we don't panic.