### PR TITLE
Fix block boundary checking in FetchBlockRegion(s)

### DIFF
--- a/database/ffldb/blockio.go
+++ b/database/ffldb/blockio.go
@@ -56,6 +56,11 @@ const (
 	//  [4:8]  File offset (4 bytes)
 	//  [8:12] Block length (4 bytes)
 	blockLocSize = 12
+
+	// blockMetadataSize is the number of bytes added as the metadata to
+	// a serialized block (4 bytes network version + 4 bytes block size +
+	// 4 bytes checksum).
+	blockMetadataSize = 12
 )
 
 var (

--- a/database/ffldb/db.go
+++ b/database/ffldb/db.go
@@ -1455,12 +1455,15 @@ func (tx *transaction) FetchBlockRegion(region *database.BlockRegion) ([]byte, e
 	}
 	location := deserializeBlockLoc(blockRow)
 
+	// Calculate the actual block size by removing the metadata.
+	blockLen := location.blockLen - blockMetadataSize
+
 	// Ensure the region is within the bounds of the block.
 	endOffset := region.Offset + region.Len
-	if endOffset < region.Offset || endOffset > location.blockLen {
+	if endOffset < region.Offset || endOffset > blockLen {
 		str := fmt.Sprintf("block %s region offset %d, length %d "+
 			"exceeds block length of %d", region.Hash,
-			region.Offset, region.Len, location.blockLen)
+			region.Offset, region.Len, blockLen)
 		return nil, makeDbErr(database.ErrBlockRegionInvalid, str, nil)
 
 	}
@@ -1553,12 +1556,15 @@ func (tx *transaction) FetchBlockRegions(regions []database.BlockRegion) ([][]by
 		}
 		location := deserializeBlockLoc(blockRow)
 
+		// Calculate the actual block size by removing the metadata.
+		blockLen := location.blockLen - blockMetadataSize
+
 		// Ensure the region is within the bounds of the block.
 		endOffset := region.Offset + region.Len
-		if endOffset < region.Offset || endOffset > location.blockLen {
+		if endOffset < region.Offset || endOffset > blockLen {
 			str := fmt.Sprintf("block %s region offset %d, length "+
 				"%d exceeds block length of %d", region.Hash,
-				region.Offset, region.Len, location.blockLen)
+				region.Offset, region.Len, blockLen)
 			return nil, makeDbErr(database.ErrBlockRegionInvalid, str, nil)
 		}
 

--- a/database/ffldb/interface_test.go
+++ b/database/ffldb/interface_test.go
@@ -1360,6 +1360,19 @@ func testFetchBlockIO(tc *testContext, tx database.Tx) bool {
 		if !checkDbError(tc.t, testName, err, wantErrCode) {
 			return false
 		}
+
+		// Ensure fetching a block region larger than the block returns
+		// the expected error.
+		testName = fmt.Sprintf("FetchBlockRegion(%s) out of block size",
+			blockHash)
+		wantErrCode = database.ErrBlockRegionInvalid
+		region.Hash = blockHash
+		region.Offset = 0
+		region.Len = uint32(len(blockBytes) + 1)
+		_, err = tx.FetchBlockRegion(&region)
+		if !checkDbError(tc.t, testName, err, wantErrCode) {
+			return false
+		}
 	}
 
 	// -----------------
@@ -1497,6 +1510,20 @@ func testFetchBlockIO(tc *testContext, tx database.Tx) bool {
 	badBlockRegions = badBlockRegions[:len(badBlockRegions)-1]
 	for i := range badBlockRegions {
 		badBlockRegions[i].Offset = ^uint32(0)
+	}
+	wantErrCode = database.ErrBlockRegionInvalid
+	_, err = tx.FetchBlockRegions(badBlockRegions)
+	if !checkDbError(tc.t, testName, err, wantErrCode) {
+		return false
+	}
+
+	// Ensure fetching block regions larger than the block returns the
+	// expected error.
+	testName = "FetchBlockRegions out of bunds"
+	badBlockRegions = badBlockRegions[:len(badBlockRegions)-1]
+	for i := range badBlockRegions {
+		badBlockRegions[i].Offset = 0
+		badBlockRegions[i].Len = uint32(len(allBlockBytes[i]) + 1)
 	}
 	wantErrCode = database.ErrBlockRegionInvalid
 	_, err = tx.FetchBlockRegions(badBlockRegions)


### PR DESCRIPTION
In ffldb, a serialized block has some metadata attached. The corresponding `blockLocation.Len` is used to check if the fetching region is out of bunds. However it counts not only the block size but also the 12 bytes metadata, which is not considered accessible by the caller:

`[4 bytes: network version] [4 bytes: block size] [block] [4 bytes: checksum]`

This PR fixes the issue.