### PR TITLE
integration/rpctest: make exec path compatible with modules

### DIFF
--- a/integration/rpctest/btcd.go
+++ b/integration/rpctest/btcd.go
@@ -6,7 +6,6 @@ package rpctest
 
 import (
 	"fmt"
-	"go/build"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -44,24 +43,14 @@ func btcdExecutablePath() (string, error) {
 		return "", err
 	}
 
-	// Determine import path of this package. Not necessarily btcsuite/btcd if
-	// this is a forked repo.
-	_, rpctestDir, _, ok := runtime.Caller(1)
-	if !ok {
-		return "", fmt.Errorf("Cannot get path to btcd source code")
-	}
-	btcdPkgPath := filepath.Join(rpctestDir, "..", "..", "..")
-	btcdPkg, err := build.ImportDir(btcdPkgPath, build.FindOnly)
-	if err != nil {
-		return "", fmt.Errorf("Failed to build btcd: %v", err)
-	}
-
 	// Build btcd and output an executable in a static temp path.
 	outputPath := filepath.Join(testDir, "btcd")
 	if runtime.GOOS == "windows" {
 		outputPath += ".exe"
 	}
-	cmd := exec.Command("go", "build", "-o", outputPath, btcdPkg.ImportPath)
+	cmd := exec.Command(
+		"go", "build", "-o", outputPath, "github.com/btcsuite/btcd",
+	)
 	err = cmd.Run()
 	if err != nil {
 		return "", fmt.Errorf("Failed to build btcd: %v", err)


### PR DESCRIPTION
With the use of go modules, the btcdPkgPath will no longer be `github.com/btcsuite/btcd`, but end with a version string (e.g. btcd@v0.0.0-20181129140220-beb77e89572a).

This trips up build.ImportDir, which will return a ImportPath of ".", since this package cannot be found in the go path.

There are probably several ways of fixing this, by clever string magic, but seems easiest to just hardcode the btcd package name.

Relevant issue: https://github.com/golang/go/issues/26504