### PR TITLE
[WIP] Implement a UTXO cache 

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -85,6 +85,26 @@ func newBestState(node *blockNode, blockSize, blockWeight, numTxns,
 	}
 }
 
+// FlushMode is used to indicate the different urgency types for a flush.
+type FlushMode uint8
+
+const (
+	// FlushRequired is the flush mode that means a flush must be performed
+	// regardless of the cache state.  For example right before shutting down.
+	FlushRequired FlushMode = iota
+
+	// FlushPeriodic is the flush mode that means a flush can be performed
+	// when it would be almost needed.  This is used to periodically signal when
+	// no I/O heavy operations are expected soon, so there is time to flush.
+	FlushPeriodic
+
+	// FlushIfNeeded is the flush mode that means a flush must be performed only
+	// if the cache is exceeding a safety threshold very close to its maximum
+	// size.  This is used mostly internally in between operations that can
+	// increase the cache size.
+	FlushIfNeeded
+)
+
 // BlockChain provides functions for working with the bitcoin block chain.
 // It includes functionality such as rejecting duplicate blocks, ensuring blocks
 // follow all rules, orphan handling, checkpoint handling, and best chain
@@ -125,6 +145,12 @@ type BlockChain struct {
 	// efficient chain view into the block index.
 	index     *blockIndex
 	bestChain *chainView
+
+	// The UTXO state holds a cached view of the UTXO state of the chain.
+	//
+	// It has its own lock, however it is often also protected by the chain lock
+	// to help prevent logic races when blocks are being processed.
+	utxoCache *utxoCache
 
 	// These fields are related to handling of orphan blocks.  They are
 	// protected by a combination of the chain lock and the orphan lock.
@@ -622,14 +648,6 @@ func (b *BlockChain) connectBlock(node *blockNode, block *btcutil.Block,
 			return err
 		}
 
-		// Update the utxo set using the state of the utxo view.  This
-		// entails removing all of the utxos spent and adding the new
-		// ones created by the block.
-		err = dbPutUtxoView(dbTx, view)
-		if err != nil {
-			return err
-		}
-
 		// Update the transaction spend journal by adding a record for
 		// the block that contains all txos spent by it.
 		err = dbPutSpendJournalEntry(dbTx, block.Hash(), stxos)
@@ -653,9 +671,9 @@ func (b *BlockChain) connectBlock(node *blockNode, block *btcutil.Block,
 		return err
 	}
 
-	// Prune fully spent entries and mark all entries in the view unmodified
-	// now that the modifications have been committed to the database.
-	view.commit()
+	// Commit all modifications made to the view into the utxo state.  This also
+	// prunes these changes from the view.
+	b.utxoCache.Commit(view)
 
 	// This node is now the end of the best chain.
 	b.bestChain.SetTip(node)
@@ -675,6 +693,12 @@ func (b *BlockChain) connectBlock(node *blockNode, block *btcutil.Block,
 	b.chainLock.Unlock()
 	b.sendNotification(NTBlockConnected, block)
 	b.chainLock.Lock()
+
+	// Since we just changed the UTXO cache, we make sure it didn't excee its
+	// maximum size.
+	if err := b.utxoCache.Flush(FlushIfNeeded, state); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -734,14 +758,6 @@ func (b *BlockChain) disconnectBlock(node *blockNode, block *btcutil.Block, view
 			return err
 		}
 
-		// Update the utxo set using the state of the utxo view.  This
-		// entails restoring all of the utxos spent and removing the new
-		// ones created by the block.
-		err = dbPutUtxoView(dbTx, view)
-		if err != nil {
-			return err
-		}
-
 		// Before we delete the spend journal entry for this back,
 		// we'll fetch it as is so the indexers can utilize if needed.
 		stxos, err := dbFetchSpendJournalEntry(dbTx, block)
@@ -772,9 +788,9 @@ func (b *BlockChain) disconnectBlock(node *blockNode, block *btcutil.Block, view
 		return err
 	}
 
-	// Prune fully spent entries and mark all entries in the view unmodified
-	// now that the modifications have been committed to the database.
-	view.commit()
+	// Commit all modifications made to the view into the utxo state.  This also
+	// prunes these changes from the view.
+	b.utxoCache.Commit(view)
 
 	// This node's parent is now the end of the best chain.
 	b.bestChain.SetTip(node.parent)
@@ -794,6 +810,12 @@ func (b *BlockChain) disconnectBlock(node *blockNode, block *btcutil.Block, view
 	b.chainLock.Unlock()
 	b.sendNotification(NTBlockDisconnected, block)
 	b.chainLock.Lock()
+
+	// Since we just changed the UTXO cache, we make sure it didn't excee its
+	// maximum size.
+	if err := b.utxoCache.Flush(FlushIfNeeded, state); err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -866,7 +888,6 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 	// database and using that information to unspend all of the spent txos
 	// and remove the utxos created by the blocks.
 	view := NewUtxoViewpoint()
-	view.SetBestHash(&oldBest.hash)
 	for e := detachNodes.Front(); e != nil; e = e.Next() {
 		n := e.Value.(*blockNode)
 		var block *btcutil.Block
@@ -886,7 +907,7 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 
 		// Load all of the utxos referenced by the block that aren't
 		// already in the view.
-		err = view.fetchInputUtxos(b.db, block)
+		err = view.addInputUtxos(b.utxoCache, block)
 		if err != nil {
 			return err
 		}
@@ -906,7 +927,7 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 		detachBlocks = append(detachBlocks, block)
 		detachSpentTxOuts = append(detachSpentTxOuts, stxos)
 
-		err = view.disconnectTransactions(b.db, block, stxos)
+		err = disconnectTransactions(view, block, stxos, b.utxoCache)
 		if err != nil {
 			return err
 		}
@@ -953,11 +974,11 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 		// checkConnectBlock gets skipped, we still need to update the UTXO
 		// view.
 		if b.index.NodeStatus(n).KnownValid() {
-			err = view.fetchInputUtxos(b.db, block)
+			err = view.addInputUtxos(b.utxoCache, block)
 			if err != nil {
 				return err
 			}
-			err = view.connectTransactions(block, nil)
+			err = connectTransactions(view, block, nil, false)
 			if err != nil {
 				return err
 			}
@@ -996,7 +1017,6 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 	// view to be valid from the viewpoint of each block being connected or
 	// disconnected.
 	view = NewUtxoViewpoint()
-	view.SetBestHash(&b.bestChain.Tip().hash)
 
 	// Disconnect blocks from the main chain.
 	for i, e := 0, detachNodes.Front(); e != nil; i, e = i+1, e.Next() {
@@ -1005,15 +1025,15 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 
 		// Load all of the utxos referenced by the block that aren't
 		// already in the view.
-		err := view.fetchInputUtxos(b.db, block)
+		err := view.addInputUtxos(b.utxoCache, block)
 		if err != nil {
 			return err
 		}
 
 		// Update the view to unspend all of the spent txos and remove
 		// the utxos created by the block.
-		err = view.disconnectTransactions(b.db, block,
-			detachSpentTxOuts[i])
+		err = disconnectTransactions(view, block, detachSpentTxOuts[i],
+			b.utxoCache)
 		if err != nil {
 			return err
 		}
@@ -1032,7 +1052,7 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 
 		// Load all of the utxos referenced by the block that aren't
 		// already in the view.
-		err := view.fetchInputUtxos(b.db, block)
+		err := view.addInputUtxos(b.utxoCache, block)
 		if err != nil {
 			return err
 		}
@@ -1042,7 +1062,7 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 		// to it.  Also, provide an stxo slice so the spent txout
 		// details are generated.
 		stxos := make([]SpentTxOut, 0, countSpentOutputs(block))
-		err = view.connectTransactions(block, &stxos)
+		err = connectTransactions(view, block, &stxos, false)
 		if err != nil {
 			return err
 		}
@@ -1107,7 +1127,6 @@ func (b *BlockChain) connectBestChain(node *blockNode, block *btcutil.Block, fla
 		// to the main chain without violating any rules and without
 		// actually connecting the block.
 		view := NewUtxoViewpoint()
-		view.SetBestHash(parentHash)
 		stxos := make([]SpentTxOut, 0, countSpentOutputs(block))
 		if !fastAdd {
 			err := b.checkConnectBlock(node, block, view, &stxos)
@@ -1131,11 +1150,11 @@ func (b *BlockChain) connectBestChain(node *blockNode, block *btcutil.Block, fla
 		// utxos, spend them, and add the new utxos being created by
 		// this block.
 		if fastAdd {
-			err := view.fetchInputUtxos(b.db, block)
+			err := view.addInputUtxos(b.utxoCache, block)
 			if err != nil {
 				return false, err
 			}
-			err = view.connectTransactions(block, &stxos)
+			err = connectTransactions(view, block, &stxos, false)
 			if err != nil {
 				return false, err
 			}
@@ -1657,6 +1676,11 @@ type Config struct {
 	// This field is required.
 	DB database.DB
 
+	// The maximum size in bytes of the UTXO cache.
+	//
+	// This field is required.
+	UtxoCacheMaxSize uint64
+
 	// Interrupt specifies a channel the caller can close to signal that
 	// long running operations, such as catching up indexes or performing
 	// database migrations, should be interrupted.
@@ -1760,6 +1784,7 @@ func New(config *Config) (*BlockChain, error) {
 		maxRetargetTimespan: targetTimespan * adjustmentFactor,
 		blocksPerRetarget:   int32(targetTimespan / targetTimePerBlock),
 		index:               newBlockIndex(config.DB, params),
+		utxoCache:           newUtxoState(config.DB, config.UtxoCacheMaxSize),
 		hashCache:           config.HashCache,
 		bestChain:           newChainView(nil),
 		orphans:             make(map[chainhash.Hash]*orphanBlock),
@@ -1780,6 +1805,13 @@ func New(config *Config) (*BlockChain, error) {
 		return nil, err
 	}
 
+	// Make sure the utxo state is catched up if it was left in an inconsistent
+	// state.
+	bestNode := b.bestChain.Tip()
+	if err := b.utxoCache.InitConsistentState(bestNode, config.Interrupt); err != nil {
+		return nil, err
+	}
+
 	// Initialize and catch up all of the currently active optional indexes
 	// as needed.
 	if config.IndexManager != nil {
@@ -1794,10 +1826,21 @@ func New(config *Config) (*BlockChain, error) {
 		return nil, err
 	}
 
-	bestNode := b.bestChain.Tip()
+	bestNode = b.bestChain.Tip()
 	log.Infof("Chain state (height %d, hash %v, totaltx %d, work %v)",
 		bestNode.height, bestNode.hash, b.stateSnapshot.TotalTxns,
 		bestNode.workSum)
 
 	return &b, nil
+}
+
+// FlushCachedState flushes all the cached state of the blockchain to the
+// database.
+//
+// This method is safe for concurrent access.
+func (b *BlockChain) FlushCachedState(mode FlushMode) error {
+	b.chainLock.Lock()
+	err := b.utxoCache.Flush(mode, b.stateSnapshot)
+	b.chainLock.Unlock()
+	return err
 }

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -694,7 +694,7 @@ func (b *BlockChain) connectBlock(node *blockNode, block *btcutil.Block,
 	b.sendNotification(NTBlockConnected, block)
 	b.chainLock.Lock()
 
-	// Since we just changed the UTXO cache, we make sure it didn't excee its
+	// Since we just changed the UTXO cache, we make sure it didn't exceed its
 	// maximum size.
 	if err := b.utxoCache.Flush(FlushIfNeeded, state); err != nil {
 		return err
@@ -811,7 +811,7 @@ func (b *BlockChain) disconnectBlock(node *blockNode, block *btcutil.Block, view
 	b.sendNotification(NTBlockDisconnected, block)
 	b.chainLock.Lock()
 
-	// Since we just changed the UTXO cache, we make sure it didn't excee its
+	// Since we just changed the UTXO cache, we make sure it didn't exceed its
 	// maximum size.
 	if err := b.utxoCache.Flush(FlushIfNeeded, state); err != nil {
 		return err
@@ -1784,7 +1784,7 @@ func New(config *Config) (*BlockChain, error) {
 		maxRetargetTimespan: targetTimespan * adjustmentFactor,
 		blocksPerRetarget:   int32(targetTimespan / targetTimePerBlock),
 		index:               newBlockIndex(config.DB, params),
-		utxoCache:           newUtxoState(config.DB, config.UtxoCacheMaxSize),
+		utxoCache:           newUtxoCache(config.DB, config.UtxoCacheMaxSize),
 		hashCache:           config.HashCache,
 		bestChain:           newChainView(nil),
 		orphans:             make(map[chainhash.Hash]*orphanBlock),

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -849,6 +849,10 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 		return nil
 	}
 
+	// The rest of the reorg depends on all STXOs already being in the database
+	// so we flush before reorg
+	b.utxoCache.Flush(FlushRequired, b.BestSnapshot())
+
 	// Ensure the provided nodes match the current best chain.
 	tip := b.bestChain.Tip()
 	if detachNodes.Len() != 0 {

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1848,7 +1848,6 @@ func (b *BlockChain) CachedStateSize() uint64 {
 // This method is safe for concurrent access.
 func (b *BlockChain) FlushCachedState(mode FlushMode) error {
 	b.chainLock.Lock()
-	err := b.utxoCache.Flush(mode, b.stateSnapshot)
-	b.chainLock.Unlock()
-	return err
+	defer b.chainLock.Unlock()
+	return b.utxoCache.Flush(mode, b.stateSnapshot)
 }

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1834,6 +1834,12 @@ func New(config *Config) (*BlockChain, error) {
 	return &b, nil
 }
 
+// CachedStateSize returns the total size of the cached state of the blockchain
+// in bytes.
+func (b *BlockChain) CachedStateSize() uint64 {
+	return b.utxoCache.TotalMemoryUsage()
+}
+
 // FlushCachedState flushes all the cached state of the blockchain to the
 // database.
 //

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -984,7 +984,7 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 			if err != nil {
 				return err
 			}
-			err = connectTransactions(view, block, nil, false)
+			err = connectTransactions(view, block, nil, true)
 			if err != nil {
 				return err
 			}

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -147,7 +147,6 @@ func TestCalcSequenceLock(t *testing.T) {
 	})
 	utxoView := NewUtxoViewpoint()
 	utxoView.AddTxOuts(targetTx, int32(numBlocksToActivate)-4)
-	utxoView.SetBestHash(&node.hash)
 
 	// Create a utxo that spends the fake utxo created above for use in the
 	// transactions created in the tests.  It has an age of 4 blocks.  Note

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -51,6 +51,10 @@ var (
 	// chain state.
 	chainStateKeyName = []byte("chainstate")
 
+	// utxoStateConsistencyKeyName is the name of the db key used to store the
+	// consistency status of the utxo state.
+	utxoStateConsistencyKeyName = []byte("utxostateconsistency")
+
 	// spendJournalVersionKeyName is the name of the db key used to store
 	// the version of the spend journal currently in the database.
 	spendJournalVersionKeyName = []byte("spendjournalversion")
@@ -766,47 +770,37 @@ func dbFetchUtxoEntry(dbTx database.Tx, outpoint wire.OutPoint) (*UtxoEntry, err
 	return entry, nil
 }
 
-// dbPutUtxoView uses an existing database transaction to update the utxo set
-// in the database based on the provided utxo view contents and state.  In
-// particular, only the entries that have been marked as modified are written
-// to the database.
-func dbPutUtxoView(dbTx database.Tx, view *UtxoViewpoint) error {
+// dbPutUtxoEntry uses an existing database transaction to update the utxo entry
+// in the database.
+func dbPutUtxoEntry(dbTx database.Tx, outpoint wire.OutPoint, entry *UtxoEntry) error {
 	utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
-	for outpoint, entry := range view.entries {
-		// No need to update the database if the entry was not modified.
-		if entry == nil || !entry.isModified() {
-			continue
-		}
 
-		// Remove the utxo entry if it is spent.
-		if entry.IsSpent() {
-			key := outpointKey(outpoint)
-			err := utxoBucket.Delete(*key)
-			recycleOutpointKey(key)
-			if err != nil {
-				return err
-			}
-
-			continue
-		}
-
-		// Serialize and store the utxo entry.
-		serialized, err := serializeUtxoEntry(entry)
-		if err != nil {
-			return err
-		}
-		key := outpointKey(outpoint)
-		err = utxoBucket.Put(*key, serialized)
-		// NOTE: The key is intentionally not recycled here since the
-		// database interface contract prohibits modifications.  It will
-		// be garbage collected normally when the database is done with
-		// it.
-		if err != nil {
-			return err
-		}
+	if entry == nil || entry.IsSpent() {
+		return AssertError("trying to store nil or spent entry")
 	}
 
-	return nil
+	// Serialize and store the utxo entry.
+	serialized, err := serializeUtxoEntry(entry)
+	if err != nil {
+		return err
+	}
+	key := outpointKey(outpoint)
+	return utxoBucket.Put(*key, serialized)
+	// NOTE: The key is intentionally not recycled here since the
+	// database interface contract prohibits modifications.  It will
+	// be garbage collected normally when the database is done with
+	// it.
+}
+
+// dbDeleteUtxoEntry uses an existing database transaction to delete the utxo
+// entry from the database.
+func dbDeleteUtxoEntry(dbTx database.Tx, outpoint wire.OutPoint) error {
+	utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
+
+	key := outpointKey(outpoint)
+	err := utxoBucket.Delete(*key)
+	recycleOutpointKey(key)
+	return err
 }
 
 // -----------------------------------------------------------------------------
@@ -997,6 +991,101 @@ func dbPutBestState(dbTx database.Tx, snapshot *BestState, workSum *big.Int) err
 
 	// Store the current best chain state into the database.
 	return dbTx.Metadata().Put(chainStateKeyName, serializedData)
+}
+
+// -----------------------------------------------------------------------------
+// The utxo state consistency status is stored as the last hash at which the
+// state finished a flush and an indicator whether it was left in the middle
+// of a flush.
+//
+// The serialized format is:
+//
+//   <status code><consistent hash>
+//
+//   Field             Type             Size
+//   status code       byte             1
+//   consistent hash   chainhash.Hash   chainhash.HashSize
+//
+// The possible values for the state code are:
+//
+//   1: consistent with the given hash, no flush ongoing
+//   2: flush ongoing from the stored consistent hash to best state (see best
+//      state bucket)
+// -----------------------------------------------------------------------------
+
+const (
+	// UTXO consistency status (UCS) codes are used to indicate the
+	// consistency status of the utxo state in the database.
+
+	// ucsEmpty is used as a return value to indicate that no status was
+	// stored.  The zero value should not be stored in the database.
+	ucsEmpty byte = 0
+
+	ucsConsistent   = 1
+	ucsFlushOngoing = 2
+
+	// ucsNbCodes is the number of valid utxo consistency status codes.
+	ucsNbCodes = 3
+)
+
+// serializeUtxoStateConsistency serializes the utxo state consistency status
+// based on the given status code and hash.
+func serializeUtxoStateConsistency(code byte, hash *chainhash.Hash) []byte {
+	// Serialize the data as code + hash.
+	serialized := make([]byte, 1+chainhash.HashSize)
+	serialized[0] = code
+	copy(serialized[1:], hash[:])
+
+	return serialized
+}
+
+// deserializeUtxoStateConsistency deserializes the bytes representing the utxo
+// state consistency status into the status code and hash.
+func deserializeUtxoStateConsistency(serialized []byte) (byte, *chainhash.Hash, error) {
+	// Size must be status code byte + single hash.
+	if len(serialized) != chainhash.HashSize+1 {
+		return 0, nil, database.Error{
+			ErrorCode:   database.ErrCorruption,
+			Description: "corrupt utxo state consistency status",
+		}
+	}
+
+	code := serialized[0]
+	if code >= ucsNbCodes {
+		return 0, nil, database.Error{
+			ErrorCode:   database.ErrCorruption,
+			Description: "corrupt utxo state consistency status: unknown code",
+		}
+	}
+
+	// Ignore error as this only fails on incorrect hash size.
+	hash, _ := chainhash.NewHash(serialized[1 : 1+chainhash.HashSize])
+	return code, hash, nil
+}
+
+// dbPutUtxoStateConsistency uses an existing database transaction to
+// update the utxo state consistency status with the given parameters.
+func dbPutUtxoStateConsistency(dbTx database.Tx, code byte, hash *chainhash.Hash) error {
+	// Seralize the utxo state consistency status.
+	serialized := serializeUtxoStateConsistency(code, hash)
+
+	// Store the utxo state consistency status into the database.
+	return dbTx.Metadata().Put(utxoStateConsistencyKeyName, serialized)
+}
+
+// dbFetchUtxoStateConsistency uses an existing database transaction to retrieve
+// the utxo state consistency status from the database.  The code is 0 when
+// nothing was found.
+func dbFetchUtxoStateConsistency(dbTx database.Tx) (byte, *chainhash.Hash, error) {
+	// Fetch the serialized data from the database.
+	serialized := dbTx.Metadata().Get(utxoStateConsistencyKeyName)
+	if serialized == nil {
+		// Not stored, so return empty state.
+		return ucsEmpty, nil, nil
+	}
+
+	// Deserialize to the consistency status.
+	return deserializeUtxoStateConsistency(serialized)
 }
 
 // createChainState initializes both the database and the chain state to the
@@ -1201,6 +1290,7 @@ func (b *BlockChain) initChainState() error {
 			lastNode = node
 			i++
 		}
+		log.Debug("Done loading block index")
 
 		// Set the best chain view to the stored best state.
 		tip := b.index.LookupNode(&state.hash)

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -732,11 +732,12 @@ func dbFetchUtxoEntryByHash(dbTx database.Tx, hash *chainhash.Hash) (*UtxoEntry,
 //
 // When there is no entry for the provided output, nil will be returned for both
 // the entry and the error.
-func dbFetchUtxoEntry(dbTx database.Tx, outpoint wire.OutPoint) (*UtxoEntry, error) {
+func dbFetchUtxoEntry(dbTx database.Tx, utxoBucket database.Bucket,
+	outpoint wire.OutPoint) (*UtxoEntry, error) {
+
 	// Fetch the unspent transaction output information for the passed
 	// transaction output.  Return now when there is no entry.
 	key := outpointKey(outpoint)
-	utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
 	serializedUtxo := utxoBucket.Get(*key)
 	recycleOutpointKey(key)
 	if serializedUtxo == nil {

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -687,7 +687,6 @@ func deserializeUtxoEntry(serialized []byte) (*UtxoEntry, error) {
 		amount:      int64(amount),
 		pkScript:    pkScript,
 		blockHeight: blockHeight,
-		packedFlags: 0,
 	}
 	if isCoinBase {
 		entry.packedFlags |= tfCoinBase
@@ -786,7 +785,11 @@ func dbPutUtxoEntries(dbTx database.Tx, entries map[wire.OutPoint]*UtxoEntry) er
 			return err
 		}
 		key := outpointKey(outpoint)
-		return utxoBucket.Put(*key, serialized)
+		err = utxoBucket.Put(*key, serialized)
+		if err != nil {
+			return err
+		}
+
 		// NOTE: The key is intentionally not recycled here since the
 		// database interface contract prohibits modifications.  It will
 		// be garbage collected normally when the database is done with

--- a/blockchain/doc.go
+++ b/blockchain/doc.go
@@ -79,3 +79,6 @@ This package includes spec changes outlined by the following BIPs:
 		BIP0034 (https://en.bitcoin.it/wiki/BIP_0034)
 */
 package blockchain
+
+//TODO(stevenroose) update the BIP list there
+//TODO(stevenroose) add utxo cache stuffs

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -709,13 +709,11 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 	var statusNodeNext *blockNode // the first one higher than the statusNode
 	attachNodes := list.New()
 	for node := tip; node.height >= 0; node = node.parent {
-		attachNodes.PushFront(node)
-
 		if node.hash == *statusHash {
 			statusNode = node
 			break
 		}
-
+		attachNodes.PushFront(node)
 		statusNodeNext = node
 	}
 
@@ -788,7 +786,7 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 	}
 
 	log.Debugf("Replaying %d blocks to rebuild UTXO state...",
-		tip.height-statusNodeNext.height)
+		tip.height-statusNodeNext.height+1)
 
 	// Then we replay the blocks from the last consistent state up to the best
 	// state. Iterate forward from the consistent node to the tip of the best
@@ -836,6 +834,9 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 			log.Warn("UTXO state reconstruction interrupted")
 
 			return errInterruptRequested
+		}
+		if node.height == tip.height {
+			break
 		}
 	}
 

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -232,6 +232,16 @@ func (s *utxoCache) totalMemoryUsage() uint64 {
 	return nbEntries*outpointSize + nbEntries*8 + s.totalEntryMemory
 }
 
+// TotalMemoryUsage returns the total memory usage in bytes of the UTXO cache.
+//
+// This method is safe for concurrent access.
+func (s *utxoCache) TotalMemoryUsage() uint64 {
+	s.mtx.Lock()
+	tmu := s.totalMemoryUsage()
+	s.mtx.Unlock()
+	return tmu
+}
+
 // fetchAndCacheEntry tries to fetch an entry from the database.  In none is
 // found, nil is returned.  If an entry is found, it is cached.
 //

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -501,6 +501,14 @@ func (s *utxoCache) Commit(view *UtxoViewpoint) error {
 			continue
 		}
 
+		// It's possible if we disconnected this UTXO at some point, removing it from
+		// the UTXO set, only to have a future block add it back. In that case it could
+		// be going from being marked spent to needing to be marked unspent so we handle
+		// that case by overriding here.
+		if ourEntry.IsSpent() && !entry.IsSpent() {
+			ourEntry = entry
+		}
+
 		// Store the entry we don't know.
 		if err := s.addEntry(outpoint, ourEntry, false); err != nil {
 			return err

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -713,7 +713,7 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 	// blocks from the last best block all the way back to the last
 	// consistent block.
 	log.Debugf("Rolling back %d blocks to rebuild the UTXO state...",
-		tip.height-statusNode.height)
+		tip.height-statusNode.height+1)
 
 	// Roll back blocks in batches.
 	rollbackBatch := func(dbTx database.Tx, node *blockNode) (*blockNode, error) {
@@ -746,7 +746,7 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 	}
 	for node := tip; node.height >= statusNode.height; {
 		log.Tracef("Rolling back %d more blocks...",
-			node.height-statusNode.height)
+			node.height-statusNode.height+1)
 		err := s.db.Update(func(dbTx database.Tx) error {
 			var err error
 			node, err = rollbackBatch(dbTx, node)
@@ -776,7 +776,7 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 	}
 
 	log.Debugf("Replaying %d blocks to rebuild UTXO state...",
-		tip.height-statusNodeNext.height)
+		tip.height-statusNodeNext.height+1)
 
 	// Then we replay the blocks from the last consistent state up to the best
 	// state.  Iterate forward from the consistent node to the tip of the best
@@ -808,8 +808,8 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 		err := dbPutUtxoStateConsistency(dbTx, ucsConsistent, &node.hash)
 		return node, err
 	}
-	for node := statusNodeNext; node.height < tip.height; {
-		log.Tracef("Replaying %d more blocks...", tip.height-node.height)
+	for node := statusNodeNext; node.height <= tip.height; {
+		log.Tracef("Replaying %d more blocks...", tip.height-node.height+1)
 		err := s.db.Update(func(dbTx database.Tx) error {
 			var err error
 			node, err = rollforwardBatch(dbTx, node)
@@ -822,6 +822,10 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 		if interruptRequested(interrupt) {
 			log.Warn("UTXO state reconstruction interrupted")
 			return errInterruptRequested
+		}
+
+		if node.height == tip.height {
+			break
 		}
 	}
 

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -718,7 +718,7 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 	// Roll back blocks in batches.
 	rollbackBatch := func(dbTx database.Tx, node *blockNode) (*blockNode, error) {
 		nbBatchBlocks := 0
-		for ; node.height > statusNode.height; node = node.parent {
+		for ; node.height >= statusNode.height; node = node.parent {
 			block, err := dbFetchBlockByNode(dbTx, node)
 			if err != nil {
 				return nil, err
@@ -737,10 +737,14 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 			if nbBatchBlocks >= utxoBatchSizeBlocks {
 				break
 			}
+
+			if node.height == statusNode.height {
+				break
+			}
 		}
 		return node, nil
 	}
-	for node := tip; node.height > statusNode.height; {
+	for node := tip; node.height >= statusNode.height; {
 		log.Tracef("Rolling back %d more blocks...",
 			node.height-statusNode.height)
 		err := s.db.Update(func(dbTx database.Tx) error {
@@ -755,6 +759,10 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 		if interruptRequested(interrupt) {
 			log.Warn("UTXO state reconstruction interrupted")
 			return errInterruptRequested
+		}
+
+		if node.height == statusNode.height {
+			break
 		}
 	}
 

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -665,11 +665,13 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 	err := s.db.View(func(dbTx database.Tx) error {
 		var err error
 		statusCode, statusHash, err = dbFetchUtxoStateConsistency(dbTx)
+
 		return err
 	})
 	if err != nil {
 		return err
 	}
+
 	log.Tracef("UTXO cache consistency status from disk: [%d] hash %v",
 		statusCode, statusHash)
 
@@ -679,7 +681,7 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 	s.lastFlushHash = tip.hash
 
 	// If no status was found, the database is old and didn't have a cached utxo
-	// state yet.  In that case, we set the status to the best state and write
+	// state yet. In that case, we set the status to the best state and write
 	// this to the database.
 	if statusCode == ucsEmpty {
 		log.Debugf("Database didn't specify UTXO state consistency: consistent "+
@@ -687,12 +689,14 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 		err := s.db.Update(func(dbTx database.Tx) error {
 			return dbPutUtxoStateConsistency(dbTx, ucsConsistent, &tip.hash)
 		})
+
 		return err
 	}
 
 	// If state is consistent, we are done.
 	if statusCode == ucsConsistent && *statusHash == tip.hash {
 		log.Debugf("UTXO state consistent (%d:%v)", tip.height, tip.hash)
+
 		return nil
 	}
 
@@ -706,12 +710,15 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 	attachNodes := list.New()
 	for node := tip; node.height >= 0; node = node.parent {
 		attachNodes.PushFront(node)
+
 		if node.hash == *statusHash {
 			statusNode = node
 			break
 		}
+
 		statusNodeNext = node
 	}
+
 	if statusNode == nil {
 		return AssertError(fmt.Sprintf("last utxo consistency status contains "+
 			"hash that is not in best chain: %v", statusHash))
@@ -721,12 +728,12 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 	// blocks from the last best block all the way back to the last
 	// consistent block.
 	log.Debugf("Rolling back %d blocks to rebuild the UTXO state...",
-		tip.height-statusNode.height+1)
+		tip.height-statusNode.height)
 
 	// Roll back blocks in batches.
 	rollbackBatch := func(dbTx database.Tx, node *blockNode) (*blockNode, error) {
 		nbBatchBlocks := 0
-		for ; node.height >= statusNode.height; node = node.parent {
+		for ; node.height > statusNode.height; node = node.parent {
 			block, err := dbFetchBlockByNode(dbTx, node)
 			if err != nil {
 				return nil, err
@@ -740,24 +747,24 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 			if err := s.rollBackBlock(block, stxos); err != nil {
 				return nil, err
 			}
+
 			nbBatchBlocks++
 
 			if nbBatchBlocks >= utxoBatchSizeBlocks {
 				break
 			}
-
-			if node.height == statusNode.height {
-				break
-			}
 		}
+
 		return node, nil
 	}
-	for node := tip; node.height >= statusNode.height; {
+
+	for node := tip; node.height > statusNode.height; {
 		log.Tracef("Rolling back %d more blocks...",
-			node.height-statusNode.height+1)
+			node.height-statusNode.height)
 		err := s.db.Update(func(dbTx database.Tx) error {
 			var err error
 			node, err = rollbackBatch(dbTx, node)
+
 			return err
 		})
 		if err != nil {
@@ -766,11 +773,8 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 
 		if interruptRequested(interrupt) {
 			log.Warn("UTXO state reconstruction interrupted")
-			return errInterruptRequested
-		}
 
-		if node.height == statusNode.height {
-			break
+			return errInterruptRequested
 		}
 	}
 
@@ -784,11 +788,11 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 	}
 
 	log.Debugf("Replaying %d blocks to rebuild UTXO state...",
-		tip.height-statusNodeNext.height+1)
+		tip.height-statusNodeNext.height)
 
 	// Then we replay the blocks from the last consistent state up to the best
-	// state.  Iterate forward from the consistent node to the tip of the best
-	// chain.  After every batch, we can also update the consistency state to
+	// state. Iterate forward from the consistent node to the tip of the best
+	// chain. After every batch, we can also update the consistency state to
 	// avoid redoing the work when interrupted.
 	rollforwardBatch := func(dbTx database.Tx, node *blockNode) (*blockNode, error) {
 		nbBatchBlocks := 0
@@ -813,14 +817,15 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 
 		// We can update this after each batch to avoid having to redo the work
 		// when interrupted.
-		err := dbPutUtxoStateConsistency(dbTx, ucsConsistent, &node.hash)
-		return node, err
+		return node, dbPutUtxoStateConsistency(dbTx, ucsConsistent, &node.hash)
 	}
+
 	for node := statusNodeNext; node.height <= tip.height; {
 		log.Tracef("Replaying %d more blocks...", tip.height-node.height+1)
 		err := s.db.Update(func(dbTx database.Tx) error {
 			var err error
 			node, err = rollforwardBatch(dbTx, node)
+
 			return err
 		})
 		if err != nil {
@@ -829,14 +834,12 @@ func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{
 
 		if interruptRequested(interrupt) {
 			log.Warn("UTXO state reconstruction interrupted")
-			return errInterruptRequested
-		}
 
-		if node.height == tip.height {
-			break
+			return errInterruptRequested
 		}
 	}
 
 	log.Debug("UTXO state reconstruction done")
+
 	return nil
 }

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -410,8 +410,8 @@ func (s *utxoCache) addEntry(outpoint wire.OutPoint, entry *UtxoEntry, overwrite
 		// Prevent overwriting not-fully-spent entries.  Note that this is not
 		// a consensus check.
 		if cachedEntry != nil && !cachedEntry.IsSpent() {
-			log.Warnf("utxo entry %s attempts to overwrite existing entry that is not "+
-				"fully spent (maybe pre-bip30?)", outpoint)
+			log.Warnf("utxo entry %s attempted to overwrite existing unspent "+
+				"entry (pre-bip30?) ", outpoint)
 			return nil
 		}
 

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -1,0 +1,793 @@
+// Copyright (c) 2015-2018 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/database"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btcutil"
+)
+
+const (
+	// The utxo writes big amounts of data to the database.  In order to limit
+	// the size of individual database transactions, it works in batches.
+
+	// utxoBatchSizeEntries is the maximum number of utxo entries to be written
+	// in a single transaction.
+	utxoBatchSizeEntries = 200000
+
+	// utxoBatchSizeBlocks is the maximum number of blocks to be processed in a
+	// single transaction.
+	utxoBatchSizeBlocks = 50
+
+	// utxoFlushPeriodicThreshold is the threshold percentage at which a flush is
+	// performed when the flush mode FlushPeriodic is used.
+	utxoFlushPeriodicThreshold = 90
+)
+
+// txoFlags is a bitmask defining additional information and state for a
+// transaction output in a utxo view.
+type txoFlags uint8
+
+const (
+	// tfCoinBase indicates that a txout was contained in a coinbase tx.
+	tfCoinBase txoFlags = 1 << iota
+
+	// tfSpent indicates that a txout is spent.
+	tfSpent
+
+	// tfModified indicates that a txout has been modified since it was
+	// loaded.
+	tfModified
+
+	// tfFresh indicates that the entry is fresh.  This means that the parent
+	// view never saw this entry.  Note that tfFresh is a performance
+	// optimization with which we can erase entries that are fully spent if we
+	// know we do not need to commit them.  It is always safe to not mark
+	// tfFresh if that condition is not guaranteed.
+	tfFresh
+)
+
+// UtxoEntry houses details about an individual transaction output in a utxo
+// view such as whether or not it was contained in a coinbase tx, the height of
+// the block that contains the tx, whether or not it is spent, its public key
+// script, and how much it pays.
+type UtxoEntry struct {
+	// NOTE: Additions, deletions, or modifications to the order of the
+	// definitions in this struct should not be changed without considering
+	// how it affects alignment on 64-bit platforms.  The current order is
+	// specifically crafted to result in minimal padding.  There will be a
+	// lot of these in memory, so a few extra bytes of padding adds up.
+	// Any changes here should also be reflected in the memoryUsage() function.
+
+	amount      int64
+	pkScript    []byte // The public key script for the output.
+	blockHeight int32  // Height of block containing tx.
+
+	// packedFlags contains additional info about output such as whether it
+	// is a coinbase, whether it is spent, and whether it has been modified
+	// since it was loaded.  This approach is used in order to reduce memory
+	// usage since there will be a lot of these in memory.
+	packedFlags txoFlags
+}
+
+// IsCoinBase returns whether or not the output was contained in a coinbase
+// transaction.
+func (entry *UtxoEntry) IsCoinBase() bool {
+	return entry.packedFlags&tfCoinBase == tfCoinBase
+}
+
+// IsSpent returns whether or not the output has been spent based upon the
+// current state of the unspent transaction output view it was obtained from.
+func (entry *UtxoEntry) IsSpent() bool {
+	return entry.packedFlags&tfSpent == tfSpent
+}
+
+// isModified returns whether or not the output has been modified since it was
+// loaded.
+func (entry *UtxoEntry) isModified() bool {
+	return entry.packedFlags&tfModified == tfModified
+}
+
+// isFresh returns whether or not it's certain the output has never previously
+// been stored in the database.
+func (entry *UtxoEntry) isFresh() bool {
+	return entry.packedFlags&tfFresh == tfFresh
+}
+
+// BlockHeight returns the height of the block containing the output.
+func (entry *UtxoEntry) BlockHeight() int32 {
+	return entry.blockHeight
+}
+
+// Amount returns the amount of the output.
+func (entry *UtxoEntry) Amount() int64 {
+	return entry.amount
+}
+
+// PkScript returns the public key script for the output.
+func (entry *UtxoEntry) PkScript() []byte {
+	return entry.pkScript
+}
+
+// memoryUsage returns the memory usage in bytes of the UTXO entry.
+// It returns 0 for the nil element.
+func (entry *UtxoEntry) memoryUsage() uint64 {
+	if entry == nil {
+		return 0
+	}
+
+	// This value is calculated by running the following on a 64-bit system:
+	//   unsafe.Sizeof(UtxoEntry{})
+	baseEntrySize := uint64(40)
+
+	return baseEntrySize + uint64(len(entry.pkScript))
+}
+
+// Spend marks the output as spent.  Spending an output that is already spent
+// has no effect.
+func (entry *UtxoEntry) Spend() {
+	// Nothing to do if the output is already spent.
+	if entry.IsSpent() {
+		return
+	}
+
+	// Mark the output as spent and modified.
+	entry.packedFlags |= tfSpent | tfModified
+}
+
+// Clone returns a shallow copy of the utxo entry.
+func (entry *UtxoEntry) Clone() *UtxoEntry {
+	if entry == nil {
+		return nil
+	}
+
+	return &UtxoEntry{
+		amount:      entry.amount,
+		pkScript:    entry.pkScript,
+		blockHeight: entry.blockHeight,
+		packedFlags: entry.packedFlags,
+	}
+}
+
+// utxoView is a common interface for structures that implement a UTXO view.
+type utxoView interface {
+	// getEntry tries to get an entry from the view.  If the entry is not in the
+	// view, both the returned entry and the error are nil.
+	getEntry(outpoint wire.OutPoint) (*UtxoEntry, error)
+
+	// addEntry adds a new entry to the view.  Set overwrite to true if this
+	// entry should overwrite any existing entry for the same outpoint.
+	addEntry(outpoint wire.OutPoint, entry *UtxoEntry, overwrite bool) error
+	// spendEntry marks an entry as spent.
+	spendEntry(outpoint wire.OutPoint, entry *UtxoEntry) error
+}
+
+// utxoByHashSource is an interface that allows fetching UTXO entries by
+// transaction hash.
+// This interface exists due to the legacy spend journal database structure.
+type utxoByHashSource interface {
+	// getEntryByHash looks for an entry with the given transaction hash.
+	// This method exists due to the legacy spend journal database structure.
+	// Its execution is very inefficient, but it's almost never used.
+	getEntryByHash(hash *chainhash.Hash) (*UtxoEntry, error)
+}
+
+// utxoCache is a cached utxo view in the chainstate of a BlockChain.
+//
+// It implements the utxoView interface, but should only be used as such with the
+// state mutex held.  It also implements the utxoByHashSource interface.
+type utxoCache struct {
+	db database.DB
+
+	// maxTotalMemoryUsage is the maximum memory usage in bytes that the state
+	// should contain in normal circumstances.
+	maxTotalMemoryUsage uint64
+
+	// This mutex protects the internal state.
+	// A simple mutex instead of a read-write mutex is chosen because the main
+	// read method also possibly does a write on a cache miss.
+	mtx sync.Mutex
+
+	// cachedEntries keeps the internal cache of the utxo state.  The tfModified
+	// flag indicates that the state of the entry (potentially) deviates from the
+	// state in the database.  Explicit nil values in the map are used to
+	// indicate that the database does not contain the entry.
+	cachedEntries    map[wire.OutPoint]*UtxoEntry
+	totalEntryMemory uint64 // Total memory usage in bytes.
+	lastFlushHash    chainhash.Hash
+}
+
+// newUtxoState initiates a new utxo state instance.
+func newUtxoState(db database.DB, maxTotalMemoryUsage uint64) *utxoCache {
+	return &utxoCache{
+		db:                  db,
+		maxTotalMemoryUsage: maxTotalMemoryUsage,
+
+		cachedEntries: make(map[wire.OutPoint]*UtxoEntry),
+	}
+}
+
+// totalMemoryUsage returns the total memory usage in bytes of the UTXO cache.
+//
+// This method should be called with the state lock held.
+func (s *utxoCache) totalMemoryUsage() uint64 {
+	// This value is calculated by running the following on a 64-bit system:
+	//   unsafe.Sizeof(wire.OutPoint{})
+	outpointSize := uint64(36)
+
+	// Total memory is all the keys plus the total memory of all the entries.
+	nbEntries := uint64(len(s.cachedEntries))
+	return nbEntries*outpointSize + s.totalEntryMemory
+}
+
+// fetchAndCacheEntry tries to fetch an entry from the database.  In none is
+// found, nil is returned.  If an entry is found, it is cached.
+//
+// This method should be called with the state lock held.
+func (s *utxoCache) fetchAndCacheEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
+	var entry *UtxoEntry
+	err := s.db.View(func(dbTx database.Tx) error {
+		var err error
+		entry, err = dbFetchUtxoEntry(dbTx, outpoint)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Add the entry to the memory cache.
+	// NOTE: When the fetched entry is nil, it is still added to the cache as a
+	// miss; this prevents future lookups to perform the same database fetch.
+	s.cachedEntries[outpoint] = entry
+	s.totalEntryMemory += entry.memoryUsage()
+
+	return entry, nil
+}
+
+// getEntry returns the UTXO entry for the given outpoint.  It returns nil if
+// there is no entry for the outpoint in the UTXO state.
+//
+// This method is part of the utxoView interface.
+// This method should be called with the state lock held.
+func (s *utxoCache) getEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
+	if entry, found := s.cachedEntries[outpoint]; found {
+		return entry, nil
+	}
+
+	return s.fetchAndCacheEntry(outpoint)
+}
+
+// FetchEntry returns the UTXO entry for the given outpoint.  It returns nil if
+// there is no entry for the outpoint in the UTXO state.
+//
+// This method is safe for concurrent access.
+func (s *utxoCache) FetchEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
+	s.mtx.Lock()
+	entry, err := s.getEntry(outpoint)
+	s.mtx.Unlock()
+	return entry.Clone(), err
+}
+
+// FetchUtxoEntry returns the requested unspent transaction output from the point
+// of view of the end of the main chain.
+//
+// NOTE: Requesting an output for which there is no data will NOT return an
+// error.  Instead both the entry and the error will be nil.  This is done to
+// allow pruning of spent transaction outputs.  In practice this means the
+// caller must check if the returned entry is nil before invoking methods on it.
+//
+// This function is safe for concurrent access however the returned entry (if
+// any) is NOT.
+func (b *BlockChain) FetchUtxoEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
+	b.chainLock.RLock()
+	entry, err := b.utxoCache.FetchEntry(outpoint)
+	b.chainLock.RUnlock()
+	return entry, err
+}
+
+// getEntryByHash attempts to find any available UTXO for the given hash by
+// searching the entire set of possible outputs for the given hash.
+//
+// This method is part of the utxoByHashSource interface.
+// This method should be called with the state lock held.
+func (s *utxoCache) getEntryByHash(hash *chainhash.Hash) (*UtxoEntry, error) {
+	// First attempt to find a utxo with the provided hash in the cache.
+	prevOut := wire.OutPoint{Hash: *hash}
+	for idx := uint32(0); idx < MaxOutputsPerBlock; idx++ {
+		prevOut.Index = idx
+		if entry, _ := s.cachedEntries[prevOut]; entry != nil {
+			return entry.Clone(), nil
+		}
+	}
+
+	// Then fall back to the database.
+	var entry *UtxoEntry
+	err := s.db.View(func(dbTx database.Tx) error {
+		var err error
+		entry, err = dbFetchUtxoEntryByHash(dbTx, hash)
+		return err
+	})
+
+	// Since we don't know the entries outpoint, we can't cache it.
+	return entry, err
+}
+
+// FetchEntryByHash attempts to find any available UTXO for the given hash by
+// searching the entire set of possible outputs for the given hash.
+//
+// This method is safe for concurrent access.
+func (s *utxoCache) FetchEntryByHash(hash *chainhash.Hash) (*UtxoEntry, error) {
+	s.mtx.Lock()
+	entry, err := s.getEntryByHash(hash)
+	defer s.mtx.Unlock()
+	return entry.Clone(), err
+}
+
+// spendEntry marks the output as spent.  Spending an output that is already
+// spent has no effect.  Entries that need not be stored anymore after being
+// spent will be removed from the cache.
+//
+// This method is part of the utxoView interface.
+// This method should be called with the state lock held.
+func (s *utxoCache) spendEntry(outpoint wire.OutPoint, addIfNil *UtxoEntry) error {
+	entry := s.cachedEntries[outpoint]
+
+	// If we don't have an entry in cache and an entry was provided, we add it.
+	if entry == nil && addIfNil != nil {
+		if err := s.addEntry(outpoint, addIfNil, false); err != nil {
+			return err
+		}
+		entry = addIfNil
+	}
+
+	// If it's nil or already spent, nothing to do.
+	if entry == nil || entry.IsSpent() {
+		return nil
+	}
+
+	// If an entry is fresh, meaning that there hasn't been a flush since it was
+	// introduced, it can simply be removed.
+	if entry.isFresh() {
+		// We don't delete it from the map, but set the value to nil, so that
+		// later lookups for the entry know that the entry does not exist in the
+		// database.
+		s.cachedEntries[outpoint] = nil
+		s.totalEntryMemory -= entry.memoryUsage()
+		return nil
+	}
+
+	// Mark the output as spent and modified.
+	entry.packedFlags |= tfSpent | tfModified
+
+	//TODO(stevenroose) check if it's ok to drop the pkScript
+	// Since we don't need it anymore, drop the pkScript value of the entry.
+	s.totalEntryMemory -= entry.memoryUsage()
+	entry.pkScript = nil
+	s.totalEntryMemory += entry.memoryUsage()
+
+	return nil
+}
+
+// addEntry adds a new unspent entry if it is not probably unspendable.  Set
+// overwrite to true to skip validity and freshness checks and simply add the
+// item, possibly overwriting another entry that is not-fully-spent.
+//
+// This method is part of the utxoView interface.
+// This method should be called with the state lock held.
+func (s *utxoCache) addEntry(outpoint wire.OutPoint, entry *UtxoEntry, overwrite bool) error {
+	// Don't add provably unspendable outputs.
+	if txscript.IsUnspendable(entry.pkScript) {
+		return nil
+	}
+
+	cachedEntry, _ := s.cachedEntries[outpoint]
+
+	// In overwrite mode, simply add the entry without doing these checks.
+	if !overwrite {
+		// Prevent overwriting not-fully-spent entries.  Note that this is not
+		// a consensus check.
+		if cachedEntry != nil && !cachedEntry.IsSpent() {
+			return AssertError("entry overwrites existing entry that is not " +
+				"fully spent")
+		}
+
+		// If we didn't have an entry for the outpoint and the existing entry is
+		// not marked modified, we can mark it fresh as the database does not
+		// know about this entry.  This will allow us to erase it when it gets
+		// spent before the next flush.
+		if cachedEntry == nil && !entry.isModified() {
+			entry.packedFlags |= tfFresh
+		}
+	}
+
+	entry.packedFlags |= tfModified
+	s.cachedEntries[outpoint] = entry
+	s.totalEntryMemory -= cachedEntry.memoryUsage() // 0 for nil
+	s.totalEntryMemory += entry.memoryUsage()
+	return nil
+}
+
+// FetchTxView returns a local view on the utxo state for the given transaction.
+//
+// This method is safe for concurrent access.
+func (s *utxoCache) FetchTxView(tx *btcutil.Tx) (*UtxoViewpoint, error) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	view := NewUtxoViewpoint()
+	viewEntries := view.Entries()
+	if !IsCoinBase(tx) {
+		for _, txIn := range tx.MsgTx().TxIn {
+			entry, err := s.getEntry(txIn.PreviousOutPoint)
+			if err != nil {
+				return nil, err
+			}
+			viewEntries[txIn.PreviousOutPoint] = entry.Clone()
+		}
+	}
+	prevOut := wire.OutPoint{Hash: *tx.Hash()}
+	for txOutIdx := range tx.MsgTx().TxOut {
+		prevOut.Index = uint32(txOutIdx)
+
+		entry, err := s.getEntry(prevOut)
+		if err != nil {
+			return nil, err
+		}
+		viewEntries[prevOut] = entry.Clone()
+	}
+
+	return view, nil
+}
+
+// FetchUtxoView loads unspent transaction outputs for the inputs referenced by
+// the passed transaction from the point of view of the end of the main chain.
+// It also attempts to get the utxos for the outputs of the transaction itself
+// so the returned view can be examined for duplicate transactions.
+//
+// This function is safe for concurrent access however the returned view is NOT.
+func (b *BlockChain) FetchUtxoView(tx *btcutil.Tx) (*UtxoViewpoint, error) {
+	b.chainLock.RLock()
+	view, err := b.utxoCache.FetchTxView(tx)
+	b.chainLock.RUnlock()
+	return view, err
+}
+
+// Commit commits all the entries in the view to the cache.
+//
+// This function is safe for concurrent access.
+func (s *utxoCache) Commit(view *UtxoViewpoint) error {
+	for outpoint, entry := range view.Entries() {
+		// No need to update the database if the entry was not modified or fresh.
+		if entry == nil || (!entry.isModified() && !entry.isFresh()) {
+			continue
+		}
+
+		// We can't use the view entry directly because it can be modified
+		// lateron.
+		ourEntry := s.cachedEntries[outpoint]
+		if ourEntry == nil {
+			ourEntry = entry.Clone()
+		}
+
+		// Remove the utxo entry if it is spent.
+		if entry.IsSpent() {
+			if err := s.spendEntry(outpoint, ourEntry); err != nil {
+				return err
+			}
+			continue
+		}
+
+		// Store the entry we don't know.
+		if err := s.addEntry(outpoint, ourEntry, false); err != nil {
+			return err
+		}
+	}
+
+	view.prune()
+	return nil
+}
+
+// flush flushes the UTXO state to the database.
+//
+// This method should be called with the state lock held.
+func (s *utxoCache) flush(bestState *BestState) error {
+	// If we performed a flush in the current best state, we have nothing to do.
+	if bestState.Hash == s.lastFlushHash {
+		return nil
+	}
+
+	// Add one to round up the integer division.
+	totalMiB := s.totalMemoryUsage()/(1024*1024) + 1
+	log.Infof("Flushing UTXO cache of ~%v MiB to disk. For large sizes, "+
+		"this can take up to several minutes...", totalMiB)
+
+	// First update the database to indicate that a utxo state flush is started.
+	// This allows us to recover when the node shuts down in the middle of this
+	// method.
+	err := s.db.Update(func(dbTx database.Tx) error {
+		return dbPutUtxoStateConsistency(dbTx, ucsFlushOngoing, &s.lastFlushHash)
+	})
+	if err != nil {
+		return err
+	}
+
+	// Store all entries in batches.
+	flushBatch := func(dbTx database.Tx) error {
+		nbBatchEntries := 0
+		for outpoint, entry := range s.cachedEntries {
+			// Nil entries or unmodified entries can just be pruned.
+			// They don't count for the batch size.
+			if entry == nil || !entry.isModified() {
+				s.totalEntryMemory -= entry.memoryUsage()
+				delete(s.cachedEntries, outpoint)
+				continue
+			}
+
+			if entry.IsSpent() {
+				if err := dbDeleteUtxoEntry(dbTx, outpoint); err != nil {
+					return err
+				}
+			} else {
+				if err := dbPutUtxoEntry(dbTx, outpoint, entry); err != nil {
+					return err
+				}
+			}
+			nbBatchEntries++
+
+			s.totalEntryMemory -= entry.memoryUsage()
+			delete(s.cachedEntries, outpoint)
+
+			// End this batch when the maximum number of entries per batch has
+			// been reached.
+			if nbBatchEntries >= utxoBatchSizeEntries {
+				break
+			}
+		}
+		return nil
+	}
+	for len(s.cachedEntries) > 0 {
+		log.Tracef("Flushing %d more entries...", len(s.cachedEntries))
+		err := s.db.Update(func(dbTx database.Tx) error {
+			return flushBatch(dbTx)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	// When done, store the best state hash in the database to indicate the state
+	// is consistent until that hash.
+	err = s.db.Update(func(dbTx database.Tx) error {
+		return dbPutUtxoStateConsistency(dbTx, ucsConsistent, &bestState.Hash)
+	})
+	if err != nil {
+		return err
+	}
+
+	log.Debug("Done flushing UTXO cache to disk")
+	return nil
+}
+
+// Flush flushes the UTXO state to the database.
+//
+// This function is safe for concurrent access.
+func (s *utxoCache) Flush(mode FlushMode, bestState *BestState) error {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	var threshold uint64
+	switch mode {
+	case FlushRequired:
+		threshold = 0
+
+	case FlushIfNeeded:
+		threshold = s.maxTotalMemoryUsage
+
+	case FlushPeriodic:
+		threshold = (utxoFlushPeriodicThreshold * s.maxTotalMemoryUsage) / 100
+	}
+
+	if s.totalMemoryUsage() > threshold {
+		return s.flush(bestState)
+	}
+	return nil
+}
+
+// rollBackBlock rolls back the effects of the block when the state was left in
+// an inconsistent state.  This means that no errors will be raised when the
+// state is invalid.
+//
+// This method should be called with the state lock held.
+func (s *utxoCache) rollBackBlock(block *btcutil.Block, stxos []SpentTxOut) error {
+	return disconnectTransactions(s, block, stxos, s)
+}
+
+// rollForwardBlock rolls forward the effects of the block when the state was
+// left in an inconsistent state.  This means that no errors will be raised when
+// the state is invalid.
+//
+// This method should be called with the state lock held.
+func (s *utxoCache) rollForwardBlock(block *btcutil.Block) error {
+	// We don't need the collect stxos and we allow overwriting existing entries.
+	return connectTransactions(s, block, nil, true)
+}
+
+// InitConsistentState checks the consistency status of the utxo state and
+// replays blocks if it lags behind the best state of the blockchain.
+//
+// It needs to be ensured that the chainView passed to this method does not
+// get changed during the execution of this method.
+func (s *utxoCache) InitConsistentState(tip *blockNode, interrupt <-chan struct{}) error {
+	// Load the consistency status from the database.
+	var statusCode byte
+	var statusHash *chainhash.Hash
+	err := s.db.View(func(dbTx database.Tx) error {
+		var err error
+		statusCode, statusHash, err = dbFetchUtxoStateConsistency(dbTx)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	log.Tracef("UTXO cache consistency status from disk: [%d] hash %v",
+		statusCode, statusHash)
+
+	// We can set this variable now already because it will always be valid
+	// unless an error is returned, in which case the state is entirely invalid.
+	// Doing it here prevents forgetting it later.
+	s.lastFlushHash = tip.hash
+
+	// If no status was found, the database is old and didn't have a cached utxo
+	// state yet.  In that case, we set the status to the best state and write
+	// this to the database.
+	if statusCode == ucsEmpty {
+		log.Debugf("Database didn't specify UTXO state consistency: consistent "+
+			"to best chain tip (%v)", tip.hash)
+		err := s.db.Update(func(dbTx database.Tx) error {
+			return dbPutUtxoStateConsistency(dbTx, ucsConsistent, &tip.hash)
+		})
+		return err
+	}
+
+	// If state is consistent, we are done.
+	if statusCode == ucsConsistent && *statusHash == tip.hash {
+		log.Debugf("UTXO state consistent (%d:%v)", tip.height, tip.hash)
+		return nil
+	}
+
+	log.Info("Reconstructing UTXO state after unclean shutdown. This may take " +
+		"a long time...")
+
+	// Even though this should always be true, make sure the fetched hash is in
+	// the best chain.
+	var statusNode *blockNode
+	var statusNodeNext *blockNode // the first one higher than the statusNode
+	for node := tip; node.height > 0; node = node.parent {
+		if node.hash == *statusHash {
+			statusNode = node
+			break
+		}
+		statusNodeNext = node
+	}
+	if statusNode == nil {
+		return AssertError(fmt.Sprintf("last utxo consistency status contains "+
+			"hash that is not in best chain: %v", statusHash))
+	}
+
+	// If data was in the middle of a flush, we have to roll back all blocks from
+	// the last best block all the way back to the last consistent block.
+	if statusCode == ucsFlushOngoing {
+		log.Debugf("btcd was shut down during a UTXO cache flush, "+
+			"rolling back %d blocks...", tip.height-statusNode.height)
+
+		// Roll back blocks in batches.
+		rollbackBatch := func(dbTx database.Tx, node *blockNode) (*blockNode, error) {
+			nbBatchBlocks := 0
+			for ; node.height > statusNode.height; node = node.parent {
+				block, err := dbFetchBlockByNode(dbTx, node)
+				if err != nil {
+					return nil, err
+				}
+
+				stxos, err := dbFetchSpendJournalEntry(dbTx, block)
+				if err != nil {
+					return nil, err
+				}
+
+				if err := s.rollBackBlock(block, stxos); err != nil {
+					return nil, err
+				}
+				nbBatchBlocks++
+
+				if nbBatchBlocks >= utxoBatchSizeBlocks {
+					break
+				}
+			}
+			return node, nil
+		}
+		for node := tip; node.height > statusNode.height; {
+			log.Tracef("Rolling back %d more blocks...",
+				node.height-statusNode.height)
+			err := s.db.Update(func(dbTx database.Tx) error {
+				var err error
+				node, err = rollbackBatch(dbTx, node)
+				return err
+			})
+			if err != nil {
+				return err
+			}
+
+			if interruptRequested(interrupt) {
+				log.Warn("UTXO state reconstruction interrupted")
+				return errInterruptRequested
+			}
+		}
+
+		// Now we can update the status already to avoid redoing this work when
+		// interrupted.
+		err := s.db.Update(func(dbTx database.Tx) error {
+			return dbPutUtxoStateConsistency(dbTx, ucsConsistent, statusHash)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Debugf("Replaying %d blocks to rebuild UTXO state...",
+		tip.height-statusNodeNext.height)
+
+	// Then we replay the blocks from the last consistent state up to the best
+	// state.  Iterate forward from the consistent node to the tip of the best
+	// chain.  After every batch, we can also update the consistency state to
+	// avoid redoing the work when interrupted.
+	rollforwardBatch := func(dbTx database.Tx, node *blockNode) (*blockNode, error) {
+		nbBatchBlocks := 0
+		for ; node.height <= tip.height; node = node.parent {
+			block, err := dbFetchBlockByNode(dbTx, node)
+			if err != nil {
+				return nil, err
+			}
+
+			if err := s.rollForwardBlock(block); err != nil {
+				return nil, err
+			}
+			nbBatchBlocks++
+
+			if nbBatchBlocks >= utxoBatchSizeBlocks {
+				break
+			}
+		}
+
+		// We can update this after each batch to avoid having to redo the work
+		// when interrupted.
+		err := dbPutUtxoStateConsistency(dbTx, ucsConsistent, &node.hash)
+		return node, err
+	}
+	for node := statusNodeNext; node.height <= tip.height; {
+		log.Tracef("Replaying %d more blocks...", tip.height-node.height)
+		err := s.db.Update(func(dbTx database.Tx) error {
+			var err error
+			node, err = rollforwardBatch(dbTx, node)
+			return err
+		})
+		if err != nil {
+			return err
+		}
+
+		if interruptRequested(interrupt) {
+			log.Warn("UTXO state reconstruction interrupted")
+			return errInterruptRequested
+		}
+	}
+
+	log.Debug("UTXO state reconstruction done")
+	return nil
+}

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -272,8 +272,10 @@ func (s *utxoCache) fetchAndCacheEntries(ops map[wire.OutPoint]struct{}) (
 
 	entries := make(map[wire.OutPoint]*UtxoEntry, len(ops))
 	err := s.db.View(func(dbTx database.Tx) error {
+		utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
+
 		for op := range ops {
-			entry, err := dbFetchUtxoEntry(dbTx, op)
+			entry, err := dbFetchUtxoEntry(dbTx, utxoBucket, op)
 			if err != nil {
 				return err
 			}

--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -1,0 +1,452 @@
+package blockchain
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/database"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/btcsuite/btclog"
+	"github.com/btcsuite/btcutil"
+	"github.com/davecgh/go-spew/spew"
+)
+
+var (
+	// opTrueScript is simply a public key script that contains the OP_TRUE
+	// opcode.  It is defined here to reduce garbage creation.
+	opTrueScript = []byte{txscript.OP_TRUE}
+
+	// lowFee is a single satoshi and exists to make the test code more
+	// readable.
+	lowFee = btcutil.Amount(1)
+)
+
+// uniqueOpReturnScript returns a standard provably-pruneable OP_RETURN script
+// with a random uint64 encoded as the data.
+func uniqueOpReturnScript() []byte {
+	rand, err := wire.RandomUint64()
+	if err != nil {
+		panic(err)
+	}
+
+	data := make([]byte, 8)
+	binary.LittleEndian.PutUint64(data[0:8], rand)
+
+	builder := txscript.NewScriptBuilder()
+	script, err := builder.AddOp(txscript.OP_RETURN).AddData(data).Script()
+	if err != nil {
+		panic(err)
+	}
+	return script
+}
+
+// solveBlock attempts to find a nonce which makes the passed block header hash
+// to a value less than the target difficulty.  When a successful solution is
+// found true is returned and the nonce field of the passed header is updated
+// with the solution.  False is returned if no solution exists.
+func solveBlock(header *wire.BlockHeader) bool {
+	// sbResult is used by the solver goroutines to send results.
+	type sbResult struct {
+		found bool
+		nonce uint32
+	}
+
+	// solver accepts a block header and a nonce range to test. It is
+	// intended to be run as a goroutine.
+	targetDifficulty := CompactToBig(header.Bits)
+	quit := make(chan bool)
+	results := make(chan sbResult)
+	solver := func(hdr wire.BlockHeader, startNonce, stopNonce uint32) {
+		// We need to modify the nonce field of the header, so make sure
+		// we work with a copy of the original header.
+		for i := startNonce; i >= startNonce && i <= stopNonce; i++ {
+			select {
+			case <-quit:
+				return
+			default:
+				hdr.Nonce = i
+				hash := hdr.BlockHash()
+				if HashToBig(&hash).Cmp(
+					targetDifficulty) <= 0 {
+
+					results <- sbResult{true, i}
+					return
+				}
+			}
+		}
+		results <- sbResult{false, 0}
+	}
+
+	startNonce := uint32(1)
+	stopNonce := uint32(math.MaxUint32)
+	numCores := uint32(runtime.NumCPU())
+	noncesPerCore := (stopNonce - startNonce) / numCores
+	for i := uint32(0); i < numCores; i++ {
+		rangeStart := startNonce + (noncesPerCore * i)
+		rangeStop := startNonce + (noncesPerCore * (i + 1)) - 1
+		if i == numCores-1 {
+			rangeStop = stopNonce
+		}
+		go solver(*header, rangeStart, rangeStop)
+	}
+	for i := uint32(0); i < numCores; i++ {
+		result := <-results
+		if result.found {
+			close(quit)
+			header.Nonce = result.nonce
+			return true
+		}
+	}
+
+	return false
+}
+
+// spendableOut represents a transaction output that is spendable along with
+// additional metadata such as the block its in and how much it pays.
+type spendableOut struct {
+	prevOut wire.OutPoint
+	amount  btcutil.Amount
+}
+
+// makeSpendableOutForTx returns a spendable output for the given transaction
+// and transaction output index within the transaction.
+func makeSpendableOutForTx(tx *wire.MsgTx, txOutIndex uint32) spendableOut {
+	return spendableOut{
+		prevOut: wire.OutPoint{
+			Hash:  tx.TxHash(),
+			Index: txOutIndex,
+		},
+		amount: btcutil.Amount(tx.TxOut[txOutIndex].Value),
+	}
+}
+
+// addBlock adds a block to the blockchain that succeeds prev.  The blocks spends
+// all the provided spendable outputs.  The new block is returned, together with
+// the new spendable outputs created in the block.
+//
+// Panics on errors.
+func addBlock(chain *BlockChain, prev *btcutil.Block, spends []*spendableOut) (*btcutil.Block, []*spendableOut) {
+	blockHeight := prev.Height() + 1
+	txns := make([]*wire.MsgTx, 0, 1+len(spends))
+
+	// Create and add coinbase tx.
+	coinbaseScript, err := txscript.NewScriptBuilder().
+		AddInt64(int64(blockHeight)).
+		AddInt64(int64(0)).Script()
+	if err != nil {
+		panic(err)
+	}
+	cb := wire.NewMsgTx(1)
+	cb.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: *wire.NewOutPoint(&chainhash.Hash{},
+			wire.MaxPrevOutIndex),
+		Sequence:        wire.MaxTxInSequenceNum,
+		SignatureScript: coinbaseScript,
+	})
+	cb.AddTxOut(&wire.TxOut{
+		Value:    CalcBlockSubsidy(blockHeight, chain.chainParams),
+		PkScript: opTrueScript,
+	})
+	txns = append(txns, cb)
+
+	// Spend all txs to be spent.
+	for _, spend := range spends {
+		spendTx := wire.NewMsgTx(1)
+		spendTx.AddTxIn(&wire.TxIn{
+			PreviousOutPoint: spend.prevOut,
+			Sequence:         wire.MaxTxInSequenceNum,
+			SignatureScript:  nil,
+		})
+		spendTx.AddTxOut(wire.NewTxOut(int64(spend.amount-lowFee),
+			opTrueScript))
+		// Add a random (prunable) OP_RETURN output to make the txid unique.
+		spendTx.AddTxOut(wire.NewTxOut(0, uniqueOpReturnScript()))
+
+		cb.TxOut[0].Value += int64(lowFee)
+		txns = append(txns, spendTx)
+	}
+
+	// Create spendable outs to return at the end.
+	outs := make([]*spendableOut, len(txns))
+	for i, tx := range txns {
+		out := makeSpendableOutForTx(tx, 0)
+		outs[i] = &out
+	}
+
+	// Build the block.
+
+	// Use a timestamp that is one second after the previous block unless
+	// this is the first block in which case the current time is used.
+	var ts time.Time
+	if blockHeight == 1 {
+		ts = time.Unix(time.Now().Unix(), 0)
+	} else {
+		ts = prev.MsgBlock().Header.Timestamp.Add(time.Second)
+	}
+
+	// Calculate merkle root.
+	utilTxns := make([]*btcutil.Tx, 0, len(txns))
+	for _, tx := range txns {
+		utilTxns = append(utilTxns, btcutil.NewTx(tx))
+	}
+	merkles := BuildMerkleTreeStore(utilTxns, false)
+
+	block := btcutil.NewBlock(&wire.MsgBlock{
+		Header: wire.BlockHeader{
+			Version:    1,
+			PrevBlock:  *prev.Hash(),
+			MerkleRoot: *merkles[len(merkles)-1],
+			Bits:       chain.chainParams.PowLimitBits,
+			Timestamp:  ts,
+			Nonce:      0, // To be solved.
+		},
+		Transactions: txns,
+	})
+	block.SetHeight(blockHeight)
+
+	// Solve the block.
+	if !solveBlock(&block.MsgBlock().Header) {
+		panic(fmt.Sprintf("Unable to solve block at height %d", blockHeight))
+	}
+
+	_, _, err = chain.ProcessBlock(block, BFNone)
+	if err != nil {
+		panic(err)
+	}
+
+	return block, outs
+}
+
+// assertConsistencyState asserts the utxo consistency states of the blockchain.
+func assertConsistencyState(t *testing.T, chain *BlockChain, code byte, hash *chainhash.Hash) {
+	var actualCode byte
+	var actualHash *chainhash.Hash
+	err := chain.db.View(func(dbTx database.Tx) (err error) {
+		actualCode, actualHash, err = dbFetchUtxoStateConsistency(dbTx)
+		return
+	})
+	if err != nil {
+		t.Fatalf("Error fetching utxo state consistency: %v", err)
+	}
+	if actualCode != code {
+		t.Fatalf("Unexpected consistency code: %d instead of %d",
+			actualCode, code)
+	}
+	if !actualHash.IsEqual(hash) {
+		t.Fatalf("Unexpected consistency hash: %v instead of %v",
+			actualHash, hash)
+	}
+}
+
+func parseOutpointKey(b []byte) wire.OutPoint {
+	op := wire.OutPoint{}
+	copy(op.Hash[:], b[:chainhash.HashSize])
+	idx, _ := deserializeVLQ(b[chainhash.HashSize:])
+	op.Index = uint32(idx)
+	return op
+}
+
+// assertNbEntriesOnDisk asserts that the total number of utxo entries on the
+// disk is equal to the given expected number.
+func assertNbEntriesOnDisk(t *testing.T, chain *BlockChain, expectedNumber int) {
+	t.Log("Asserting nb entries on disk...")
+	var nb int
+	err := chain.db.View(func(dbTx database.Tx) error {
+		cursor := dbTx.Metadata().Bucket(utxoSetBucketName).Cursor()
+		nb = 0
+		for b := cursor.First(); b; b = cursor.Next() {
+			nb++
+			entry, err := deserializeUtxoEntry(cursor.Value())
+			if err != nil {
+				t.Fatalf("Failed to deserialize entry: %v", err)
+			}
+			outpoint := parseOutpointKey(cursor.Key())
+			t.Log(outpoint.String())
+			t.Log(spew.Sdump(entry))
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Error fetching utxo entries: %v", err)
+	}
+	if nb != expectedNumber {
+		t.Fatalf("Expected %d elements in the UTXO set, but found %d",
+			expectedNumber, nb)
+	}
+	t.Log("Assertion done")
+}
+
+func init() {
+	//TODO(stevenroose) remove
+	UseLogger(btclog.NewBackend(os.Stdout).Logger("TST"))
+	log.SetLevel(btclog.LevelTrace)
+}
+
+// utxoCacheTestChain creates a test BlockChain to be used for utxo cache tests.
+// It uses the regression test parameters, a coin matutiry of 1 block and sets
+// the cache size limit to 10 MiB.
+func utxoCacheTestChain(testName string) (*BlockChain, *chaincfg.Params, func()) {
+	params := chaincfg.RegressionNetParams
+	chain, tearDown, err := chainSetup(testName, &params)
+	if err != nil {
+		panic(fmt.Sprintf("error loading blockchain with database: %v", err))
+	}
+
+	chain.TstSetCoinbaseMaturity(1)
+	chain.utxoCache.maxTotalMemoryUsage = 10 * 1024 * 1024
+
+	return chain, &params, tearDown
+}
+
+func TestUtxoCache_SimpleFlush(t *testing.T) {
+	t.Parallel()
+
+	chain, params, tearDown := utxoCacheTestChain("TestUtxoCache_SimpleFlush")
+	defer tearDown()
+	cache := chain.utxoCache
+	tip := btcutil.NewBlock(params.GenesisBlock)
+
+	// The chainSetup init triggered write of consistency status of genesis.
+	assertConsistencyState(t, chain, ucsConsistent, params.GenesisHash)
+	assertNbEntriesOnDisk(t, chain, 0)
+
+	// LastFlushHash starts with genesis.
+	if cache.lastFlushHash != *params.GenesisHash {
+		t.Fatalf("lastFlushHash before first flush expected to be "+
+			"genesis block hash, instead was %v", cache.lastFlushHash)
+	}
+
+	// First, add 10 utxos without flushing.
+	for i := 0; i < 10; i++ {
+		tip, _ = addBlock(chain, tip, nil)
+	}
+	if len(cache.cachedEntries) != 10 {
+		t.Fatalf("Expected 10 entries, has %d instead", len(cache.cachedEntries))
+	}
+
+	// All elements should be fresh and modified.
+	for outpoint, elem := range cache.cachedEntries {
+		if elem == nil {
+			t.Fatalf("Unexpected nil entry found for %v", outpoint)
+		}
+		if elem.packedFlags&tfModified == 0 {
+			t.Fatal("Entry should be marked mofified")
+		}
+		if elem.packedFlags&tfFresh == 0 {
+			t.Fatal("Entry should be marked fresh")
+		}
+	}
+
+	// Not flushed yet.
+	assertConsistencyState(t, chain, ucsConsistent, params.GenesisHash)
+	assertNbEntriesOnDisk(t, chain, 0)
+
+	// Flush.
+	if err := chain.FlushCachedState(FlushRequired); err != nil {
+		t.Fatalf("unexpected error while flushing cache: %v", err)
+	}
+	if len(cache.cachedEntries) != 0 {
+		t.Fatalf("Expected 0 entries, has %d instead", len(cache.cachedEntries))
+	}
+	assertConsistencyState(t, chain, ucsConsistent, tip.Hash())
+	assertNbEntriesOnDisk(t, chain, 10)
+}
+
+func TestUtxoCache_ThresholdPeriodicFlush(t *testing.T) {
+	t.Parallel()
+
+	chain, params, tearDown := utxoCacheTestChain("TestUtxoCache_ThresholdPeriodicFlush")
+	defer tearDown()
+	cache := chain.utxoCache
+	tip := btcutil.NewBlock(params.GenesisBlock)
+
+	// Set the limit to the size of 10 empty elements.  This will trigger
+	// flushing when adding 10 non-empty elements.
+	cache.maxTotalMemoryUsage = (*UtxoEntry)(nil).memoryUsage() * 10
+
+	// Add 10 elems and let it exceed the threshold.
+	var flushedAt *chainhash.Hash
+	for i := 0; i < 10; i++ {
+		tip, _ = addBlock(chain, tip, nil)
+		if len(cache.cachedEntries) == 0 {
+			flushedAt = tip.Hash()
+		}
+	}
+
+	// Should have flushed in the meantime.
+	if flushedAt == nil {
+		t.Fatal("should have flushed")
+	}
+	assertConsistencyState(t, chain, ucsConsistent, flushedAt)
+	if len(cache.cachedEntries) >= 10 {
+		t.Fatalf("Expected less than 10 entries, has %d instead",
+			len(cache.cachedEntries))
+	}
+
+	// Make sure flushes on periodic.
+	cache.maxTotalMemoryUsage = (90*cache.totalMemoryUsage())/100 - 1
+	if err := chain.FlushCachedState(FlushPeriodic); err != nil {
+		t.Fatalf("unexpected error while flushing cache: %v", err)
+	}
+	if len(cache.cachedEntries) != 0 {
+		t.Fatalf("Expected 0 entries, has %d instead", len(cache.cachedEntries))
+	}
+	assertConsistencyState(t, chain, ucsConsistent, tip.Hash())
+	assertNbEntriesOnDisk(t, chain, 10)
+}
+
+func TestUtxoCache_Reorg(t *testing.T) {
+	t.Parallel()
+
+	chain, params, tearDown := utxoCacheTestChain("TestUtxoCache_Reorg")
+	defer tearDown()
+	tip := btcutil.NewBlock(params.GenesisBlock)
+
+	// First make two blocks that create spendable outputs.
+	var spendableOuts []*spendableOut
+	tip, spendableOuts = addBlock(chain, tip, spendableOuts)
+	tip, spendableOuts = addBlock(chain, tip, spendableOuts)
+	t.Log(spew.Sdump(spendableOuts))
+
+	if err := chain.FlushCachedState(FlushRequired); err != nil {
+		t.Fatalf("unexpected error while flushing cache: %v", err)
+	}
+	assertConsistencyState(t, chain, ucsConsistent, tip.Hash())
+	assertNbEntriesOnDisk(t, chain, len(spendableOuts))
+
+	b0 := tip
+
+	// Spend all spendable outs and confirm with a block.
+	var forkSpendables []*spendableOut
+	b1a, forkSpendables := addBlock(chain, b0, spendableOuts)
+	b2a, forkSpendables := addBlock(chain, b1a, forkSpendables)
+
+	if err := chain.FlushCachedState(FlushRequired); err != nil {
+		t.Fatalf("unexpected error while flushing cache: %v", err)
+	}
+	assertConsistencyState(t, chain, ucsConsistent, b2a.Hash())
+	assertNbEntriesOnDisk(t, chain, len(forkSpendables))
+
+	// Build an alternative chain of 3 blocks.
+	b1b, spendable := addBlock(chain, b0, nil)
+	spendableOuts = append(spendableOuts, spendable...)
+	b2b, spendable := addBlock(chain, b1b, nil)
+	spendableOuts = append(spendableOuts, spendable...)
+	b3b, spendable := addBlock(chain, b2b, nil)
+	spendableOuts = append(spendableOuts, spendable...)
+	t.Log(spew.Sdump(spendableOuts))
+
+	if err := chain.FlushCachedState(FlushRequired); err != nil {
+		t.Fatalf("unexpected error while flushing cache: %v", err)
+	}
+	assertConsistencyState(t, chain, ucsConsistent, b3b.Hash())
+	assertNbEntriesOnDisk(t, chain, len(spendableOuts))
+}

--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -427,13 +427,10 @@ func TestUtxoCache_Reorg(t *testing.T) {
 	// Spend all spendable outs and confirm with a block.
 	var forkSpendables []*spendableOut
 	b1a, forkSpendables := addBlock(chain, b0, spendableOuts)
-	b2a, forkSpendables := addBlock(chain, b1a, forkSpendables)
+	_, forkSpendables = addBlock(chain, b1a, forkSpendables)
 
-	if err := chain.FlushCachedState(FlushRequired); err != nil {
-		t.Fatalf("unexpected error while flushing cache: %v", err)
-	}
-	assertConsistencyState(t, chain, ucsConsistent, b2a.Hash())
-	assertNbEntriesOnDisk(t, chain, len(forkSpendables))
+	// leave the spent outs in the cache which lets us exercise
+	// un-spending entries both in the db and in the utxocache
 
 	// Build an alternative chain of 3 blocks.
 	b1b, spendable := addBlock(chain, b0, nil)

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -177,10 +177,9 @@ func (view *UtxoViewpoint) addInputUtxos(source utxoView, block *btcutil.Block) 
 
 			// Add the entry from the source.
 			entry, err := source.getEntry(txIn.PreviousOutPoint)
-			if err != nil {
-				return err
+			if err == nil && entry != nil {
+				view.entries[txIn.PreviousOutPoint] = entry.Clone()
 			}
-			view.entries[txIn.PreviousOutPoint] = entry.Clone()
 		}
 	}
 

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -8,108 +8,10 @@ import (
 	"fmt"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/btcsuite/btcd/database"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcutil"
 )
-
-// txoFlags is a bitmask defining additional information and state for a
-// transaction output in a utxo view.
-type txoFlags uint8
-
-const (
-	// tfCoinBase indicates that a txout was contained in a coinbase tx.
-	tfCoinBase txoFlags = 1 << iota
-
-	// tfSpent indicates that a txout is spent.
-	tfSpent
-
-	// tfModified indicates that a txout has been modified since it was
-	// loaded.
-	tfModified
-)
-
-// UtxoEntry houses details about an individual transaction output in a utxo
-// view such as whether or not it was contained in a coinbase tx, the height of
-// the block that contains the tx, whether or not it is spent, its public key
-// script, and how much it pays.
-type UtxoEntry struct {
-	// NOTE: Additions, deletions, or modifications to the order of the
-	// definitions in this struct should not be changed without considering
-	// how it affects alignment on 64-bit platforms.  The current order is
-	// specifically crafted to result in minimal padding.  There will be a
-	// lot of these in memory, so a few extra bytes of padding adds up.
-
-	amount      int64
-	pkScript    []byte // The public key script for the output.
-	blockHeight int32  // Height of block containing tx.
-
-	// packedFlags contains additional info about output such as whether it
-	// is a coinbase, whether it is spent, and whether it has been modified
-	// since it was loaded.  This approach is used in order to reduce memory
-	// usage since there will be a lot of these in memory.
-	packedFlags txoFlags
-}
-
-// isModified returns whether or not the output has been modified since it was
-// loaded.
-func (entry *UtxoEntry) isModified() bool {
-	return entry.packedFlags&tfModified == tfModified
-}
-
-// IsCoinBase returns whether or not the output was contained in a coinbase
-// transaction.
-func (entry *UtxoEntry) IsCoinBase() bool {
-	return entry.packedFlags&tfCoinBase == tfCoinBase
-}
-
-// BlockHeight returns the height of the block containing the output.
-func (entry *UtxoEntry) BlockHeight() int32 {
-	return entry.blockHeight
-}
-
-// IsSpent returns whether or not the output has been spent based upon the
-// current state of the unspent transaction output view it was obtained from.
-func (entry *UtxoEntry) IsSpent() bool {
-	return entry.packedFlags&tfSpent == tfSpent
-}
-
-// Spend marks the output as spent.  Spending an output that is already spent
-// has no effect.
-func (entry *UtxoEntry) Spend() {
-	// Nothing to do if the output is already spent.
-	if entry.IsSpent() {
-		return
-	}
-
-	// Mark the output as spent and modified.
-	entry.packedFlags |= tfSpent | tfModified
-}
-
-// Amount returns the amount of the output.
-func (entry *UtxoEntry) Amount() int64 {
-	return entry.amount
-}
-
-// PkScript returns the public key script for the output.
-func (entry *UtxoEntry) PkScript() []byte {
-	return entry.pkScript
-}
-
-// Clone returns a shallow copy of the utxo entry.
-func (entry *UtxoEntry) Clone() *UtxoEntry {
-	if entry == nil {
-		return nil
-	}
-
-	return &UtxoEntry{
-		amount:      entry.amount,
-		pkScript:    entry.pkScript,
-		blockHeight: entry.blockHeight,
-		packedFlags: entry.packedFlags,
-	}
-}
 
 // UtxoViewpoint represents a view into the set of unspent transaction outputs
 // from a specific point of view in the chain.  For example, it could be for
@@ -121,18 +23,10 @@ func (entry *UtxoEntry) Clone() *UtxoEntry {
 type UtxoViewpoint struct {
 	entries  map[wire.OutPoint]*UtxoEntry
 	bestHash chainhash.Hash
-}
 
-// BestHash returns the hash of the best block in the chain the view currently
-// respresents.
-func (view *UtxoViewpoint) BestHash() *chainhash.Hash {
-	return &view.bestHash
-}
-
-// SetBestHash sets the hash of the best block in the chain the view currently
-// respresents.
-func (view *UtxoViewpoint) SetBestHash(hash *chainhash.Hash) {
-	view.bestHash = *hash
+	// getEntryByHashSource is used to fulfill the method getEntryByHash, which
+	// is only used for chains with a legacy database.
+	getEntryByHashSource *utxoCache
 }
 
 // LookupEntry returns information about a given transaction output according to
@@ -141,6 +35,32 @@ func (view *UtxoViewpoint) SetBestHash(hash *chainhash.Hash) {
 // disconnected during a reorg.
 func (view *UtxoViewpoint) LookupEntry(outpoint wire.OutPoint) *UtxoEntry {
 	return view.entries[outpoint]
+}
+
+//TODO(stevenroose) copy documentation.
+// This method is part of the utxoView interface.
+func (view *UtxoViewpoint) getEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
+	return view.LookupEntry(outpoint), nil
+}
+
+//TODO(stevenroose) copy documentation.
+// This method is part of the utxoView interface.
+func (view *UtxoViewpoint) addEntry(outpoint wire.OutPoint, entry *UtxoEntry, overwrite bool) error {
+	view.entries[outpoint] = entry
+	return nil
+}
+
+func (view *UtxoViewpoint) spendEntry(outpoint wire.OutPoint, putIfNil *UtxoEntry) error {
+	// If we don't have the entry yet, add it.
+	entry, found := view.entries[outpoint]
+	if !found {
+		entry = putIfNil
+		view.entries[outpoint] = entry
+	}
+
+	// Then mark it as spent.
+	entry.Spend()
+	return nil
 }
 
 // addTxOut adds the specified output to the view if it is not provably
@@ -211,51 +131,140 @@ func (view *UtxoViewpoint) AddTxOuts(tx *btcutil.Tx, blockHeight int32) {
 	}
 }
 
+// addInputUtxos adds the unspent transaction outputs for the inputs referenced
+// by the transactions in the given block to the view.  In particular, referenced
+// entries that are earlier in the block are added to the view and entries that
+// are already in the view are not modified.
+func (view *UtxoViewpoint) addInputUtxos(source utxoView, block *btcutil.Block) error {
+	// Build a map of in-flight transactions because some of the inputs in
+	// this block could be referencing other transactions earlier in this
+	// block which are not yet in the chain.
+	txInFlight := map[chainhash.Hash]int{}
+	transactions := block.Transactions()
+	for i, tx := range transactions {
+		txInFlight[*tx.Hash()] = i
+	}
+
+	// Loop through all of the transaction inputs (except for the coinbase
+	// which has no inputs) collecting them into sets of what is needed and
+	// what is already known (in-flight).
+	for i, tx := range transactions[1:] {
+		for _, txIn := range tx.MsgTx().TxIn {
+			// Don't do anything for entries that are already in the view.
+			if _, ok := view.entries[txIn.PreviousOutPoint]; ok {
+				continue
+			}
+
+			// It is acceptable for a transaction input to reference
+			// the output of another transaction in this block only
+			// if the referenced transaction comes before the
+			// current one in this block.  Add the outputs of the
+			// referenced transaction as available utxos when this
+			// is the case.  Otherwise, the utxo details are still
+			// needed.
+			//
+			// NOTE: The >= is correct here because i is one less
+			// than the actual position of the transaction within
+			// the block due to skipping the coinbase.
+			originHash := &txIn.PreviousOutPoint.Hash
+			if inFlightIndex, ok := txInFlight[*originHash]; ok &&
+				i >= inFlightIndex {
+
+				originTx := transactions[inFlightIndex]
+				view.AddTxOuts(originTx, block.Height())
+				continue
+			}
+
+			// Add the entry from the source.
+			entry, err := source.getEntry(txIn.PreviousOutPoint)
+			if err != nil {
+				return err
+			}
+			view.entries[txIn.PreviousOutPoint] = entry.Clone()
+		}
+	}
+
+	return nil
+}
+
 // connectTransaction updates the view by adding all new utxos created by the
 // passed transaction and marking all utxos that the transactions spend as
 // spent.  In addition, when the 'stxos' argument is not nil, it will be updated
 // to append an entry for each spent txout.  An error will be returned if the
-// view does not contain the required utxos.
-func (view *UtxoViewpoint) connectTransaction(tx *btcutil.Tx, blockHeight int32, stxos *[]SpentTxOut) error {
-	// Coinbase transactions don't have any inputs to spend.
-	if IsCoinBase(tx) {
-		// Add the transaction's outputs as available utxos.
-		view.AddTxOuts(tx, blockHeight)
-		return nil
-	}
+// view does not contain the required utxos.  Set overwrite to true of new
+// entries should be allowed to overwrite existing not-fully-spent entries.
+func connectTransaction(view utxoView, tx *btcutil.Tx, blockHeight int32,
+	stxos *[]SpentTxOut, overwrite bool) error {
 
-	// Spend the referenced utxos by marking them spent in the view and,
-	// if a slice was provided for the spent txout details, append an entry
-	// to it.
-	for _, txIn := range tx.MsgTx().TxIn {
-		// Ensure the referenced utxo exists in the view.  This should
-		// never happen unless there is a bug is introduced in the code.
-		entry := view.entries[txIn.PreviousOutPoint]
-		if entry == nil {
-			return AssertError(fmt.Sprintf("view missing input %v",
-				txIn.PreviousOutPoint))
-		}
-
-		// Only create the stxo details if requested.
-		if stxos != nil {
-			// Populate the stxo details using the utxo entry.
-			var stxo = SpentTxOut{
-				Amount:     entry.Amount(),
-				PkScript:   entry.PkScript(),
-				Height:     entry.BlockHeight(),
-				IsCoinBase: entry.IsCoinBase(),
+	// Skip input processing when tx is coinbase.
+	if !IsCoinBase(tx) {
+		// Spend the referenced utxos by marking them spent in the view and,
+		// if a slice was provided for the spent txout details, append an entry
+		// to it.
+		for _, txIn := range tx.MsgTx().TxIn {
+			// Ensure the referenced utxo exists in the view.  This should
+			// never happen unless there is a bug is introduced in the code.
+			entry, err := view.getEntry(txIn.PreviousOutPoint)
+			if err != nil {
+				return err
 			}
-			*stxos = append(*stxos, stxo)
-		}
+			if entry == nil {
+				return AssertError(fmt.Sprintf("view missing input %v",
+					txIn.PreviousOutPoint))
+			}
 
-		// Mark the entry as spent.  This is not done until after the
-		// relevant details have been accessed since spending it might
-		// clear the fields from memory in the future.
-		entry.Spend()
+			// Only create the stxo details if requested.
+			if stxos != nil {
+				// Populate the stxo details using the utxo entry.
+				var stxo = SpentTxOut{
+					Amount:     entry.Amount(),
+					PkScript:   entry.PkScript(),
+					Height:     entry.BlockHeight(),
+					IsCoinBase: entry.IsCoinBase(),
+				}
+				*stxos = append(*stxos, stxo)
+			}
+
+			// Mark the entry as spent.
+			if err := view.spendEntry(txIn.PreviousOutPoint, entry); err != nil {
+				return err
+			}
+		}
 	}
 
 	// Add the transaction's outputs as available utxos.
-	view.AddTxOuts(tx, blockHeight)
+	isCoinBase := IsCoinBase(tx)
+	prevOut := wire.OutPoint{Hash: *tx.Hash()}
+	for txOutIdx, txOut := range tx.MsgTx().TxOut {
+		prevOut.Index = uint32(txOutIdx)
+
+		// Don't add provably unspendable outputs.
+		if txscript.IsUnspendable(txOut.PkScript) {
+			continue
+		}
+
+		// Create a new entry from the output.
+		entry := &UtxoEntry{
+			amount:      txOut.Value,
+			pkScript:    txOut.PkScript,
+			blockHeight: blockHeight,
+			packedFlags: tfModified,
+		}
+		if isCoinBase {
+			entry.packedFlags |= tfCoinBase
+		}
+		if !overwrite {
+			// If overwrite is false (i.e. we are not replaying blocks in
+			// recovery mode), this entry is fresh, meaning it can be pruned when
+			// it gets spent before the next flush.
+			entry.packedFlags |= tfFresh
+		}
+
+		// Add entry to the view.
+		if err := view.addEntry(prevOut, entry, overwrite); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -263,52 +272,28 @@ func (view *UtxoViewpoint) connectTransaction(tx *btcutil.Tx, blockHeight int32,
 // of the transactions in the passed block, marking all utxos the transactions
 // spend as spent, and setting the best hash for the view to the passed block.
 // In addition, when the 'stxos' argument is not nil, it will be updated to
-// append an entry for each spent txout.
-func (view *UtxoViewpoint) connectTransactions(block *btcutil.Block, stxos *[]SpentTxOut) error {
+// append an entry for each spent txout.  Set overwrite to true of new
+// entries should be allowed to overwrite existing not-fully-spent entries.
+func connectTransactions(view utxoView, block *btcutil.Block,
+	stxos *[]SpentTxOut, overwrite bool) error {
+
 	for _, tx := range block.Transactions() {
-		err := view.connectTransaction(tx, block.Height(), stxos)
+		err := connectTransaction(view, tx, block.Height(), stxos, overwrite)
 		if err != nil {
 			return err
 		}
 	}
 
-	// Update the best hash for view to include this block since all of its
-	// transactions have been connected.
-	view.SetBestHash(block.Hash())
 	return nil
-}
-
-// fetchEntryByHash attempts to find any available utxo for the given hash by
-// searching the entire set of possible outputs for the given hash.  It checks
-// the view first and then falls back to the database if needed.
-func (view *UtxoViewpoint) fetchEntryByHash(db database.DB, hash *chainhash.Hash) (*UtxoEntry, error) {
-	// First attempt to find a utxo with the provided hash in the view.
-	prevOut := wire.OutPoint{Hash: *hash}
-	for idx := uint32(0); idx < MaxOutputsPerBlock; idx++ {
-		prevOut.Index = idx
-		entry := view.LookupEntry(prevOut)
-		if entry != nil {
-			return entry, nil
-		}
-	}
-
-	// Check the database since it doesn't exist in the view.  This will
-	// often by the case since only specifically referenced utxos are loaded
-	// into the view.
-	var entry *UtxoEntry
-	err := db.View(func(dbTx database.Tx) error {
-		var err error
-		entry, err = dbFetchUtxoEntryByHash(dbTx, hash)
-		return err
-	})
-	return entry, err
 }
 
 // disconnectTransactions updates the view by removing all of the transactions
 // created by the passed block, restoring all utxos the transactions spent by
 // using the provided spent txo information, and setting the best hash for the
 // view to the block before the passed block.
-func (view *UtxoViewpoint) disconnectTransactions(db database.DB, block *btcutil.Block, stxos []SpentTxOut) error {
+func disconnectTransactions(view utxoView, block *btcutil.Block,
+	stxos []SpentTxOut, byHashSource utxoByHashSource) error {
+
 	// Sanity check the correct number of stxos are provided.
 	if len(stxos) != countSpentOutputs(block) {
 		return AssertError("disconnectTransactions called with bad " +
@@ -349,19 +334,18 @@ func (view *UtxoViewpoint) disconnectTransactions(db database.DB, block *btcutil
 			}
 
 			prevOut.Index = uint32(txOutIdx)
-			entry := view.entries[prevOut]
-			if entry == nil {
-				entry = &UtxoEntry{
-					amount:      txOut.Value,
-					pkScript:    txOut.PkScript,
-					blockHeight: block.Height(),
-					packedFlags: packedFlags,
-				}
 
-				view.entries[prevOut] = entry
+			// Mark the entry as spent.  To make sure the view has the entry,
+			// create one to pass along.
+			entry := &UtxoEntry{
+				amount:      txOut.Value,
+				pkScript:    txOut.PkScript,
+				blockHeight: block.Height(),
+				packedFlags: packedFlags,
 			}
-
-			entry.Spend()
+			if err := view.spendEntry(prevOut, entry); err != nil {
+				return err
+			}
 		}
 
 		// Loop backwards through all of the transaction inputs (except
@@ -372,20 +356,12 @@ func (view *UtxoViewpoint) disconnectTransactions(db database.DB, block *btcutil
 			continue
 		}
 		for txInIdx := len(tx.MsgTx().TxIn) - 1; txInIdx > -1; txInIdx-- {
+			originOut := tx.MsgTx().TxIn[txInIdx].PreviousOutPoint
+
 			// Ensure the spent txout index is decremented to stay
 			// in sync with the transaction input.
 			stxo := &stxos[stxoIdx]
 			stxoIdx--
-
-			// When there is not already an entry for the referenced
-			// output in the view, it means it was previously spent,
-			// so create a new utxo entry in order to resurrect it.
-			originOut := &tx.MsgTx().TxIn[txInIdx].PreviousOutPoint
-			entry := view.entries[*originOut]
-			if entry == nil {
-				entry = new(UtxoEntry)
-				view.entries[*originOut] = entry
-			}
 
 			// The legacy v1 spend journal format only stored the
 			// coinbase flag and height when the output was the last
@@ -406,14 +382,14 @@ func (view *UtxoViewpoint) disconnectTransactions(db database.DB, block *btcutil
 			// only ever run with the new v2 format, this code path
 			// will never run.
 			if stxo.Height == 0 {
-				utxo, err := view.fetchEntryByHash(db, txHash)
+				utxo, err := byHashSource.getEntryByHash(txHash)
 				if err != nil {
 					return err
 				}
 				if utxo == nil {
 					return AssertError(fmt.Sprintf("unable "+
 						"to resurrect legacy stxo %v",
-						*originOut))
+						originOut))
 				}
 
 				stxo.Height = utxo.BlockHeight()
@@ -422,19 +398,23 @@ func (view *UtxoViewpoint) disconnectTransactions(db database.DB, block *btcutil
 
 			// Restore the utxo using the stxo data from the spend
 			// journal and mark it as modified.
-			entry.amount = stxo.Amount
-			entry.pkScript = stxo.PkScript
-			entry.blockHeight = stxo.Height
-			entry.packedFlags = tfModified
+			entry := &UtxoEntry{
+				amount:      stxo.Amount,
+				pkScript:    stxo.PkScript,
+				blockHeight: stxo.Height,
+				packedFlags: tfModified,
+			}
 			if stxo.IsCoinBase {
 				entry.packedFlags |= tfCoinBase
+			}
+
+			// Then store the entry in the view.
+			if err := view.addEntry(originOut, entry, true); err != nil {
+				return err
 			}
 		}
 	}
 
-	// Update the best hash for view to the previous block since all of the
-	// transactions for the current block have been disconnected.
-	view.SetBestHash(&block.MsgBlock().Header.PrevBlock)
 	return nil
 }
 
@@ -450,9 +430,9 @@ func (view *UtxoViewpoint) Entries() map[wire.OutPoint]*UtxoEntry {
 	return view.entries
 }
 
-// commit prunes all entries marked modified that are now fully spent and marks
+// prune prunes all entries marked modified that are now fully spent and marks
 // all entries as unmodified.
-func (view *UtxoViewpoint) commit() {
+func (view *UtxoViewpoint) prune() {
 	for outpoint, entry := range view.entries {
 		if entry == nil || (entry.isModified() && entry.IsSpent()) {
 			delete(view.entries, outpoint)
@@ -463,180 +443,9 @@ func (view *UtxoViewpoint) commit() {
 	}
 }
 
-// fetchUtxosMain fetches unspent transaction output data about the provided
-// set of outpoints from the point of view of the end of the main chain at the
-// time of the call.
-//
-// Upon completion of this function, the view will contain an entry for each
-// requested outpoint.  Spent outputs, or those which otherwise don't exist,
-// will result in a nil entry in the view.
-func (view *UtxoViewpoint) fetchUtxosMain(db database.DB, outpoints map[wire.OutPoint]struct{}) error {
-	// Nothing to do if there are no requested outputs.
-	if len(outpoints) == 0 {
-		return nil
-	}
-
-	// Load the requested set of unspent transaction outputs from the point
-	// of view of the end of the main chain.
-	//
-	// NOTE: Missing entries are not considered an error here and instead
-	// will result in nil entries in the view.  This is intentionally done
-	// so other code can use the presence of an entry in the store as a way
-	// to unnecessarily avoid attempting to reload it from the database.
-	return db.View(func(dbTx database.Tx) error {
-		for outpoint := range outpoints {
-			entry, err := dbFetchUtxoEntry(dbTx, outpoint)
-			if err != nil {
-				return err
-			}
-
-			view.entries[outpoint] = entry
-		}
-
-		return nil
-	})
-}
-
-// fetchUtxos loads the unspent transaction outputs for the provided set of
-// outputs into the view from the database as needed unless they already exist
-// in the view in which case they are ignored.
-func (view *UtxoViewpoint) fetchUtxos(db database.DB, outpoints map[wire.OutPoint]struct{}) error {
-	// Nothing to do if there are no requested outputs.
-	if len(outpoints) == 0 {
-		return nil
-	}
-
-	// Filter entries that are already in the view.
-	neededSet := make(map[wire.OutPoint]struct{})
-	for outpoint := range outpoints {
-		// Already loaded into the current view.
-		if _, ok := view.entries[outpoint]; ok {
-			continue
-		}
-
-		neededSet[outpoint] = struct{}{}
-	}
-
-	// Request the input utxos from the database.
-	return view.fetchUtxosMain(db, neededSet)
-}
-
-// fetchInputUtxos loads the unspent transaction outputs for the inputs
-// referenced by the transactions in the given block into the view from the
-// database as needed.  In particular, referenced entries that are earlier in
-// the block are added to the view and entries that are already in the view are
-// not modified.
-func (view *UtxoViewpoint) fetchInputUtxos(db database.DB, block *btcutil.Block) error {
-	// Build a map of in-flight transactions because some of the inputs in
-	// this block could be referencing other transactions earlier in this
-	// block which are not yet in the chain.
-	txInFlight := map[chainhash.Hash]int{}
-	transactions := block.Transactions()
-	for i, tx := range transactions {
-		txInFlight[*tx.Hash()] = i
-	}
-
-	// Loop through all of the transaction inputs (except for the coinbase
-	// which has no inputs) collecting them into sets of what is needed and
-	// what is already known (in-flight).
-	neededSet := make(map[wire.OutPoint]struct{})
-	for i, tx := range transactions[1:] {
-		for _, txIn := range tx.MsgTx().TxIn {
-			// It is acceptable for a transaction input to reference
-			// the output of another transaction in this block only
-			// if the referenced transaction comes before the
-			// current one in this block.  Add the outputs of the
-			// referenced transaction as available utxos when this
-			// is the case.  Otherwise, the utxo details are still
-			// needed.
-			//
-			// NOTE: The >= is correct here because i is one less
-			// than the actual position of the transaction within
-			// the block due to skipping the coinbase.
-			originHash := &txIn.PreviousOutPoint.Hash
-			if inFlightIndex, ok := txInFlight[*originHash]; ok &&
-				i >= inFlightIndex {
-
-				originTx := transactions[inFlightIndex]
-				view.AddTxOuts(originTx, block.Height())
-				continue
-			}
-
-			// Don't request entries that are already in the view
-			// from the database.
-			if _, ok := view.entries[txIn.PreviousOutPoint]; ok {
-				continue
-			}
-
-			neededSet[txIn.PreviousOutPoint] = struct{}{}
-		}
-	}
-
-	// Request the input utxos from the database.
-	return view.fetchUtxosMain(db, neededSet)
-}
-
 // NewUtxoViewpoint returns a new empty unspent transaction output view.
 func NewUtxoViewpoint() *UtxoViewpoint {
 	return &UtxoViewpoint{
 		entries: make(map[wire.OutPoint]*UtxoEntry),
 	}
-}
-
-// FetchUtxoView loads unspent transaction outputs for the inputs referenced by
-// the passed transaction from the point of view of the end of the main chain.
-// It also attempts to fetch the utxos for the outputs of the transaction itself
-// so the returned view can be examined for duplicate transactions.
-//
-// This function is safe for concurrent access however the returned view is NOT.
-func (b *BlockChain) FetchUtxoView(tx *btcutil.Tx) (*UtxoViewpoint, error) {
-	// Create a set of needed outputs based on those referenced by the
-	// inputs of the passed transaction and the outputs of the transaction
-	// itself.
-	neededSet := make(map[wire.OutPoint]struct{})
-	prevOut := wire.OutPoint{Hash: *tx.Hash()}
-	for txOutIdx := range tx.MsgTx().TxOut {
-		prevOut.Index = uint32(txOutIdx)
-		neededSet[prevOut] = struct{}{}
-	}
-	if !IsCoinBase(tx) {
-		for _, txIn := range tx.MsgTx().TxIn {
-			neededSet[txIn.PreviousOutPoint] = struct{}{}
-		}
-	}
-
-	// Request the utxos from the point of view of the end of the main
-	// chain.
-	view := NewUtxoViewpoint()
-	b.chainLock.RLock()
-	err := view.fetchUtxosMain(b.db, neededSet)
-	b.chainLock.RUnlock()
-	return view, err
-}
-
-// FetchUtxoEntry loads and returns the requested unspent transaction output
-// from the point of view of the end of the main chain.
-//
-// NOTE: Requesting an output for which there is no data will NOT return an
-// error.  Instead both the entry and the error will be nil.  This is done to
-// allow pruning of spent transaction outputs.  In practice this means the
-// caller must check if the returned entry is nil before invoking methods on it.
-//
-// This function is safe for concurrent access however the returned entry (if
-// any) is NOT.
-func (b *BlockChain) FetchUtxoEntry(outpoint wire.OutPoint) (*UtxoEntry, error) {
-	b.chainLock.RLock()
-	defer b.chainLock.RUnlock()
-
-	var entry *UtxoEntry
-	err := b.db.View(func(dbTx database.Tx) error {
-		var err error
-		entry, err = dbFetchUtxoEntry(dbTx, outpoint)
-		return err
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return entry, nil
 }

--- a/cmd/addblock/import.go
+++ b/cmd/addblock/import.go
@@ -287,6 +287,16 @@ func (bi *blockImporter) Import() chan *importResults {
 	// the status handler when done.
 	go func() {
 		bi.wg.Wait()
+
+		// Flush the changes made to the blockchain.
+		log.Info("Flushing blockchain caches to the disk...")
+		if err := bi.chain.FlushCachedState(blockchain.FlushRequired); err != nil {
+			log.Errorf("Error while flushing the blockchain state: %v", err)
+			bi.errChan <- err
+			return
+		}
+		log.Info("Done flushing blockchain caches to disk")
+
 		bi.doneChan <- true
 	}()
 

--- a/config.go
+++ b/config.go
@@ -61,6 +61,7 @@ const (
 	defaultMaxOrphanTransactions = 100
 	defaultMaxOrphanTxSize       = 100000
 	defaultSigCacheMaxSize       = 100000
+	defaultUtxoCacheMaxSizeMiB   = 250
 	sampleConfigFilename         = "sample-btcd.conf"
 	defaultTxIndex               = false
 	defaultAddrIndex             = false
@@ -156,6 +157,7 @@ type config struct {
 	NoCFilters           bool          `long:"nocfilters" description:"Disable committed filtering (CF) support"`
 	DropCfIndex          bool          `long:"dropcfindex" description:"Deletes the index used for committed filtering (CF) support from the database on start up and then exits."`
 	SigCacheMaxSize      uint          `long:"sigcachemaxsize" description:"The maximum number of entries in the signature verification cache"`
+	UtxoCacheMaxSizeMiB  uint          `long:"utxocachemaxsize" description:"The maximum size in MiB of the UTXO cache"`
 	BlocksOnly           bool          `long:"blocksonly" description:"Do not accept transactions from remote peers."`
 	TxIndex              bool          `long:"txindex" description:"Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
 	DropTxIndex          bool          `long:"droptxindex" description:"Deletes the hash-based transaction index from the database on start up and then exits."`
@@ -426,6 +428,7 @@ func loadConfig() (*config, []string, error) {
 		BlockPrioritySize:    mempool.DefaultBlockPrioritySize,
 		MaxOrphanTxs:         defaultMaxOrphanTransactions,
 		SigCacheMaxSize:      defaultSigCacheMaxSize,
+		UtxoCacheMaxSizeMiB:  defaultUtxoCacheMaxSizeMiB,
 		Generate:             defaultGenerate,
 		TxIndex:              defaultTxIndex,
 		AddrIndex:            defaultAddrIndex,

--- a/netsync/blocklogger.go
+++ b/netsync/blocklogger.go
@@ -5,9 +5,11 @@
 package netsync
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btclog"
 	"github.com/btcsuite/btcutil"
 )
@@ -40,7 +42,7 @@ func newBlockProgressLogger(progressMessage string, logger btclog.Logger) *block
 // LogBlockHeight logs a new block height as an information message to show
 // progress to the user. In order to prevent spam, it limits logging to one
 // message every 10 seconds with duration and totals included.
-func (b *blockProgressLogger) LogBlockHeight(block *btcutil.Block) {
+func (b *blockProgressLogger) LogBlockHeight(block *btcutil.Block, chain *blockchain.BlockChain) {
 	b.Lock()
 	defer b.Unlock()
 
@@ -66,9 +68,10 @@ func (b *blockProgressLogger) LogBlockHeight(block *btcutil.Block) {
 	if b.receivedLogTx == 1 {
 		txStr = "transaction"
 	}
-	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, height %d, %s)",
+	cacheSizeStr := fmt.Sprintf("~%d MiB", chain.CachedStateSize()/1024/1024)
+	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, height %d, %s, %s cache)",
 		b.progressAction, b.receivedLogBlocks, blockStr, tDuration, b.receivedLogTx,
-		txStr, block.Height(), block.MsgBlock().Header.Timestamp)
+		txStr, block.Height(), block.MsgBlock().Header.Timestamp, cacheSizeStr)
 
 	b.receivedLogBlocks = 0
 	b.receivedLogTx = 0

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -636,7 +636,7 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 	} else {
 		// When the block is not an orphan, log information about it and
 		// update the chain state.
-		sm.progressLogger.LogBlockHeight(bmsg.block)
+		sm.progressLogger.LogBlockHeight(bmsg.block, sm.chain)
 
 		// Update this peer's latest block height, for future
 		// potential sync node candidacy.

--- a/server.go
+++ b/server.go
@@ -2630,14 +2630,15 @@ func newServer(listenAddrs []string, db database.DB, chainParams *chaincfg.Param
 	// Create a new block chain instance with the appropriate configuration.
 	var err error
 	s.chain, err = blockchain.New(&blockchain.Config{
-		DB:           s.db,
-		Interrupt:    interrupt,
-		ChainParams:  s.chainParams,
-		Checkpoints:  checkpoints,
-		TimeSource:   s.timeSource,
-		SigCache:     s.sigCache,
-		IndexManager: indexManager,
-		HashCache:    s.hashCache,
+		DB:               s.db,
+		UtxoCacheMaxSize: uint64(cfg.UtxoCacheMaxSizeMiB) * 1024 * 1024,
+		Interrupt:        interrupt,
+		ChainParams:      s.chainParams,
+		Checkpoints:      checkpoints,
+		TimeSource:       s.timeSource,
+		SigCache:         s.sigCache,
+		IndexManager:     indexManager,
+		HashCache:        s.hashCache,
 	})
 	if err != nil {
 		return nil, err

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -848,7 +848,7 @@ func getWitnessSigOps(pkScript []byte, witness wire.TxWitness) int {
 }
 
 // IsUnspendable returns whether the passed public key script is unspendable, or
-// guaranteed to fail at execution.  This allows inputs to be pruned instantly
+// guaranteed to fail at execution.  This allows outputs to be pruned instantly
 // when entering the UTXO set.
 func IsUnspendable(pkScript []byte) bool {
 	pops, err := parseScript(pkScript)


### PR DESCRIPTION
This PR picks off where #1168 left off. I've back ported fixes from the `gcash` repo, ensuring all commits have their authors properly attributed. I've started to test this PR as is on both mainnet and testnet. We also need to examine the set of fixes and ensure they're absolutely necessary, as many of the back-ported `gcash` fixes didn't have accompanying unit tests that failed before the fix was applied. 

Additionally, I plan to fix what I view as two design flaws in the current UTXO set cache:
  1. When entries are added, we don't evict them in real time. As a result, the cache can grow very large beyond the targeted constrained sized. In the future, we'll likely also implement more advanced eviction logic, such as evicting the oldest present UTXO, as empirically, UTXOs die young. 
  2. When we flush the cache, we also remove all in memory entries from the cache. This causes additional G/C pressure, as the very next block, we then need to re-allocate the map. Additionally, this causes more cache hits, as we start with a cold cache for the next block which guarantees that we'll have a large set of cache misses. Instead, we should only seek to sync our in memory view with that what's on disk, only syncing the entires that have been modified. 

Thanks to everyone that had a part in this including @stevenroose, @cfromknecht and @cpacia. 