### PR TITLE
mempool,txscript: avoid big array copies in for-range

### DIFF
--- a/mempool/estimatefee.go
+++ b/mempool/estimatefee.go
@@ -510,7 +510,7 @@ func (ef *FeeEstimator) newEstimateFeeSet() *estimateFeeSet {
 	set := &estimateFeeSet{}
 
 	capacity := 0
-	for i, b := range ef.bin {
+	for i, b := range &ef.bin {
 		l := len(b)
 		set.bin[i] = uint32(l)
 		capacity += l
@@ -519,7 +519,7 @@ func (ef *FeeEstimator) newEstimateFeeSet() *estimateFeeSet {
 	set.feeRate = make([]SatoshiPerByte, capacity)
 
 	i := 0
-	for _, b := range ef.bin {
+	for _, b := range &ef.bin {
 		for _, o := range b {
 			set.feeRate[i] = o.feeRate
 			i++
@@ -656,7 +656,7 @@ func (ef *FeeEstimator) Save() FeeEstimatorState {
 	}
 
 	// Save all the right bins.
-	for _, list := range ef.bin {
+	for _, list := range &ef.bin {
 
 		binary.Write(w, binary.BigEndian, uint32(len(list)))
 

--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -2437,7 +2437,7 @@ func init() {
 	// opcode array.  Also add entries for "OP_FALSE", "OP_TRUE", and
 	// "OP_NOP2" since they are aliases for "OP_0", "OP_1",
 	// and "OP_CHECKLOCKTIMEVERIFY" respectively.
-	for _, op := range opcodeArray {
+	for _, op := range &opcodeArray {
 		OpcodeByName[op.name] = op.value
 	}
 	OpcodeByName["OP_FALSE"] = OP_FALSE


### PR DESCRIPTION
When array is used in place of range expression,
whole array is copied. Using &array avoids this issue.

Found using https://go-critic.github.io/overview#rangeExprCopy-ref

Linter output:
```
$GOPATH/src/github.com/btcsuite/btcd/mempool/estimatefee.go:513:2: rangeExprCopy: copy of ef.bin (600 bytes) can be avoided with &ef.bin
$GOPATH/src/github.com/btcsuite/btcd/mempool/estimatefee.go:522:2: rangeExprCopy: copy of ef.bin (600 bytes) can be avoided with &ef.bin
$GOPATH/src/github.com/btcsuite/btcd/mempool/estimatefee.go:659:2: rangeExprCopy: copy of ef.bin (600 bytes) can be avoided with &ef.bin
$GOPATH/src/github.com/btcsuite/btcd/txscript/opcode.go:2440:2: rangeExprCopy: copy of opcodeArray (10240 bytes) can be avoided with &opcodeArray
```