### PR TITLE
Fix one-off bug in signRFC6979

### DIFF
--- a/btcec/signature.go
+++ b/btcec/signature.go
@@ -427,9 +427,7 @@ func signRFC6979(privateKey *PrivateKey, hash []byte) (*Signature, error) {
 	k := nonceRFC6979(privkey.D, hash)
 	inv := new(big.Int).ModInverse(k, N)
 	r, _ := privkey.Curve.ScalarBaseMult(k.Bytes())
-	if r.Cmp(N) == 1 {
-		r.Sub(r, N)
-	}
+	r.Mod(r, N)
 
 	if r.Sign() == 0 {
 		return nil, errors.New("calculated R is zero")


### PR DESCRIPTION
Ultra rare edge case where r == N.

1. L430 returns 0 so is NOT == 1 and if statement NOT entered.
2. L434 r.Sign() returns 1 (since N > 0) so if statement is NOT entered.
3. mod N function for s calculation is not performed until after an addition operation (if it were only Multiplication we would still arrive at 0 when mod N is performed, since a*N mod N is always 0. But there is an addition between that)
4. The Signature object is returned with R == curve.N...

Obviously I can't find a test case where nonceRFC6979 returns a k what when scalar Multiplied gets an x value == N... but N with both 0x02 and 0x03 DER headers is a valid point on the curve...

So the chance is not 0.