### PR TITLE
Fix issue with AddMultisigAddress callback unmarshalling wrong object

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -47,6 +47,13 @@ type GetBlockVerboseResult struct {
 	NextHash      string        `json:"nextblockhash,omitempty"`
 }
 
+// AddMultisigAddressResult models the data returned from the addmultisigaddress
+// command.
+type AddMultisigAddressResult struct {
+	Address      string `json:"address"`
+	RedeemScript string `json:"redeemScript"`
+}
+
 // CreateMultiSigResult models the data returned from the createmultisig
 // command.
 type CreateMultiSigResult struct {

--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -764,14 +764,14 @@ func (r FutureAddMultisigAddressResult) Receive() (btcutil.Address, error) {
 		return nil, err
 	}
 
-	// Unmarshal result as a string.
-	var addr string
-	err = json.Unmarshal(res, &addr)
+	// Unmarshal result as a addmultisigaddress result object.
+	var addmultisigRes btcjson.AddMultisigAddressResult
+	err = json.Unmarshal(res, &addmultisigRes)
 	if err != nil {
 		return nil, err
 	}
 
-	return btcutil.DecodeAddress(addr, &chaincfg.MainNetParams)
+	return btcutil.DecodeAddress(addmultisigRes.Address, &chaincfg.MainNetParams)
 }
 
 // AddMultisigAddressAsync returns an instance of a type that can be used to get


### PR DESCRIPTION
AddMultisigAddress was doing unmarshall on string instead of result object from addmultisigaddress, which is the same as createmultisig result