### PR TITLE
[README] Add note about glide not being in your path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ recommended that `GOPATH` is set to a directory in your home directory such as
 $ go get -u github.com/Masterminds/glide
 $ git clone https://github.com/btcsuite/btcd $GOPATH/src/github.com/btcsuite/btcd
 $ cd $GOPATH/src/github.com/btcsuite/btcd
-$ glide install
+$ glide install # glide is $GOTPATH/bin/glide, invoke it directly if it isn't in your PATH
 $ go install . ./cmd/...
 ```
 


### PR DESCRIPTION
I skimmed the part saying add your `$GOPATH/bin` to your `$PATH`, maybe this will save someone else 30 seconds trying to figure out glide is