### PR TITLE
simplify `x = x <op> ...` to `x <op>= ...`

### DIFF
--- a/btcd.go
+++ b/btcd.go
@@ -204,7 +204,7 @@ func blockDbPath(dbType string) string {
 	// The database name is based on the database type.
 	dbName := blockDbNamePrefix + "_" + dbType
 	if dbType == "sqlite" {
-		dbName = dbName + ".db"
+		dbName += ".db"
 	}
 	dbPath := filepath.Join(cfg.DataDir, dbName)
 	return dbPath

--- a/btcec/field.go
+++ b/btcec/field.go
@@ -277,26 +277,26 @@ func (f *fieldVal) Normalize() *fieldVal {
 	// additional carry to bit 256 (bit 22 of the high order word).
 	t9 := f.n[9]
 	m := t9 >> fieldMSBBits
-	t9 = t9 & fieldMSBMask
+	t9 &= fieldMSBMask
 	t0 := f.n[0] + m*977
 	t1 := (t0 >> fieldBase) + f.n[1] + (m << 6)
-	t0 = t0 & fieldBaseMask
+	t0 &= fieldBaseMask
 	t2 := (t1 >> fieldBase) + f.n[2]
-	t1 = t1 & fieldBaseMask
+	t1 &= fieldBaseMask
 	t3 := (t2 >> fieldBase) + f.n[3]
-	t2 = t2 & fieldBaseMask
+	t2 &= fieldBaseMask
 	t4 := (t3 >> fieldBase) + f.n[4]
-	t3 = t3 & fieldBaseMask
+	t3 &= fieldBaseMask
 	t5 := (t4 >> fieldBase) + f.n[5]
-	t4 = t4 & fieldBaseMask
+	t4 &= fieldBaseMask
 	t6 := (t5 >> fieldBase) + f.n[6]
-	t5 = t5 & fieldBaseMask
+	t5 &= fieldBaseMask
 	t7 := (t6 >> fieldBase) + f.n[7]
-	t6 = t6 & fieldBaseMask
+	t6 &= fieldBaseMask
 	t8 := (t7 >> fieldBase) + f.n[8]
-	t7 = t7 & fieldBaseMask
+	t7 &= fieldBaseMask
 	t9 = (t8 >> fieldBase) + t9
-	t8 = t8 & fieldBaseMask
+	t8 &= fieldBaseMask
 
 	// At this point, the magnitude is guaranteed to be one, however, the
 	// value could still be greater than the prime if there was either a
@@ -331,26 +331,26 @@ func (f *fieldVal) Normalize() *fieldVal {
 	} else {
 		m |= 0
 	}
-	t0 = t0 + m*977
+	t0 += m * 977
 	t1 = (t0 >> fieldBase) + t1 + (m << 6)
-	t0 = t0 & fieldBaseMask
+	t0 &= fieldBaseMask
 	t2 = (t1 >> fieldBase) + t2
-	t1 = t1 & fieldBaseMask
+	t1 &= fieldBaseMask
 	t3 = (t2 >> fieldBase) + t3
-	t2 = t2 & fieldBaseMask
+	t2 &= fieldBaseMask
 	t4 = (t3 >> fieldBase) + t4
-	t3 = t3 & fieldBaseMask
+	t3 &= fieldBaseMask
 	t5 = (t4 >> fieldBase) + t5
-	t4 = t4 & fieldBaseMask
+	t4 &= fieldBaseMask
 	t6 = (t5 >> fieldBase) + t6
-	t5 = t5 & fieldBaseMask
+	t5 &= fieldBaseMask
 	t7 = (t6 >> fieldBase) + t7
-	t6 = t6 & fieldBaseMask
+	t6 &= fieldBaseMask
 	t8 = (t7 >> fieldBase) + t8
-	t7 = t7 & fieldBaseMask
+	t7 &= fieldBaseMask
 	t9 = (t8 >> fieldBase) + t9
-	t8 = t8 & fieldBaseMask
-	t9 = t9 & fieldMSBMask // Remove potential multiple of 2^256.
+	t8 &= fieldBaseMask
+	t9 &= fieldMSBMask // Remove potential multiple of 2^256.
 
 	// Finally, set the normalized and reduced words.
 	f.n[0] = t0
@@ -848,7 +848,7 @@ func (f *fieldVal) Mul2(val *fieldVal, val2 *fieldVal) *fieldVal {
 	t8 = m & fieldBaseMask
 	m = (m >> fieldBase) + t9 + t18*1024 + t19*68719492368
 	t9 = m & fieldMSBMask
-	m = m >> fieldMSBBits
+	m >>= fieldMSBBits
 
 	// At this point, if the magnitude is greater than 0, the overall value
 	// is greater than the max possible 256-bit value.  In particular, it is
@@ -1081,7 +1081,7 @@ func (f *fieldVal) SquareVal(val *fieldVal) *fieldVal {
 	t8 = m & fieldBaseMask
 	m = (m >> fieldBase) + t9 + t18*1024 + t19*68719492368
 	t9 = m & fieldMSBMask
-	m = m >> fieldMSBBits
+	m >>= fieldMSBBits
 
 	// At this point, if the magnitude is greater than 0, the overall value
 	// is greater than the max possible 256-bit value.  In particular, it is

--- a/btcjson/cmdinfo.go
+++ b/btcjson/cmdinfo.go
@@ -103,7 +103,7 @@ func subArrayUsage(arrayType reflect.Type, fieldName string) string {
 	singularFieldName := fieldName
 	if strings.HasSuffix(fieldName, "ies") {
 		singularFieldName = strings.TrimSuffix(fieldName, "ies")
-		singularFieldName = singularFieldName + "y"
+		singularFieldName += "y"
 	} else if strings.HasSuffix(fieldName, "es") {
 		singularFieldName = strings.TrimSuffix(fieldName, "es")
 	} else if strings.HasSuffix(fieldName, "s") {

--- a/peer/log.go
+++ b/peer/log.go
@@ -137,7 +137,7 @@ func sanitizeString(str string, maxLength uint) string {
 	// Limit the string to the max allowed length.
 	if maxLength > 0 && uint(len(str)) > maxLength {
 		str = str[:maxLength]
-		str = str + "..."
+		str += "..."
 	}
 	return str
 }

--- a/server.go
+++ b/server.go
@@ -2335,7 +2335,7 @@ func (s *server) ScheduleShutdown(duration time.Duration) {
 				s.Stop()
 				break out
 			case <-ticker.C:
-				remaining = remaining - tickDuration
+				remaining -= tickDuration
 				if remaining < time.Second {
 					continue
 				}

--- a/upgrade.go
+++ b/upgrade.go
@@ -68,7 +68,7 @@ func upgradeDBPathNet(oldDbPath, netName string) error {
 		newDbRoot := filepath.Join(filepath.Dir(cfg.DataDir), netName)
 		newDbName := blockDbNamePrefix + "_" + oldDbType
 		if oldDbType == "sqlite" {
-			newDbName = newDbName + ".db"
+			newDbName += ".db"
 		}
 		newDbPath := filepath.Join(newDbRoot, newDbName)
 


### PR DESCRIPTION
Found using https://go-critic.github.io/overview#assignOp-ref