### PR TITLE
wire: cache the non-witness serialization of MsgTx to memoize part of…

### DIFF
--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -384,6 +384,8 @@ func additionalCoinbase(amount btcutil.Amount) func(*wire.MsgBlock) {
 		// Increase the first proof-of-work coinbase subsidy by the
 		// provided amount.
 		b.Transactions[0].TxOut[0].Value += int64(amount)
+
+		b.Transactions[0].WipeCache()
 	}
 }
 
@@ -402,6 +404,8 @@ func additionalSpendFee(fee btcutil.Amount) func(*wire.MsgBlock) {
 				fee))
 		}
 		b.Transactions[1].TxOut[0].Value -= int64(fee)
+
+		b.Transactions[1].WipeCache()
 	}
 }
 
@@ -410,6 +414,8 @@ func additionalSpendFee(fee btcutil.Amount) func(*wire.MsgBlock) {
 func replaceSpendScript(pkScript []byte) func(*wire.MsgBlock) {
 	return func(b *wire.MsgBlock) {
 		b.Transactions[1].TxOut[0].PkScript = pkScript
+
+		b.Transactions[1].WipeCache()
 	}
 }
 
@@ -418,6 +424,8 @@ func replaceSpendScript(pkScript []byte) func(*wire.MsgBlock) {
 func replaceCoinbaseSigScript(script []byte) func(*wire.MsgBlock) {
 	return func(b *wire.MsgBlock) {
 		b.Transactions[0].TxIn[0].SignatureScript = script
+
+		b.Transactions[0].WipeCache()
 	}
 }
 

--- a/btcutil/txsort/txsort_test.go
+++ b/btcutil/txsort/txsort_test.go
@@ -114,6 +114,9 @@ func TestSort(t *testing.T) {
 		// Now sort the transaction using the mutable version and ensure
 		// the resulting hash is the expected value.
 		txsort.InPlaceSort(&tx)
+
+		tx.WipeCache()
+
 		if got := tx.TxHash().String(); got != test.sortedHash {
 			t.Errorf("SortMutate (%s): sorted hash does not match "+
 				"expected - got %v, want %v", test.name, got,

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -137,6 +137,18 @@ func TestMessage(t *testing.T) {
 				spew.Sdump(msg))
 			continue
 		}
+
+		// Blank out the cached encoding for transactions to ensure the
+		// deep equality check doesn't fail.
+		if tx, ok := msg.(*MsgTx); ok {
+			tx.cachedSeralizedNoWitness = nil
+		}
+		if block, ok := msg.(*MsgBlock); ok {
+			for _, tx := range block.Transactions {
+				tx.cachedSeralizedNoWitness = nil
+			}
+		}
+
 		if !reflect.DeepEqual(msg, test.out) {
 			t.Errorf("ReadMessage #%d\n got: %v want: %v", i,
 				spew.Sdump(msg), spew.Sdump(test.out))
@@ -170,6 +182,18 @@ func TestMessage(t *testing.T) {
 				spew.Sdump(msg))
 			continue
 		}
+
+		// Blank out the cached encoding for transactions to ensure the
+		// deep equality check doesn't fail.
+		if tx, ok := msg.(*MsgTx); ok {
+			tx.cachedSeralizedNoWitness = nil
+		}
+		if block, ok := msg.(*MsgBlock); ok {
+			for _, tx := range block.Transactions {
+				tx.cachedSeralizedNoWitness = nil
+			}
+		}
+
 		if !reflect.DeepEqual(msg, test.out) {
 			t.Errorf("ReadMessage #%d\n got: %v want: %v", i,
 				spew.Sdump(msg), spew.Sdump(test.out))

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -877,6 +877,10 @@ func (msg *MsgTx) Serialize(w io.Writer) error {
 // Serialize, however even if the source transaction has inputs with witness
 // data, the old serialization format will still be used.
 func (msg *MsgTx) SerializeNoWitness(w io.Writer) error {
+	if msg.cachedSeralizedNoWitness != nil {
+		w.Write(msg.cachedSeralizedNoWitness)
+	}
+
 	return msg.BtcEncode(w, 0, BaseEncoding)
 }
 

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -378,6 +378,13 @@ func (msg *MsgTx) TxHash() chainhash.Hash {
 	return chainhash.DoubleHashH(msg.cachedSeralizedNoWitness)
 }
 
+// WipeCache removes the cached serialized bytes of the transaction. This is
+// useful to be able to get the correct txid after mutating a transaction's
+// state.
+func (msg *MsgTx) WipeCache() {
+	msg.cachedSeralizedNoWitness = nil
+}
+
 // WitnessHash generates the hash of the transaction serialized according to
 // the new witness serialization defined in BIP0141 and BIP0144. The final
 // output is used within the Segregated Witness commitment of all the witnesses


### PR DESCRIPTION
… TxHash

In this commit, we add a new field to the `MsgTx` struct:
`cachedSeralizedNoWitness`. As we decode the main transaction, we use an
`io.TeeReader` to copy over the non-witness bytes into this new field.
As a result, we can fully cache all tx serialization when computing the
TxHash. This has been shown to show up on profiles during IBD. Caching
this value allows us to optimize TxHash calculation across the entire
daemon as a whole.