### PR TITLE
Improve error message about non-active segwit on simnet

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -639,7 +639,7 @@ func (mp *TxPool) FetchTransaction(txHash *chainhash.Hash) (*btcutil.Tx, error) 
 func (mp *TxPool) maybeAcceptTransaction(tx *btcutil.Tx, isNew, rateLimit, rejectDupOrphans bool) ([]*chainhash.Hash, *TxDesc, error) {
 	txHash := tx.Hash()
 
-	// If a transaction has iwtness data, and segwit isn't active yet, If
+	// If a transaction has witness data, and segwit isn't active yet, If
 	// segwit isn't active yet, then we won't accept it into the mempool as
 	// it can't be mined yet.
 	if tx.MsgTx().HasWitness() {
@@ -649,8 +649,14 @@ func (mp *TxPool) maybeAcceptTransaction(tx *btcutil.Tx, isNew, rateLimit, rejec
 		}
 
 		if !segwitActive {
+			simnetHint := ""
+			if mp.cfg.ChainParams.Net == wire.SimNet {
+				bestHeight := mp.cfg.BestHeight()
+				simnetHint = fmt.Sprintf(" (The threshold for segwit activation is 300 blocks on simnet, "+
+					"current best height is %d)", bestHeight)
+			}
 			str := fmt.Sprintf("transaction %v has witness data, "+
-				"but segwit isn't active yet", txHash)
+				"but segwit isn't active yet%s", txHash, simnetHint)
 			return nil, nil, txRuleError(wire.RejectNonstandard, str)
 		}
 	}


### PR DESCRIPTION
I started playing with btcd+lnd on simnet and was confronted with error message:

```
[ERR] FNDG: Unable to broadcast funding tx for ChannelPoint(<point>:0):
-22: TX rejected: transaction <tx> has witness data, but segwit isn't active yet
```

I wasn't aware of the activation period so I got quite puzzled.
Google helped. But I think the message could mention likely cause.

Newly it optionally prints something like:

```
(The threshold for segwit activation is 300 blocks on simnet, current best height is 113)
```