### PR TITLE
Adding a method to send a pre-serialized raw transaction

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -4,7 +4,9 @@
 
 package btcjson
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 // GetBlockHeaderVerboseResult models the data from the getblockheader command when
 // the verbose flag is set.  When the verbose flag is not set, getblockheader
@@ -471,7 +473,7 @@ type GetMiningInfoResult struct {
 	Generate           bool    `json:"generate"`
 	GenProcLimit       int32   `json:"genproclimit"`
 	HashesPerSec       int64   `json:"hashespersec"`
-	NetworkHashPS      int64   `json:"networkhashps"`
+	NetworkHashPS      float64  `json:"networkhashps"`
 	PooledTx           uint64  `json:"pooledtx"`
 	TestNet            bool    `json:"testnet"`
 }

--- a/rpcclient/rawtransactions.go
+++ b/rpcclient/rawtransactions.go
@@ -13,6 +13,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
+	"errors"
 )
 
 // SigHashType enumerates the available signature hashing types that the
@@ -285,8 +286,7 @@ func (r FutureSendRawTransactionResult) Receive() (*chainhash.Hash, error) {
 // the returned instance.
 //
 // See SendRawTransaction for the blocking version and more details.
-func (c *Client) SendRawTransactionAsync(tx *wire.MsgTx, allowHighFees bool) FutureSendRawTransactionResult {
-	txHex := ""
+func (c *Client) SendRawTransactionAsync(tx *wire.MsgTx, txHex string, allowHighFees bool) FutureSendRawTransactionResult {
 	if tx != nil {
 		// Serialize the transaction and convert to hex string.
 		buf := bytes.NewBuffer(make([]byte, 0, tx.SerializeSize()))
@@ -294,6 +294,8 @@ func (c *Client) SendRawTransactionAsync(tx *wire.MsgTx, allowHighFees bool) Fut
 			return newFutureError(err)
 		}
 		txHex = hex.EncodeToString(buf.Bytes())
+	} else if txHex == "" {
+		return newFutureError(errors.New("no transaction data provided, msgTx and txHex are both empty"))
 	}
 
 	cmd := btcjson.NewSendRawTransactionCmd(txHex, &allowHighFees)
@@ -303,7 +305,13 @@ func (c *Client) SendRawTransactionAsync(tx *wire.MsgTx, allowHighFees bool) Fut
 // SendRawTransaction submits the encoded transaction to the server which will
 // then relay it to the network.
 func (c *Client) SendRawTransaction(tx *wire.MsgTx, allowHighFees bool) (*chainhash.Hash, error) {
-	return c.SendRawTransactionAsync(tx, allowHighFees).Receive()
+	return c.SendRawTransactionAsync(tx, "", allowHighFees).Receive()
+}
+
+// SendRawSerializedTransaction submits the pre-serialized transaction to the server which will
+// then relay it to the network.
+func (c *Client) SendRawSerializedTransaction(txHex string, allowHighFees bool) (*chainhash.Hash, error) {
+	return c.SendRawTransactionAsync(nil, txHex, allowHighFees).Receive()
 }
 
 // FutureSignRawTransactionResult is a future promise to deliver the result

--- a/rpcclient/rawtransactions.go
+++ b/rpcclient/rawtransactions.go
@@ -9,11 +9,11 @@ import (
 	"encoding/hex"
 	"encoding/json"
 
+	"errors"
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
-	"errors"
 )
 
 // SigHashType enumerates the available signature hashing types that the

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2345,7 +2345,7 @@ func handleGetMiningInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 	if err != nil {
 		return nil, err
 	}
-	networkHashesPerSec, ok := networkHashesPerSecIface.(int64)
+	networkHashesPerSec, ok := networkHashesPerSecIface.(float64)
 	if !ok {
 		return nil, &btcjson.RPCError{
 			Code:    btcjson.ErrRPCInternal.Code,
@@ -2355,17 +2355,16 @@ func handleGetMiningInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 
 	best := s.cfg.Chain.BestSnapshot()
 	result := btcjson.GetMiningInfoResult{
-		Blocks:             int64(best.Height),
-		CurrentBlockSize:   best.BlockSize,
-		CurrentBlockWeight: best.BlockWeight,
-		CurrentBlockTx:     best.NumTxns,
-		Difficulty:         getDifficultyRatio(best.Bits, s.cfg.ChainParams),
-		Generate:           s.cfg.CPUMiner.IsMining(),
-		GenProcLimit:       s.cfg.CPUMiner.NumWorkers(),
-		HashesPerSec:       int64(s.cfg.CPUMiner.HashesPerSecond()),
-		NetworkHashPS:      networkHashesPerSec,
-		PooledTx:           uint64(s.cfg.TxMemPool.Count()),
-		TestNet:            cfg.TestNet3,
+		Blocks:           int64(best.Height),
+		CurrentBlockSize: best.BlockSize,
+		CurrentBlockTx:   best.NumTxns,
+		Difficulty:       getDifficultyRatio(best.Bits, s.cfg.ChainParams),
+		Generate:         s.cfg.CPUMiner.IsMining(),
+		GenProcLimit:     s.cfg.CPUMiner.NumWorkers(),
+		HashesPerSec:     int64(s.cfg.CPUMiner.HashesPerSecond()),
+		NetworkHashPS:    networkHashesPerSec,
+		PooledTx:         uint64(s.cfg.TxMemPool.Count()),
+		TestNet:          cfg.TestNet3,
 	}
 	return &result, nil
 }
@@ -2433,7 +2432,7 @@ func handleGetNetworkHashPS(s *rpcServer, cmd interface{}, closeChan <-chan stru
 	// Find the min and max block timestamps as well as calculate the total
 	// amount of work that happened between the start and end blocks.
 	var minTimestamp, maxTimestamp time.Time
-	totalWork := big.NewInt(0)
+	totalWork := big.NewFloat(0.0)
 	for curHeight := startHeight; curHeight <= endHeight; curHeight++ {
 		hash, err := s.cfg.Chain.BlockHashByHeight(curHeight)
 		if err != nil {
@@ -2452,7 +2451,7 @@ func handleGetNetworkHashPS(s *rpcServer, cmd interface{}, closeChan <-chan stru
 			minTimestamp = header.Timestamp
 			maxTimestamp = minTimestamp
 		} else {
-			totalWork.Add(totalWork, blockchain.CalcWork(header.Bits))
+			totalWork.Add(totalWork, new(big.Float).SetInt(blockchain.CalcWork(header.Bits)))
 
 			if minTimestamp.After(header.Timestamp) {
 				minTimestamp = header.Timestamp
@@ -2468,11 +2467,11 @@ func handleGetNetworkHashPS(s *rpcServer, cmd interface{}, closeChan <-chan stru
 	// time difference.
 	timeDiff := int64(maxTimestamp.Sub(minTimestamp) / time.Second)
 	if timeDiff == 0 {
-		return int64(0), nil
+		return float64(0), nil
 	}
 
-	hashesPerSec := new(big.Int).Div(totalWork, big.NewInt(timeDiff))
-	return hashesPerSec.Int64(), nil
+	hashesPerSec, _ := new(big.Float).Quo(totalWork, new(big.Float).SetInt64(timeDiff)).Float64()
+	return hashesPerSec, nil
 }
 
 // handleGetPeerInfo implements the getpeerinfo command.


### PR DESCRIPTION
- this is useful when we want to process a transaction that has been previously signed by another party without requiring the private key
- this can be used nicely on a node configured with txindex=1, so there's no need to import the other party wallet
