### PR TITLE
check for cancelled connection before retry

### DIFF
--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -408,6 +408,14 @@ func (cm *ConnManager) Connect(c *ConnReq) {
 	if atomic.LoadInt32(&cm.stop) != 0 {
 		return
 	}
+
+	// During the time we wait for retry there is a chance that
+	// this connection was already cancelled
+	if c.State() == ConnCanceled {
+		log.Debugf("Ignoring connect for canceled connreq=%v", c)
+		return
+	}
+
 	if atomic.LoadUint64(&c.id) == 0 {
 		atomic.StoreUint64(&c.id, atomic.AddUint64(&cm.connReqCount, 1))
 


### PR DESCRIPTION
This PR fixes the case where a connection is cancelled at the time it is waiting for retry.
Before the fix the code would still attempt to connect and only after connecting successfully it will check for prior cancelation and ignore the connection.
After this fix the cancelation would be detected earlier and save the attempt to connect.