### PR TITLE
Put best state with parent's workSum

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -722,7 +722,7 @@ func (b *BlockChain) disconnectBlock(node *blockNode, block *btcutil.Block, view
 
 	err = b.db.Update(func(dbTx database.Tx) error {
 		// Update best block state.
-		err := dbPutBestState(dbTx, state, node.workSum)
+		err := dbPutBestState(dbTx, state, node.parent.workSum)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When disconnecting block, why put best state with `node.workSum` not parent's worksum`node.parent.workSum`