### PR TITLE
syncmanager: pick the first candidate then break

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -261,6 +261,7 @@ func (sm *SyncManager) startSync() {
 		// TODO(davec): Use a better algorithm to choose the best peer.
 		// For now, just pick the first available candidate.
 		bestPeer = peer
+		break
 	}
 
 	// Start syncing from the best peer if one was selected.


### PR DESCRIPTION
Hello. 

It looks like we forget to break the loop after picking the first available candidate at [syncmanager#L263](https://github.com/btcsuite/btcd/blob/master/netsync/manager.go#L263).