### PR TITLE
rpcclient: add GetBlockChainInfoLegacy() method

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -114,6 +114,23 @@ type GetBlockChainInfoResult struct {
 	Bip9SoftForks        map[string]*Bip9SoftForkDescription `json:"bip9_softforks"`
 }
 
+// GetBlockChainInfoLegacyResult models the data returned from the getblockchaininfo
+// command for legacy servers.
+type GetBlockChainInfoLegacyResult struct {
+	Chain                string                     `json:"chain"`
+	Blocks               int32                      `json:"blocks"`
+	Headers              int32                      `json:"headers"`
+	BestBlockHash        string                     `json:"bestblockhash"`
+	Difficulty           float64                    `json:"difficulty"`
+	MedianTime           int64                      `json:"mediantime"`
+	VerificationProgress float64                    `json:"verificationprogress,omitempty"`
+	Pruned               bool                       `json:"pruned"`
+	PruneHeight          int32                      `json:"pruneheight,omitempty"`
+	ChainWork            string                     `json:"chainwork,omitempty"`
+	SoftForks            []*SoftForkDescription     `json:"softforks"`
+	Bip9SoftForks        []*Bip9SoftForkDescription `json:"bip9_softforks"`
+}
+
 // GetBlockTemplateResultTx models the transactions field of the
 // getblocktemplate command.
 type GetBlockTemplateResultTx struct {

--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -287,6 +287,42 @@ func (c *Client) GetBlockChainInfo() (*btcjson.GetBlockChainInfoResult, error) {
 	return c.GetBlockChainInfoAsync().Receive()
 }
 
+// FutureGetBlockChainInfoLegacyResult is a promise to deliver the result of a
+// GetBlockChainInfoLegacyAsync RPC invocation (or an applicable error).
+type FutureGetBlockChainInfoLegacyResult chan *response
+
+// Receive waits for the response promised by the future and returns chain info
+// result provided by the server.
+func (r FutureGetBlockChainInfoLegacyResult) Receive() (*btcjson.GetBlockChainInfoLegacyResult, error) {
+	res, err := receiveFuture(r)
+	if err != nil {
+		return nil, err
+	}
+
+	var chainInfo btcjson.GetBlockChainInfoLegacyResult
+	if err := json.Unmarshal(res, &chainInfo); err != nil {
+		return nil, err
+	}
+	return &chainInfo, nil
+}
+
+// GetBlockChainInfoLegacyAsync returns an instance of a type that can be used to get
+// the result of the RPC at some future time by invoking the Receive function
+// on the returned instance.
+//
+// See GetBlockChainInfoLegacy for the blocking version and more details.
+func (c *Client) GetBlockChainInfoLegacyAsync() FutureGetBlockChainInfoLegacyResult {
+	cmd := btcjson.NewGetBlockChainInfoLegacyCmd()
+	return c.sendCmd(cmd)
+}
+
+// GetBlockChainInfoLegacy returns information related to the processing state of
+// various chain-specific details such as the current difficulty from the tip
+// of the main chain.
+func (c *Client) GetBlockChainInfoLegacy() (*btcjson.GetBlockChainInfoLegacyResult, error) {
+	return c.GetBlockChainInfoLegacyAsync().Receive()
+}
+
 // FutureGetBlockHashResult is a future promise to deliver the result of a
 // GetBlockHashAsync RPC invocation (or an applicable error).
 type FutureGetBlockHashResult chan *response


### PR DESCRIPTION
I have an old legacy Bitcoin Core node v0.12.x, being stable and running for years, I don't want to upgrade, putting my environment at risk with synchronization or other potential issues. 

In next major version, [v0.13.0](https://github.com/bitcoin/bitcoin/blob/452bb90c718da18a79bfad50ff9b7d1c8f1b4aa3/doc/release-notes/release-notes-0.13.0.md#rpc-and-other-apis) they've merged PR [#7863](https://github.com/bitcoin/bitcoin/pull/7863), which breaks `GetBlockChainInfoResult()` by returning json unmarshalling error, while trying to unmarshal a slice of `Bip9SoftForks` into map.

This is an attempt to solve this.