### PR TITLE
Bug Fix: Uptime was returning unix time now instead of number of seconds up

### DIFF
--- a/server.go
+++ b/server.go
@@ -2282,9 +2282,6 @@ func (s *server) Start() {
 
 	srvrLog.Trace("Starting server")
 
-	// Server startup time. Used for the uptime command for uptime calculation.
-	s.startupTime = time.Now().Unix()
-
 	// Start the peer handler which in turn starts the address and block
 	// managers.
 	s.wg.Add(1)
@@ -2563,6 +2560,7 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	}
 
 	s := server{
+		startupTime:          time.Now().Unix(),
 		chainParams:          chainParams,
 		addrManager:          amgr,
 		newPeers:             make(chan *serverPeer, cfg.MaxPeers),


### PR DESCRIPTION
The RPC `uptime` command was returning unix time now() instead of the number of seconds the server had been running.  This was due to a bug on the initialisation order of the startupTime variable occurring after the RPC server instance had been created by function newRPCServer().  Subsequently an uninitialised (zero) value was being passed to the RPC config https://github.com/btcsuite/btcd/blob/67e573d211ace594f1366b4ce9d39726c4b19bd0/server.go#L2835 resulting in the uptime calculation being `now() - 0`.
