### PR TITLE
Make http timeout configurable

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -1111,6 +1111,9 @@ type ConnConfig struct {
 	// EnableBCInfoHacks is an option provided to enable compatibility hacks
 	// when connecting to blockchain.info RPC server
 	EnableBCInfoHacks bool
+
+	// HTTPTimeout configures the timeout of HTTP post behaviour
+	HTTPTimeout time.Time
 }
 
 // newHTTPClient returns a new http client that is configured according to the
@@ -1139,6 +1142,7 @@ func newHTTPClient(config *ConnConfig) (*http.Client, error) {
 	}
 
 	client := http.Client{
+		Timeout: config.HTTPTimeout,
 		Transport: &http.Transport{
 			Proxy:           proxyFunc,
 			TLSClientConfig: tlsConfig,


### PR DESCRIPTION
By default has an infinite timeout that isn't configurable. Caused us some headaches in production.