### PR TITLE
Fix HDCoinType for simnet

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -565,7 +565,7 @@ var SimNetParams = Params{
 
 	// BIP44 coin type used in the hierarchical deterministic path for
 	// address generation.
-	HDCoinType: 115, // ASCII for s
+	HDCoinType: 1,
 }
 
 var (


### PR DESCRIPTION
According to SLIP44[1] all test networks should use coin type 1. Coin type 115 is assigned to some altcoin.

1. https://github.com/satoshilabs/slips/blob/master/slip-0044.md