### PR TITLE
Alphabetize --help output; add missing options to doc.go

### DIFF
--- a/cmd/addblock/config.go
+++ b/cmd/addblock/config.go
@@ -34,15 +34,15 @@ var (
 //
 // See loadConfig for details on the configuration load process.
 type config struct {
+	AddrIndex      bool   `long:"addrindex" description:"Build a full address-based transaction index which makes the searchrawtransactions RPC available"`
 	DataDir        string `short:"b" long:"datadir" description:"Location of the btcd data directory"`
 	DbType         string `long:"dbtype" description:"Database backend to use for the Block Chain"`
-	TestNet3       bool   `long:"testnet" description:"Use the test network"`
+	InFile         string `short:"i" long:"infile" description:"File containing the block(s)"`
+	Progress       int    `short:"p" long:"progress" description:"Show a progress message each time this number of seconds have passed -- Use 0 to disable progress announcements"`
 	RegressionTest bool   `long:"regtest" description:"Use the regression test network"`
 	SimNet         bool   `long:"simnet" description:"Use the simulation test network"`
-	InFile         string `short:"i" long:"infile" description:"File containing the block(s)"`
+	TestNet3       bool   `long:"testnet" description:"Use the test network"`
 	TxIndex        bool   `long:"txindex" description:"Build a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
-	AddrIndex      bool   `long:"addrindex" description:"Build a full address-based transaction index which makes the searchrawtransactions RPC available"`
-	Progress       int    `short:"p" long:"progress" description:"Show a progress message each time this number of seconds have passed -- Use 0 to disable progress announcements"`
 }
 
 // filesExists reports whether the named file or directory exists.

--- a/cmd/btcctl/config.go
+++ b/cmd/btcctl/config.go
@@ -92,20 +92,20 @@ func listCommands() {
 //
 // See loadConfig for details on the configuration load process.
 type config struct {
-	ShowVersion   bool   `short:"V" long:"version" description:"Display version information and exit"`
-	ListCommands  bool   `short:"l" long:"listcommands" description:"List all of the supported commands and exit"`
 	ConfigFile    string `short:"C" long:"configfile" description:"Path to configuration file"`
-	RPCUser       string `short:"u" long:"rpcuser" description:"RPC username"`
-	RPCPassword   string `short:"P" long:"rpcpass" default-mask:"-" description:"RPC password"`
-	RPCServer     string `short:"s" long:"rpcserver" description:"RPC server to connect to"`
-	RPCCert       string `short:"c" long:"rpccert" description:"RPC server certificate chain for validation"`
+	ListCommands  bool   `short:"l" long:"listcommands" description:"List all of the supported commands and exit"`
 	NoTLS         bool   `long:"notls" description:"Disable TLS"`
 	Proxy         string `long:"proxy" description:"Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
-	ProxyUser     string `long:"proxyuser" description:"Username for proxy server"`
 	ProxyPass     string `long:"proxypass" default-mask:"-" description:"Password for proxy server"`
-	TestNet3      bool   `long:"testnet" description:"Connect to testnet"`
+	ProxyUser     string `long:"proxyuser" description:"Username for proxy server"`
+	RPCCert       string `short:"c" long:"rpccert" description:"RPC server certificate chain for validation"`
+	RPCPassword   string `short:"P" long:"rpcpass" default-mask:"-" description:"RPC password"`
+	RPCServer     string `short:"s" long:"rpcserver" description:"RPC server to connect to"`
+	RPCUser       string `short:"u" long:"rpcuser" description:"RPC username"`
 	SimNet        bool   `long:"simnet" description:"Connect to the simulation test network"`
 	TLSSkipVerify bool   `long:"skipverify" description:"Do not verify tls certificates (not recommended!)"`
+	TestNet3      bool   `long:"testnet" description:"Connect to testnet"`
+	ShowVersion   bool   `short:"V" long:"version" description:"Display version information and exit"`
 	Wallet        bool   `long:"wallet" description:"Connect to wallet"`
 }
 

--- a/cmd/findcheckpoint/config.go
+++ b/cmd/findcheckpoint/config.go
@@ -37,11 +37,11 @@ var (
 type config struct {
 	DataDir        string `short:"b" long:"datadir" description:"Location of the btcd data directory"`
 	DbType         string `long:"dbtype" description:"Database backend to use for the Block Chain"`
-	TestNet3       bool   `long:"testnet" description:"Use the test network"`
+	UseGoOutput    bool   `short:"g" long:"gooutput" description:"Display the candidates using Go syntax that is ready to insert into the btcchain checkpoint list"`
+	NumCandidates  int    `short:"n" long:"numcandidates" description:"Max num of checkpoint candidates to show {1-20}"`
 	RegressionTest bool   `long:"regtest" description:"Use the regression test network"`
 	SimNet         bool   `long:"simnet" description:"Use the simulation test network"`
-	NumCandidates  int    `short:"n" long:"numcandidates" description:"Max num of checkpoint candidates to show {1-20}"`
-	UseGoOutput    bool   `short:"g" long:"gooutput" description:"Display the candidates using Go syntax that is ready to insert into the btcchain checkpoint list"`
+	TestNet3       bool   `long:"testnet" description:"Use the test network"`
 }
 
 // validDbType returns whether or not dbType is a supported database type.

--- a/cmd/gencerts/gencerts.go
+++ b/cmd/gencerts/gencerts.go
@@ -18,10 +18,10 @@ import (
 
 type config struct {
 	Directory    string   `short:"d" long:"directory" description:"Directory to write certificate pair"`
-	Years        int      `short:"y" long:"years" description:"How many years a certificate is valid for"`
-	Organization string   `short:"o" long:"org" description:"Organization in certificate"`
-	ExtraHosts   []string `short:"H" long:"host" description:"Additional hosts/IPs to create certificate for"`
 	Force        bool     `short:"f" long:"force" description:"Force overwriting of any old certs and keys"`
+	ExtraHosts   []string `short:"H" long:"host" description:"Additional hosts/IPs to create certificate for"`
+	Organization string   `short:"o" long:"org" description:"Organization in certificate"`
+	Years        int      `short:"y" long:"years" description:"How many years a certificate is valid for"`
 }
 
 func main() {

--- a/config.go
+++ b/config.go
@@ -93,79 +93,79 @@ func minUint32(a, b uint32) uint32 {
 //
 // See loadConfig for details on the configuration load process.
 type config struct {
-	ShowVersion          bool          `short:"V" long:"version" description:"Display version information and exit"`
-	ConfigFile           string        `short:"C" long:"configfile" description:"Path to configuration file"`
-	DataDir              string        `short:"b" long:"datadir" description:"Directory to store data"`
-	LogDir               string        `long:"logdir" description:"Directory to log output."`
+	AddCheckpoints       []string      `long:"addcheckpoint" description:"Add a custom checkpoint.  Format: '<height>:<hash>'"`
 	AddPeers             []string      `short:"a" long:"addpeer" description:"Add a peer to connect with at startup"`
-	ConnectPeers         []string      `long:"connect" description:"Connect only to the specified peers at startup"`
-	DisableListen        bool          `long:"nolisten" description:"Disable listening for incoming connections -- NOTE: Listening is automatically disabled if the --connect or --proxy options are used without also specifying listen interfaces via --listen"`
-	Listeners            []string      `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 8333, testnet: 18333)"`
-	MaxPeers             int           `long:"maxpeers" description:"Max number of inbound and outbound peers"`
-	DisableBanning       bool          `long:"nobanning" description:"Disable banning of misbehaving peers"`
+	AddrIndex            bool          `long:"addrindex" description:"Maintain a full address-based transaction index which makes the searchrawtransactions RPC available"`
+  AgentBlacklist       []string      `long:"agentblacklist" description:"A comma separated list of user-agent substrings which will cause btcd to reject any peers whose user-agent contains any of the blacklisted substrings."`
+	AgentWhitelist       []string      `long:"agentwhitelist" description:"A comma separated list of user-agent substrings which will cause btcd to require all peers' user-agents to contain one of the whitelisted substrings. The blacklist is applied before the blacklist, and an empty whitelist will allow all agents that do not fail the blacklist."`"`
 	BanDuration          time.Duration `long:"banduration" description:"How long to ban misbehaving peers.  Valid time units are {s, m, h}.  Minimum 1 second"`
 	BanThreshold         uint32        `long:"banthreshold" description:"Maximum allowed ban score before disconnecting and banning misbehaving peers."`
-	Whitelists           []string      `long:"whitelist" description:"Add an IP network or IP that will not be banned. (eg. 192.168.1.0/24 or ::1)"`
-	AgentBlacklist       []string      `long:"agentblacklist" description:"A comma separated list of user-agent substrings which will cause btcd to reject any peers whose user-agent contains any of the blacklisted substrings."`
-	AgentWhitelist       []string      `long:"agentwhitelist" description:"A comma separated list of user-agent substrings which will cause btcd to require all peers' user-agents to contain one of the whitelisted substrings. The blacklist is applied before the blacklist, and an empty whitelist will allow all agents that do not fail the blacklist."`
-	RPCUser              string        `short:"u" long:"rpcuser" description:"Username for RPC connections"`
-	RPCPass              string        `short:"P" long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
-	RPCLimitUser         string        `long:"rpclimituser" description:"Username for limited RPC connections"`
-	RPCLimitPass         string        `long:"rpclimitpass" default-mask:"-" description:"Password for limited RPC connections"`
-	RPCListeners         []string      `long:"rpclisten" description:"Add an interface/port to listen for RPC connections (default port: 8334, testnet: 18334)"`
-	RPCCert              string        `long:"rpccert" description:"File containing the certificate file"`
-	RPCKey               string        `long:"rpckey" description:"File containing the certificate key"`
-	RPCMaxClients        int           `long:"rpcmaxclients" description:"Max number of RPC clients for standard connections"`
-	RPCMaxWebsockets     int           `long:"rpcmaxwebsockets" description:"Max number of RPC websocket connections"`
-	RPCMaxConcurrentReqs int           `long:"rpcmaxconcurrentreqs" description:"Max number of concurrent RPC requests that may be processed concurrently"`
-	RPCQuirks            bool          `long:"rpcquirks" description:"Mirror some JSON-RPC quirks of Bitcoin Core -- NOTE: Discouraged unless interoperability issues need to be worked around"`
+	BlockMaxSize         uint32        `long:"blockmaxsize" description:"Maximum block size in bytes to be used when creating a block"`
+	BlockMinSize         uint32        `long:"blockminsize" description:"Mininum block size in bytes to be used when creating a block"`
+	BlockMaxWeight       uint32        `long:"blockmaxweight" description:"Maximum block weight to be used when creating a block"`
+	BlockMinWeight       uint32        `long:"blockminweight" description:"Mininum block weight to be used when creating a block"`
+	BlockPrioritySize    uint32        `long:"blockprioritysize" description:"Size in bytes for high-priority/low-fee transactions when creating a block"`
+	BlocksOnly           bool          `long:"blocksonly" description:"Do not accept transactions from remote peers."`
+	ConfigFile           string        `short:"C" long:"configfile" description:"Path to configuration file"`
+	ConnectPeers         []string      `long:"connect" description:"Connect only to the specified peers at startup"`
+	CPUProfile           string        `long:"cpuprofile" description:"Write CPU profile to the specified file"`
+	DataDir              string        `short:"b" long:"datadir" description:"Directory to store data"`
+	DbType               string        `long:"dbtype" description:"Database backend to use for the Block Chain"`
+	DebugLevel           string        `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
+	DropAddrIndex        bool          `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up and then exits."`
+	DropCfIndex          bool          `long:"dropcfindex" description:"Deletes the index used for committed filtering (CF) support from the database on start up and then exits."`
+	DropTxIndex          bool          `long:"droptxindex" description:"Deletes the hash-based transaction index from the database on start up and then exits."`
+	ExternalIPs          []string      `long:"externalip" description:"Add an ip to the list of local addresses we claim to listen on to peers"`
+	Generate             bool          `long:"generate" description:"Generate (mine) bitcoins using the CPU"`
+	FreeTxRelayLimit     float64       `long:"limitfreerelay" description:"Limit relay of transactions with no transaction fee to the given amount in thousands of bytes per minute"`
+	Listeners            []string      `long:"listen" description:"Add an interface/port to listen for connections (default all interfaces port: 8333, testnet: 18333)"`
+	LogDir               string        `long:"logdir" description:"Directory to log output."`
+	MaxOrphanTxs         int           `long:"maxorphantx" description:"Max number of orphan transactions to keep in memory"`
+	MaxPeers             int           `long:"maxpeers" description:"Max number of inbound and outbound peers"`
+	MiningAddrs          []string      `long:"miningaddr" description:"Add the specified payment address to the list of addresses to use for generated blocks -- At least one address is required if the generate option is set"`
+	MinRelayTxFee        float64       `long:"minrelaytxfee" description:"The minimum transaction fee in BTC/kB to be considered a non-zero fee."`
+	DisableBanning       bool          `long:"nobanning" description:"Disable banning of misbehaving peers"`
+	NoCFilters           bool          `long:"nocfilters" description:"Disable committed filtering (CF) support"`
+	DisableCheckpoints   bool          `long:"nocheckpoints" description:"Disable built-in checkpoints.  Don't do this unless you know what you're doing."`
+	DisableDNSSeed       bool          `long:"nodnsseed" description:"Disable DNS seeding for peers"`
+	DisableListen        bool          `long:"nolisten" description:"Disable listening for incoming connections -- NOTE: Listening is automatically disabled if the --connect or --proxy options are used without also specifying listen interfaces via --listen"`
+	NoOnion              bool          `long:"noonion" description:"Disable connecting to tor hidden services"`
+	NoPeerBloomFilters   bool          `long:"nopeerbloomfilters" description:"Disable bloom filtering support"`
+	NoRelayPriority      bool          `long:"norelaypriority" description:"Do not require free or low-fee transactions to have high priority for relaying"`
 	DisableRPC           bool          `long:"norpc" description:"Disable built-in RPC server -- NOTE: The RPC server is disabled by default if no rpcuser/rpcpass or rpclimituser/rpclimitpass is specified"`
 	DisableTLS           bool          `long:"notls" description:"Disable TLS for the RPC server -- NOTE: This is only allowed if the RPC server is bound to localhost"`
-	DisableDNSSeed       bool          `long:"nodnsseed" description:"Disable DNS seeding for peers"`
-	ExternalIPs          []string      `long:"externalip" description:"Add an ip to the list of local addresses we claim to listen on to peers"`
-	Proxy                string        `long:"proxy" description:"Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
-	ProxyUser            string        `long:"proxyuser" description:"Username for proxy server"`
-	ProxyPass            string        `long:"proxypass" default-mask:"-" description:"Password for proxy server"`
 	OnionProxy           string        `long:"onion" description:"Connect to tor hidden services via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
-	OnionProxyUser       string        `long:"onionuser" description:"Username for onion proxy server"`
 	OnionProxyPass       string        `long:"onionpass" default-mask:"-" description:"Password for onion proxy server"`
-	NoOnion              bool          `long:"noonion" description:"Disable connecting to tor hidden services"`
-	TorIsolation         bool          `long:"torisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
-	TestNet3             bool          `long:"testnet" description:"Use the test network"`
-	RegressionTest       bool          `long:"regtest" description:"Use the regression test network"`
-	SimNet               bool          `long:"simnet" description:"Use the simulation test network"`
-	AddCheckpoints       []string      `long:"addcheckpoint" description:"Add a custom checkpoint.  Format: '<height>:<hash>'"`
-	DisableCheckpoints   bool          `long:"nocheckpoints" description:"Disable built-in checkpoints.  Don't do this unless you know what you're doing."`
-	DbType               string        `long:"dbtype" description:"Database backend to use for the Block Chain"`
+	OnionProxyUser       string        `long:"onionuser" description:"Username for onion proxy server"`
 	Profile              string        `long:"profile" description:"Enable HTTP profiling on given port -- NOTE port must be between 1024 and 65536"`
-	CPUProfile           string        `long:"cpuprofile" description:"Write CPU profile to the specified file"`
-	DebugLevel           string        `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`
-	Upnp                 bool          `long:"upnp" description:"Use UPnP to map our listening port outside of NAT"`
-	MinRelayTxFee        float64       `long:"minrelaytxfee" description:"The minimum transaction fee in BTC/kB to be considered a non-zero fee."`
-	FreeTxRelayLimit     float64       `long:"limitfreerelay" description:"Limit relay of transactions with no transaction fee to the given amount in thousands of bytes per minute"`
-	NoRelayPriority      bool          `long:"norelaypriority" description:"Do not require free or low-fee transactions to have high priority for relaying"`
-	TrickleInterval      time.Duration `long:"trickleinterval" description:"Minimum time between attempts to send new inventory to a connected peer"`
-	MaxOrphanTxs         int           `long:"maxorphantx" description:"Max number of orphan transactions to keep in memory"`
-	Generate             bool          `long:"generate" description:"Generate (mine) bitcoins using the CPU"`
-	MiningAddrs          []string      `long:"miningaddr" description:"Add the specified payment address to the list of addresses to use for generated blocks -- At least one address is required if the generate option is set"`
-	BlockMinSize         uint32        `long:"blockminsize" description:"Mininum block size in bytes to be used when creating a block"`
-	BlockMaxSize         uint32        `long:"blockmaxsize" description:"Maximum block size in bytes to be used when creating a block"`
-	BlockMinWeight       uint32        `long:"blockminweight" description:"Mininum block weight to be used when creating a block"`
-	BlockMaxWeight       uint32        `long:"blockmaxweight" description:"Maximum block weight to be used when creating a block"`
-	BlockPrioritySize    uint32        `long:"blockprioritysize" description:"Size in bytes for high-priority/low-fee transactions when creating a block"`
-	UserAgentComments    []string      `long:"uacomment" description:"Comment to add to the user agent -- See BIP 14 for more information."`
-	NoPeerBloomFilters   bool          `long:"nopeerbloomfilters" description:"Disable bloom filtering support"`
-	NoCFilters           bool          `long:"nocfilters" description:"Disable committed filtering (CF) support"`
-	DropCfIndex          bool          `long:"dropcfindex" description:"Deletes the index used for committed filtering (CF) support from the database on start up and then exits."`
-	SigCacheMaxSize      uint          `long:"sigcachemaxsize" description:"The maximum number of entries in the signature verification cache"`
-	BlocksOnly           bool          `long:"blocksonly" description:"Do not accept transactions from remote peers."`
-	TxIndex              bool          `long:"txindex" description:"Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
-	DropTxIndex          bool          `long:"droptxindex" description:"Deletes the hash-based transaction index from the database on start up and then exits."`
-	AddrIndex            bool          `long:"addrindex" description:"Maintain a full address-based transaction index which makes the searchrawtransactions RPC available"`
-	DropAddrIndex        bool          `long:"dropaddrindex" description:"Deletes the address-based transaction index from the database on start up and then exits."`
-	RelayNonStd          bool          `long:"relaynonstd" description:"Relay non-standard transactions regardless of the default settings for the active network."`
+	Proxy                string        `long:"proxy" description:"Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)"`
+	ProxyPass            string        `long:"proxypass" default-mask:"-" description:"Password for proxy server"`
+	ProxyUser            string        `long:"proxyuser" description:"Username for proxy server"`
+	RegressionTest       bool          `long:"regtest" description:"Use the regression test network"`
 	RejectNonStd         bool          `long:"rejectnonstd" description:"Reject non-standard transactions regardless of the default settings for the active network."`
 	RejectReplacement    bool          `long:"rejectreplacement" description:"Reject transactions that attempt to replace existing transactions within the mempool through the Replace-By-Fee (RBF) signaling policy."`
+	RelayNonStd          bool          `long:"relaynonstd" description:"Relay non-standard transactions regardless of the default settings for the active network."`
+	RPCCert              string        `long:"rpccert" description:"File containing the certificate file"`
+	RPCKey               string        `long:"rpckey" description:"File containing the certificate key"`
+	RPCLimitPass         string        `long:"rpclimitpass" default-mask:"-" description:"Password for limited RPC connections"`
+	RPCLimitUser         string        `long:"rpclimituser" description:"Username for limited RPC connections"`
+	RPCListeners         []string      `long:"rpclisten" description:"Add an interface/port to listen for RPC connections (default port: 8334, testnet: 18334)"`
+	RPCMaxClients        int           `long:"rpcmaxclients" description:"Max number of RPC clients for standard connections"`
+	RPCMaxConcurrentReqs int           `long:"rpcmaxconcurrentreqs" description:"Max number of concurrent RPC requests that may be processed concurrently"`
+	RPCMaxWebsockets     int           `long:"rpcmaxwebsockets" description:"Max number of RPC websocket connections"`
+	RPCQuirks            bool          `long:"rpcquirks" description:"Mirror some JSON-RPC quirks of Bitcoin Core -- NOTE: Discouraged unless interoperability issues need to be worked around"`
+	RPCPass              string        `short:"P" long:"rpcpass" default-mask:"-" description:"Password for RPC connections"`
+	RPCUser              string        `short:"u" long:"rpcuser" description:"Username for RPC connections"`
+	SigCacheMaxSize      uint          `long:"sigcachemaxsize" description:"The maximum number of entries in the signature verification cache"`
+	SimNet               bool          `long:"simnet" description:"Use the simulation test network"`
+	TestNet3             bool          `long:"testnet" description:"Use the test network"`
+	TorIsolation         bool          `long:"torisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
+	TrickleInterval      time.Duration `long:"trickleinterval" description:"Minimum time between attempts to send new inventory to a connected peer"`
+	TxIndex              bool          `long:"txindex" description:"Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
+	UserAgentComments    []string      `long:"uacomment" description:"Comment to add to the user agent -- See BIP 14 for more information."`
+	Upnp                 bool          `long:"upnp" description:"Use UPnP to map our listening port outside of NAT"`
+	ShowVersion          bool          `short:"V" long:"version" description:"Display version information and exit"`
+	Whitelists           []string      `long:"whitelist" description:"Add an IP network or IP that will not be banned. (eg. 192.168.1.0/24 or ::1)"`
 	lookup               func(string) ([]net.IP, error)
 	oniondial            func(string, string, time.Duration) (net.Conn, error)
 	dial                 func(string, string, time.Duration) (net.Conn, error)

--- a/database/cmd/dbtool/globalconfig.go
+++ b/database/cmd/dbtool/globalconfig.go
@@ -33,9 +33,9 @@ var (
 type config struct {
 	DataDir        string `short:"b" long:"datadir" description:"Location of the btcd data directory"`
 	DbType         string `long:"dbtype" description:"Database backend to use for the Block Chain"`
-	TestNet3       bool   `long:"testnet" description:"Use the test network"`
 	RegressionTest bool   `long:"regtest" description:"Use the regression test network"`
 	SimNet         bool   `long:"simnet" description:"Use the simulation test network"`
+	TestNet3       bool   `long:"testnet" description:"Use the test network"`
 }
 
 // fileExists reports whether the named file or directory exists.

--- a/doc.go
+++ b/doc.go
@@ -21,105 +21,137 @@ Usage:
   btcd [OPTIONS]
 
 Application Options:
-  -V, --version             Display version information and exit
-  -C, --configfile=         Path to configuration file
-  -b, --datadir=            Directory to store data
-      --logdir=             Directory to log output.
-  -a, --addpeer=            Add a peer to connect with at startup
-      --connect=            Connect only to the specified peers at startup
-      --nolisten            Disable listening for incoming connections -- NOTE:
-                            Listening is automatically disabled if the --connect
-                            or --proxy options are used without also specifying
-                            listen interfaces via --listen
-      --listen=             Add an interface/port to listen for connections
-                            (default all interfaces port: 8333, testnet: 18333)
-      --maxpeers=           Max number of inbound and outbound peers (125)
-      --nobanning           Disable banning of misbehaving peers
-      --banduration=        How long to ban misbehaving peers.  Valid time units
-                            are {s, m, h}.  Minimum 1 second (24h0m0s)
-      --banthreshold=       Maximum allowed ban score before disconnecting and
-                            banning misbehaving peers.
-      --whitelist=          Add an IP network or IP that will not be banned.
-                            (eg. 192.168.1.0/24 or ::1)
-  -u, --rpcuser=            Username for RPC connections
-  -P, --rpcpass=            Password for RPC connections
-      --rpclimituser=       Username for limited RPC connections
-      --rpclimitpass=       Password for limited RPC connections
-      --rpclisten=          Add an interface/port to listen for RPC connections
-                            (default port: 8334, testnet: 18334)
-      --rpccert=            File containing the certificate file
-      --rpckey=             File containing the certificate key
-      --rpcmaxclients=      Max number of RPC clients for standard connections
-                            (10)
-      --rpcmaxwebsockets=   Max number of RPC websocket connections (25)
-      --rpcquirks           Mirror some JSON-RPC quirks of Bitcoin Core -- NOTE:
-                            Discouraged unless interoperability issues need to
-                            be worked around
-      --norpc               Disable built-in RPC server -- NOTE: The RPC server
-                            is disabled by default if no rpcuser/rpcpass or
-                            rpclimituser/rpclimitpass is specified
-      --notls               Disable TLS for the RPC server -- NOTE: This is only
-                            allowed if the RPC server is bound to localhost
-      --nodnsseed           Disable DNS seeding for peers
-      --externalip=         Add an ip to the list of local addresses we claim to
-                            listen on to peers
-      --proxy=              Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)
-      --proxyuser=          Username for proxy server
-      --proxypass=          Password for proxy server
-      --onion=              Connect to tor hidden services via SOCKS5 proxy
-                            (eg. 127.0.0.1:9050)
-      --onionuser=          Username for onion proxy server
-      --onionpass=          Password for onion proxy server
-      --noonion             Disable connecting to tor hidden services
-      --torisolation        Enable Tor stream isolation by randomizing user
-                            credentials for each connection.
-      --testnet             Use the test network
-      --regtest             Use the regression test network
-      --simnet              Use the simulation test network
-      --addcheckpoint=      Add a custom checkpoint.  Format: '<height>:<hash>'
-      --nocheckpoints       Disable built-in checkpoints.  Don't do this unless
-                            you know what you're doing.
-      --uacomment=          Comment to add to the user agent --
-                            See BIP 14 for more information.
-      --dbtype=             Database backend to use for the Block Chain (ffldb)
-      --profile=            Enable HTTP profiling on given port -- NOTE port
-                            must be between 1024 and 65536
-      --cpuprofile=         Write CPU profile to the specified file
-  -d, --debuglevel=         Logging level for all subsystems {trace, debug,
-                            info, warn, error, critical} -- You may also specify
-                            <subsystem>=<level>,<subsystem2>=<level>,... to set
-                            the log level for individual subsystems -- Use show
-                            to list available subsystems (info)
-      --upnp                Use UPnP to map our listening port outside of NAT
-      --minrelaytxfee=      The minimum transaction fee in BTC/kB to be
-                            considered a non-zero fee.
-      --limitfreerelay=     Limit relay of transactions with no transaction fee
-                            to the given amount in thousands of bytes per
-                            minute (15)
-      --norelaypriority     Do not require free or low-fee transactions to have
-                            high priority for relaying
-      --maxorphantx=        Max number of orphan transactions to keep in memory
-                            (100)
-      --generate            Generate (mine) bitcoins using the CPU
-      --miningaddr=         Add the specified payment address to the list of
-                            addresses to use for generated blocks -- At least
-                            one address is required if the generate option is
-                            set
-      --blockminsize=       Mininum block size in bytes to be used when creating
-                            a block
-      --blockmaxsize=       Maximum block size in bytes to be used when creating
-                            a block (750000)
-      --blockprioritysize=  Size in bytes for high-priority/low-fee transactions
-                            when creating a block (50000)
-      --nopeerbloomfilters  Disable bloom filtering support.
-      --nocfilters          Disable committed filtering (CF) support.
-      --sigcachemaxsize=    The maximum number of entries in the signature
-                            verification cache.
-      --blocksonly          Do not accept transactions from remote peers.
-      --relaynonstd         Relay non-standard transactions regardless of the
-                            default settings for the active network.
-      --rejectnonstd        Reject non-standard transactions regardless of the
-                            default settings for the active network.
+      --addcheckpoint=        Add a custom checkpoint.  Format:
+                              '<height>:<hash>'
+  -a, --addpeer=              Add a peer to connect with at startup
+      --addrindex             Maintain a full address-based transaction index
+                              which makes the searchrawtransactions RPC
+                              available
+      --banduration=          How long to ban misbehaving peers.  Valid time
+                              units are {s, m, h}.  Minimum 1 second (default:
+                              24h0m0s)
+      --banthreshold=         Maximum allowed ban score before disconnecting
+                              and banning misbehaving peers. (default: 100)
+      --blockmaxsize=         Maximum block size in bytes to be used when
+                              creating a block (default: 750000)
+      --blockminsize=         Mininum block size in bytes to be used when
+                              creating a block
+      --blockmaxweight=       Maximum block weight to be used when creating a
+                              block (default: 3000000)
+      --blockminweight=       Mininum block weight to be used when creating a
+                              block
+      --blockprioritysize=    Size in bytes for high-priority/low-fee
+                              transactions when creating a block (default:
+                              50000)
+      --blocksonly            Do not accept transactions from remote peers.
+  -C, --configfile=           Path to configuration file
+      --connect=              Connect only to the specified peers at startup
+      --cpuprofile=           Write CPU profile to the specified file
+  -b, --datadir=              Directory to store data
+      --dbtype=               Database backend to use for the Block Chain
+                              (default: ffldb)
+  -d, --debuglevel=           Logging level for all subsystems {trace, debug,
+                              info, warn, error, critical} -- You may also
+                              specify
+                              <subsystem>=<level>,<subsystem2>=<level>,... to
+                              set the log level for individual subsystems --
+                              Use show to list available subsystems (default:
+                              info)
+      --dropaddrindex         Deletes the address-based transaction index from
+                              the database on start up and then exits.
+      --dropcfindex           Deletes the index used for committed filtering
+                              (CF) support from the database on start up and
+                              then exits.
+      --droptxindex           Deletes the hash-based transaction index from the
+                              database on start up and then exits.
+      --externalip=           Add an ip to the list of local addresses we claim
+                              to listen on to peers
+      --generate              Generate (mine) bitcoins using the CPU
+      --limitfreerelay=       Limit relay of transactions with no transaction
+                              fee to the given amount in thousands of bytes per
+                              minute (default: 15)
+      --listen=               Add an interface/port to listen for connections
+                              (default all interfaces port: 8333, testnet:
+                              18333)
+      --logdir=               Directory to log output
+      --maxorphantx=          Max number of orphan transactions to keep in
+                              memory (default: 100)
+      --maxpeers=             Max number of inbound and outbound peers
+                              (default: 125)
+      --miningaddr=           Add the specified payment address to the list of
+                              addresses to use for generated blocks -- At least
+                              one address is required if the generate option is
+                              set
+      --minrelaytxfee=        The minimum transaction fee in BTC/kB to be
+                              considered a non-zero fee. (default: 1e-05)
+      --nobanning             Disable banning of misbehaving peers
+      --nocfilters            Disable committed filtering (CF) support
+      --nocheckpoints         Disable built-in checkpoints.  Don't do this
+                              unless you know what you're doing.
+      --nodnsseed             Disable DNS seeding for peers
+      --nolisten              Disable listening for incoming connections --
+                              NOTE: Listening is automatically disabled if the
+                              --connect or --proxy options are used without
+                              also specifying listen interfaces via --listen
+      --noonion               Disable connecting to tor hidden services
+      --nopeerbloomfilters    Disable bloom filtering support
+      --norelaypriority       Do not require free or low-fee transactions to
+                              have high priority for relaying
+      --norpc                 Disable built-in RPC server -- NOTE: The RPC
+                              server is disabled by default if no
+                              rpcuser/rpcpass or rpclimituser/rpclimitpass is
+                              specified
+      --notls                 Disable TLS for the RPC server -- NOTE: This is
+                              only allowed if the RPC server is bound to
+                              localhost
+      --onion=                Connect to tor hidden services via SOCKS5 proxy
+                              (eg. 127.0.0.1:9050)
+      --onionpass=            Password for onion proxy server
+      --onionuser=            Username for onion proxy server
+      --profile=              Enable HTTP profiling on given port -- NOTE port
+                              must be between 1024 and 65536
+      --proxy=                Connect via SOCKS5 proxy (eg. 127.0.0.1:9050)
+      --proxypass=            Password for proxy server
+      --proxyuser=            Username for proxy server
+      --regtest               Use the regression test network
+      --rejectnonstd          Reject non-standard transactions regardless of
+                              the default settings for the active network.
+      --relaynonstd           Relay non-standard transactions regardless of the
+                              default settings for the active network.
+      --rpccert=              File containing the certificate file
+      --rpckey=               File containing the certificate key
+      --rpclimitpass=         Password for limited RPC connections
+      --rpclimituser=         Username for limited RPC connections
+      --rpclisten=            Add an interface/port to listen for RPC
+                              connections (default port: 8334, testnet: 18334)
+      --rpcmaxclients=        Max number of RPC clients for standard
+                              connections (default: 10)
+      --rpcmaxconcurrentreqs= Max number of concurrent RPC requests that may be
+                              processed concurrently (default: 20)
+      --rpcmaxwebsockets=     Max number of RPC websocket connections (default:
+                              25)
+      --rpcquirks             Mirror some JSON-RPC quirks of Bitcoin Core --
+                              NOTE: Discouraged unless interoperability issues
+                              need to be worked around
+  -P, --rpcpass=              Password for RPC connections
+  -u, --rpcuser=              Username for RPC connections
+      --sigcachemaxsize=      The maximum number of entries in the signature
+                              verification cache (default: 100000)
+      --simnet                Use the simulation test network
+      --testnet               Use the test network
+      --torisolation          Enable Tor stream isolation by randomizing user
+                              credentials for each connection.
+      --trickleinterval=      Minimum time between attempts to send new
+                              inventory to a connected peer (default: 10s)
+      --txindex               Maintain a full hash-based transaction index
+                              which makes all transactions available via the
+                              getrawtransaction RPC
+      --uacomment=            Comment to add to the user agent -- See BIP 14
+                              for more information.
+      --upnp                  Use UPnP to map our listening port outside of NAT
+  -V, --version               Display version information and exit
+      --whitelist=            Add an IP network or IP that will not be banned.
+                              (eg. 192.168.1.0/24 or ::1)
 
 Help Options:
   -h, --help           Show this help message


### PR DESCRIPTION
Current --help output is a quite confusing. This change alphabetizes the output. Also update `doc.go`, alphabetizing and adding the following entries which are currently missing:

```
--addrindex
--blockmaxweight
--blockminweight
--dropaddrindex
--dropcfindex
--droptxindex
--rpcmaxconcurrentreqs
--trickleinterval
--txindex
```
