### PR TITLE
btcjson,rpcclient: use proper Deprecated comment format

### DIFF
--- a/btcjson/chainsvrwscmds.go
+++ b/btcjson/chainsvrwscmds.go
@@ -80,7 +80,7 @@ func NewStopNotifyNewTransactionsCmd() *StopNotifyNewTransactionsCmd {
 
 // NotifyReceivedCmd defines the notifyreceived JSON-RPC command.
 //
-// NOTE: Deprecated. Use LoadTxFilterCmd instead.
+// Deprecated: Use LoadTxFilterCmd instead.
 type NotifyReceivedCmd struct {
 	Addresses []string
 }
@@ -88,7 +88,7 @@ type NotifyReceivedCmd struct {
 // NewNotifyReceivedCmd returns a new instance which can be used to issue a
 // notifyreceived JSON-RPC command.
 //
-// NOTE: Deprecated. Use NewLoadTxFilterCmd instead.
+// Deprecated: Use NewLoadTxFilterCmd instead.
 func NewNotifyReceivedCmd(addresses []string) *NotifyReceivedCmd {
 	return &NotifyReceivedCmd{
 		Addresses: addresses,
@@ -128,7 +128,7 @@ func NewLoadTxFilterCmd(reload bool, addresses []string, outPoints []OutPoint) *
 
 // NotifySpentCmd defines the notifyspent JSON-RPC command.
 //
-// NOTE: Deprecated. Use LoadTxFilterCmd instead.
+// Deprecated: Use LoadTxFilterCmd instead.
 type NotifySpentCmd struct {
 	OutPoints []OutPoint
 }
@@ -136,7 +136,7 @@ type NotifySpentCmd struct {
 // NewNotifySpentCmd returns a new instance which can be used to issue a
 // notifyspent JSON-RPC command.
 //
-// NOTE: Deprecated. Use NewLoadTxFilterCmd instead.
+// Deprecated: Use NewLoadTxFilterCmd instead.
 func NewNotifySpentCmd(outPoints []OutPoint) *NotifySpentCmd {
 	return &NotifySpentCmd{
 		OutPoints: outPoints,
@@ -145,7 +145,7 @@ func NewNotifySpentCmd(outPoints []OutPoint) *NotifySpentCmd {
 
 // StopNotifyReceivedCmd defines the stopnotifyreceived JSON-RPC command.
 //
-// NOTE: Deprecated. Use LoadTxFilterCmd instead.
+// Deprecated: Use LoadTxFilterCmd instead.
 type StopNotifyReceivedCmd struct {
 	Addresses []string
 }
@@ -153,7 +153,7 @@ type StopNotifyReceivedCmd struct {
 // NewStopNotifyReceivedCmd returns a new instance which can be used to issue a
 // stopnotifyreceived JSON-RPC command.
 //
-// NOTE: Deprecated. Use NewLoadTxFilterCmd instead.
+// Deprecated: Use NewLoadTxFilterCmd instead.
 func NewStopNotifyReceivedCmd(addresses []string) *StopNotifyReceivedCmd {
 	return &StopNotifyReceivedCmd{
 		Addresses: addresses,
@@ -162,7 +162,7 @@ func NewStopNotifyReceivedCmd(addresses []string) *StopNotifyReceivedCmd {
 
 // StopNotifySpentCmd defines the stopnotifyspent JSON-RPC command.
 //
-// NOTE: Deprecated. Use LoadTxFilterCmd instead.
+// Deprecated: Use LoadTxFilterCmd instead.
 type StopNotifySpentCmd struct {
 	OutPoints []OutPoint
 }
@@ -170,7 +170,7 @@ type StopNotifySpentCmd struct {
 // NewStopNotifySpentCmd returns a new instance which can be used to issue a
 // stopnotifyspent JSON-RPC command.
 //
-// NOTE: Deprecated. Use NewLoadTxFilterCmd instead.
+// Deprecated: Use NewLoadTxFilterCmd instead.
 func NewStopNotifySpentCmd(outPoints []OutPoint) *StopNotifySpentCmd {
 	return &StopNotifySpentCmd{
 		OutPoints: outPoints,
@@ -179,7 +179,7 @@ func NewStopNotifySpentCmd(outPoints []OutPoint) *StopNotifySpentCmd {
 
 // RescanCmd defines the rescan JSON-RPC command.
 //
-// NOTE: Deprecated. Use RescanBlocksCmd instead.
+// Deprecated: Use RescanBlocksCmd instead.
 type RescanCmd struct {
 	BeginBlock string
 	Addresses  []string
@@ -193,7 +193,7 @@ type RescanCmd struct {
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
 //
-// NOTE: Deprecated. Use NewRescanBlocksCmd instead.
+// Deprecated: Use NewRescanBlocksCmd instead.
 func NewRescanCmd(beginBlock string, addresses []string, outPoints []OutPoint, endBlock *string) *RescanCmd {
 	return &RescanCmd{
 		BeginBlock: beginBlock,

--- a/btcjson/chainsvrwsntfns.go
+++ b/btcjson/chainsvrwsntfns.go
@@ -12,14 +12,14 @@ const (
 	// BlockConnectedNtfnMethod is the legacy, deprecated method used for
 	// notifications from the chain server that a block has been connected.
 	//
-	// NOTE: Deprecated. Use FilteredBlockConnectedNtfnMethod instead.
+	// Deprecated: Use FilteredBlockConnectedNtfnMethod instead.
 	BlockConnectedNtfnMethod = "blockconnected"
 
 	// BlockDisconnectedNtfnMethod is the legacy, deprecated method used for
 	// notifications from the chain server that a block has been
 	// disconnected.
 	//
-	// NOTE: Deprecated. Use FilteredBlockDisconnectedNtfnMethod instead.
+	// Deprecated: Use FilteredBlockDisconnectedNtfnMethod instead.
 	BlockDisconnectedNtfnMethod = "blockdisconnected"
 
 	// FilteredBlockConnectedNtfnMethod is the new method used for
@@ -35,7 +35,7 @@ const (
 	// notifications from the chain server that a transaction which pays to
 	// a registered address has been processed.
 	//
-	// NOTE: Deprecated. Use RelevantTxAcceptedNtfnMethod and
+	// Deprecated: Use RelevantTxAcceptedNtfnMethod and
 	// FilteredBlockConnectedNtfnMethod instead.
 	RecvTxNtfnMethod = "recvtx"
 
@@ -43,7 +43,7 @@ const (
 	// notifications from the chain server that a transaction which spends a
 	// registered outpoint has been processed.
 	//
-	// NOTE: Deprecated. Use RelevantTxAcceptedNtfnMethod and
+	// Deprecated: Use RelevantTxAcceptedNtfnMethod and
 	// FilteredBlockConnectedNtfnMethod instead.
 	RedeemingTxNtfnMethod = "redeemingtx"
 
@@ -51,14 +51,14 @@ const (
 	// notifications from the chain server that a legacy, deprecated rescan
 	// operation has finished.
 	//
-	// NOTE: Deprecated. Not used with rescanblocks command.
+	// Deprecated: Not used with rescanblocks command.
 	RescanFinishedNtfnMethod = "rescanfinished"
 
 	// RescanProgressNtfnMethod is the legacy, deprecated method used for
 	// notifications from the chain server that a legacy, deprecated rescan
 	// operation this is underway has made progress.
 	//
-	// NOTE: Deprecated. Not used with rescanblocks command.
+	// Deprecated: Not used with rescanblocks command.
 	RescanProgressNtfnMethod = "rescanprogress"
 
 	// TxAcceptedNtfnMethod is the method used for notifications from the
@@ -79,7 +79,7 @@ const (
 
 // BlockConnectedNtfn defines the blockconnected JSON-RPC notification.
 //
-// NOTE: Deprecated. Use FilteredBlockConnectedNtfn instead.
+// Deprecated: Use FilteredBlockConnectedNtfn instead.
 type BlockConnectedNtfn struct {
 	Hash   string
 	Height int32
@@ -89,7 +89,7 @@ type BlockConnectedNtfn struct {
 // NewBlockConnectedNtfn returns a new instance which can be used to issue a
 // blockconnected JSON-RPC notification.
 //
-// NOTE: Deprecated. Use NewFilteredBlockConnectedNtfn instead.
+// Deprecated: Use NewFilteredBlockConnectedNtfn instead.
 func NewBlockConnectedNtfn(hash string, height int32, time int64) *BlockConnectedNtfn {
 	return &BlockConnectedNtfn{
 		Hash:   hash,
@@ -100,7 +100,7 @@ func NewBlockConnectedNtfn(hash string, height int32, time int64) *BlockConnecte
 
 // BlockDisconnectedNtfn defines the blockdisconnected JSON-RPC notification.
 //
-// NOTE: Deprecated. Use FilteredBlockDisconnectedNtfn instead.
+// Deprecated: Use FilteredBlockDisconnectedNtfn instead.
 type BlockDisconnectedNtfn struct {
 	Hash   string
 	Height int32
@@ -110,7 +110,7 @@ type BlockDisconnectedNtfn struct {
 // NewBlockDisconnectedNtfn returns a new instance which can be used to issue a
 // blockdisconnected JSON-RPC notification.
 //
-// NOTE: Deprecated. Use NewFilteredBlockDisconnectedNtfn instead.
+// Deprecated: Use NewFilteredBlockDisconnectedNtfn instead.
 func NewBlockDisconnectedNtfn(hash string, height int32, time int64) *BlockDisconnectedNtfn {
 	return &BlockDisconnectedNtfn{
 		Hash:   hash,
@@ -163,7 +163,7 @@ type BlockDetails struct {
 
 // RecvTxNtfn defines the recvtx JSON-RPC notification.
 //
-// NOTE: Deprecated. Use RelevantTxAcceptedNtfn and FilteredBlockConnectedNtfn
+// Deprecated: Use RelevantTxAcceptedNtfn and FilteredBlockConnectedNtfn
 // instead.
 type RecvTxNtfn struct {
 	HexTx string
@@ -173,7 +173,7 @@ type RecvTxNtfn struct {
 // NewRecvTxNtfn returns a new instance which can be used to issue a recvtx
 // JSON-RPC notification.
 //
-// NOTE: Deprecated. Use NewRelevantTxAcceptedNtfn and
+// Deprecated: Use NewRelevantTxAcceptedNtfn and
 // NewFilteredBlockConnectedNtfn instead.
 func NewRecvTxNtfn(hexTx string, block *BlockDetails) *RecvTxNtfn {
 	return &RecvTxNtfn{
@@ -184,7 +184,7 @@ func NewRecvTxNtfn(hexTx string, block *BlockDetails) *RecvTxNtfn {
 
 // RedeemingTxNtfn defines the redeemingtx JSON-RPC notification.
 //
-// NOTE: Deprecated. Use RelevantTxAcceptedNtfn and FilteredBlockConnectedNtfn
+// Deprecated: Use RelevantTxAcceptedNtfn and FilteredBlockConnectedNtfn
 // instead.
 type RedeemingTxNtfn struct {
 	HexTx string
@@ -194,7 +194,7 @@ type RedeemingTxNtfn struct {
 // NewRedeemingTxNtfn returns a new instance which can be used to issue a
 // redeemingtx JSON-RPC notification.
 //
-// NOTE: Deprecated. Use NewRelevantTxAcceptedNtfn and
+// Deprecated: Use NewRelevantTxAcceptedNtfn and
 // NewFilteredBlockConnectedNtfn instead.
 func NewRedeemingTxNtfn(hexTx string, block *BlockDetails) *RedeemingTxNtfn {
 	return &RedeemingTxNtfn{
@@ -205,7 +205,7 @@ func NewRedeemingTxNtfn(hexTx string, block *BlockDetails) *RedeemingTxNtfn {
 
 // RescanFinishedNtfn defines the rescanfinished JSON-RPC notification.
 //
-// NOTE: Deprecated. Not used with rescanblocks command.
+// Deprecated: Not used with rescanblocks command.
 type RescanFinishedNtfn struct {
 	Hash   string
 	Height int32
@@ -215,7 +215,7 @@ type RescanFinishedNtfn struct {
 // NewRescanFinishedNtfn returns a new instance which can be used to issue a
 // rescanfinished JSON-RPC notification.
 //
-// NOTE: Deprecated. Not used with rescanblocks command.
+// Deprecated: Not used with rescanblocks command.
 func NewRescanFinishedNtfn(hash string, height int32, time int64) *RescanFinishedNtfn {
 	return &RescanFinishedNtfn{
 		Hash:   hash,
@@ -226,7 +226,7 @@ func NewRescanFinishedNtfn(hash string, height int32, time int64) *RescanFinishe
 
 // RescanProgressNtfn defines the rescanprogress JSON-RPC notification.
 //
-// NOTE: Deprecated. Not used with rescanblocks command.
+// Deprecated: Not used with rescanblocks command.
 type RescanProgressNtfn struct {
 	Hash   string
 	Height int32
@@ -236,7 +236,7 @@ type RescanProgressNtfn struct {
 // NewRescanProgressNtfn returns a new instance which can be used to issue a
 // rescanprogress JSON-RPC notification.
 //
-// NOTE: Deprecated. Not used with rescanblocks command.
+// Deprecated: Not used with rescanblocks command.
 func NewRescanProgressNtfn(hash string, height int32, time int64) *RescanProgressNtfn {
 	return &RescanProgressNtfn{
 		Hash:   hash,

--- a/rpcclient/notify.go
+++ b/rpcclient/notify.go
@@ -95,7 +95,7 @@ type NotificationHandlers struct {
 	// NotifyBlocks has been made to register for the notification and the
 	// function is non-nil.
 	//
-	// NOTE: Deprecated. Use OnFilteredBlockConnected instead.
+	// Deprecated: Use OnFilteredBlockConnected instead.
 	OnBlockConnected func(hash *chainhash.Hash, height int32, t time.Time)
 
 	// OnFilteredBlockConnected is invoked when a block is connected to the
@@ -111,7 +111,7 @@ type NotificationHandlers struct {
 	// NotifyBlocks has been made to register for the notification and the
 	// function is non-nil.
 	//
-	// NOTE: Deprecated. Use OnFilteredBlockDisconnected instead.
+	// Deprecated: Use OnFilteredBlockDisconnected instead.
 	OnBlockDisconnected func(hash *chainhash.Hash, height int32, t time.Time)
 
 	// OnFilteredBlockDisconnected is invoked when a block is disconnected
@@ -127,7 +127,7 @@ type NotificationHandlers struct {
 	// preceding call to NotifyReceived, Rescan, or RescanEndHeight has been
 	// made to register for the notification and the function is non-nil.
 	//
-	// NOTE: Deprecated. Use OnRelevantTxAccepted instead.
+	// Deprecated: Use OnRelevantTxAccepted instead.
 	OnRecvTx func(transaction *btcutil.Tx, details *btcjson.BlockDetails)
 
 	// OnRedeemingTx is invoked when a transaction that spends a registered
@@ -141,7 +141,7 @@ type NotificationHandlers struct {
 	// funds to the registered addresses.  This means it is possible for
 	// this to invoked indirectly as the result of a NotifyReceived call.
 	//
-	// NOTE: Deprecated. Use OnRelevantTxAccepted instead.
+	// Deprecated: Use OnRelevantTxAccepted instead.
 	OnRedeemingTx func(transaction *btcutil.Tx, details *btcjson.BlockDetails)
 
 	// OnRelevantTxAccepted is invoked when an unmined transaction passes
@@ -157,14 +157,14 @@ type NotificationHandlers struct {
 	// result of a rescan request, due to how btcd may send various rescan
 	// notifications after the rescan request has already returned.
 	//
-	// NOTE: Deprecated. Not used with RescanBlocks.
+	// Deprecated: Not used with RescanBlocks.
 	OnRescanFinished func(hash *chainhash.Hash, height int32, blkTime time.Time)
 
 	// OnRescanProgress is invoked periodically when a rescan is underway.
 	// It will only be invoked if a preceding call to Rescan or
 	// RescanEndHeight has been made and the function is non-nil.
 	//
-	// NOTE: Deprecated. Not used with RescanBlocks.
+	// Deprecated: Not used with RescanBlocks.
 	OnRescanProgress func(hash *chainhash.Hash, height int32, blkTime time.Time)
 
 	// OnTxAccepted is invoked when a transaction is accepted into the
@@ -905,7 +905,7 @@ func (c *Client) NotifyBlocks() error {
 // FutureNotifySpentResult is a future promise to deliver the result of a
 // NotifySpentAsync RPC invocation (or an applicable error).
 //
-// NOTE: Deprecated. Use FutureLoadTxFilterResult instead.
+// Deprecated: Use FutureLoadTxFilterResult instead.
 type FutureNotifySpentResult chan *response
 
 // Receive waits for the response promised by the future and returns an error
@@ -951,7 +951,7 @@ func newOutPointFromWire(op *wire.OutPoint) btcjson.OutPoint {
 //
 // NOTE: This is a btcd extension and requires a websocket connection.
 //
-// NOTE: Deprecated. Use LoadTxFilterAsync instead.
+// Deprecated: Use LoadTxFilterAsync instead.
 func (c *Client) NotifySpentAsync(outpoints []*wire.OutPoint) FutureNotifySpentResult {
 	// Not supported in HTTP POST mode.
 	if c.config.HTTPPostMode {
@@ -983,7 +983,7 @@ func (c *Client) NotifySpentAsync(outpoints []*wire.OutPoint) FutureNotifySpentR
 //
 // NOTE: This is a btcd extension and requires a websocket connection.
 //
-// NOTE: Deprecated. Use LoadTxFilter instead.
+// Deprecated: Use LoadTxFilter instead.
 func (c *Client) NotifySpent(outpoints []*wire.OutPoint) error {
 	return c.NotifySpentAsync(outpoints).Receive()
 }
@@ -1040,7 +1040,7 @@ func (c *Client) NotifyNewTransactions(verbose bool) error {
 // FutureNotifyReceivedResult is a future promise to deliver the result of a
 // NotifyReceivedAsync RPC invocation (or an applicable error).
 //
-// NOTE: Deprecated. Use FutureLoadTxFilterResult instead.
+// Deprecated: Use FutureLoadTxFilterResult instead.
 type FutureNotifyReceivedResult chan *response
 
 // Receive waits for the response promised by the future and returns an error
@@ -1078,7 +1078,7 @@ func (c *Client) notifyReceivedInternal(addresses []string) FutureNotifyReceived
 //
 // NOTE: This is a btcd extension and requires a websocket connection.
 //
-// NOTE: Deprecated. Use LoadTxFilterAsync instead.
+// Deprecated: Use LoadTxFilterAsync instead.
 func (c *Client) NotifyReceivedAsync(addresses []btcutil.Address) FutureNotifyReceivedResult {
 	// Not supported in HTTP POST mode.
 	if c.config.HTTPPostMode {
@@ -1118,7 +1118,7 @@ func (c *Client) NotifyReceivedAsync(addresses []btcutil.Address) FutureNotifyRe
 //
 // NOTE: This is a btcd extension and requires a websocket connection.
 //
-// NOTE: Deprecated. Use LoadTxFilter instead.
+// Deprecated: Use LoadTxFilter instead.
 func (c *Client) NotifyReceived(addresses []btcutil.Address) error {
 	return c.NotifyReceivedAsync(addresses).Receive()
 }
@@ -1126,7 +1126,7 @@ func (c *Client) NotifyReceived(addresses []btcutil.Address) error {
 // FutureRescanResult is a future promise to deliver the result of a RescanAsync
 // or RescanEndHeightAsync RPC invocation (or an applicable error).
 //
-// NOTE: Deprecated. Use FutureRescanBlocksResult instead.
+// Deprecated: Use FutureRescanBlocksResult instead.
 type FutureRescanResult chan *response
 
 // Receive waits for the response promised by the future and returns an error
@@ -1150,7 +1150,7 @@ func (r FutureRescanResult) Receive() error {
 //
 // NOTE: This is a btcd extension and requires a websocket connection.
 //
-// NOTE: Deprecated. Use RescanBlocksAsync instead.
+// Deprecated: Use RescanBlocksAsync instead.
 func (c *Client) RescanAsync(startBlock *chainhash.Hash,
 	addresses []btcutil.Address,
 	outpoints []*wire.OutPoint) FutureRescanResult {
@@ -1215,7 +1215,7 @@ func (c *Client) RescanAsync(startBlock *chainhash.Hash,
 //
 // NOTE: This is a btcd extension and requires a websocket connection.
 //
-// NOTE: Deprecated. Use RescanBlocks instead.
+// Deprecated: Use RescanBlocks instead.
 func (c *Client) Rescan(startBlock *chainhash.Hash,
 	addresses []btcutil.Address,
 	outpoints []*wire.OutPoint) error {
@@ -1231,7 +1231,7 @@ func (c *Client) Rescan(startBlock *chainhash.Hash,
 //
 // NOTE: This is a btcd extension and requires a websocket connection.
 //
-// NOTE: Deprecated. Use RescanBlocksAsync instead.
+// Deprecated: Use RescanBlocksAsync instead.
 func (c *Client) RescanEndBlockAsync(startBlock *chainhash.Hash,
 	addresses []btcutil.Address, outpoints []*wire.OutPoint,
 	endBlock *chainhash.Hash) FutureRescanResult {
@@ -1293,7 +1293,7 @@ func (c *Client) RescanEndBlockAsync(startBlock *chainhash.Hash,
 //
 // NOTE: This is a btcd extension and requires a websocket connection.
 //
-// NOTE: Deprecated. Use RescanBlocks instead.
+// Deprecated: Use RescanBlocks instead.
 func (c *Client) RescanEndHeight(startBlock *chainhash.Hash,
 	addresses []btcutil.Address, outpoints []*wire.OutPoint,
 	endBlock *chainhash.Hash) error {


### PR DESCRIPTION
This makes godoc and other Go tools understand deprecation notice.

Found using https://go-critic.github.io/overview#deprecatedComment-ref