### PR TITLE
blockchain: rolling merkle root

### DIFF
--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -309,8 +309,7 @@ func calcMerkleRoot(txns []*wire.MsgTx) chainhash.Hash {
 	for _, tx := range txns {
 		utilTxns = append(utilTxns, btcutil.NewTx(tx))
 	}
-	merkles := blockchain.BuildMerkleTreeStore(utilTxns, false)
-	return *merkles[len(merkles)-1]
+	return blockchain.CalcMerkleRoot(utilTxns, false)
 }
 
 // solveBlock attempts to find a nonce which makes the passed block header hash

--- a/blockchain/merkle.go
+++ b/blockchain/merkle.go
@@ -295,8 +295,7 @@ func ValidateWitnessCommitment(blk *btcutil.Block) error {
 	// the extracted witnessCommitment is equal to:
 	// SHA256(witnessMerkleRoot || witnessNonce). Where witnessNonce is the
 	// coinbase transaction's only witness item.
-	witnessMerkleTree := BuildMerkleTreeStore(blk.Transactions(), true)
-	witnessMerkleRoot := witnessMerkleTree[len(witnessMerkleTree)-1]
+	witnessMerkleRoot := CalcMerkleRoot(blk.Transactions(), true)
 
 	var witnessPreimage [chainhash.HashSize * 2]byte
 	copy(witnessPreimage[:], witnessMerkleRoot[:])

--- a/blockchain/merkle.go
+++ b/blockchain/merkle.go
@@ -154,6 +154,55 @@ func BuildMerkleTreeStore(transactions []*btcutil.Tx, witness bool) []*chainhash
 	return merkles
 }
 
+// CalcMerkleRoot computes the merkle root over a set of hashed leaves. The
+// interior nodes are computed opportunistically as the leaves are added to the
+// abstract tree to reduce the total number of allocations. Throughout the
+// computation, this computation only requires storing O(log n) interior
+// nodes.
+//
+// This method differs from BuildMerkleTreeStore in that the interior nodes are
+// discarded instead of being returned along with the root. CalcMerkleRoot is
+// slightly slower than BuildMerkleTreeStore, but requires significantly less
+// memory and fewer allocations.
+//
+// A merkle tree is a tree in which every non-leaf node is the hash of its
+// children nodes. A diagram depicting how this works for bitcoin transactions
+// where h(x) is a double sha256 follows:
+//
+//	         root = h1234 = h(h12 + h34)
+//	        /                           \
+//	  h12 = h(h1 + h2)            h34 = h(h3 + h4)
+//	   /            \              /            \
+//	h1 = h(tx1)  h2 = h(tx2)    h3 = h(tx3)  h4 = h(tx4)
+//
+// The additional bool parameter indicates if we are generating the merkle tree
+// using witness transaction id's rather than regular transaction id's. This
+// also presents an additional case wherein the wtxid of the coinbase transaction
+// is the zeroHash.
+func CalcMerkleRoot(transactions []*btcutil.Tx, witness bool) chainhash.Hash {
+	// Iteratively push the leaves onto the rolling merkle tree.
+	merkle := NewRollingMerkleTree(len(transactions))
+	for i, tx := range transactions {
+		// If we're computing a witness merkle root, instead of the
+		// regular txid, we use the modified wtxid which includes a
+		// transaction's witness data within the digest. Additionally,
+		// the coinbase's wtxid is all zeroes.
+		switch {
+		case witness && i == 0:
+			var zeroHash chainhash.Hash
+			merkle.Push(&zeroHash)
+		case witness:
+			wSha := tx.MsgTx().WitnessHash()
+			merkle.Push(&wSha)
+		default:
+			merkle.Push(tx.Hash())
+		}
+
+	}
+
+	return merkle.Root()
+}
+
 // ExtractWitnessCommitment attempts to locate, and return the witness
 // commitment for a block. The witness commitment is of the form:
 // SHA256(witness root || witness nonce). The function additionally returns a

--- a/blockchain/merkle_test.go
+++ b/blockchain/merkle_test.go
@@ -15,12 +15,20 @@ import (
 // TestMerkle tests the BuildMerkleTreeStore API.
 func TestMerkle(t *testing.T) {
 	block := btcutil.NewBlock(&Block100000)
-	merkles := BuildMerkleTreeStore(block.Transactions(), false)
-	calculatedMerkleRoot := merkles[len(merkles)-1]
+	calcMerkleRoot := CalcMerkleRoot(block.Transactions(), false)
+	merkleStoreTree := BuildMerkleTreeStore(block.Transactions(), false)
+	merkleStoreRoot := merkleStoreTree[len(merkleStoreTree)-1]
+
+	if calcMerkleRoot != *merkleStoreRoot {
+		t.Fatalf("BuildMerkleTreeStore root does not match "+
+			"CalcMerkleRoot, store: %v calc: %v", merkleStoreRoot,
+			calcMerkleRoot)
+	}
+
 	wantMerkle := &Block100000.Header.MerkleRoot
-	if !wantMerkle.IsEqual(calculatedMerkleRoot) {
+	if !wantMerkle.IsEqual(&calcMerkleRoot) {
 		t.Errorf("BuildMerkleTreeStore: merkle root mismatch - "+
-			"got %v, want %v", calculatedMerkleRoot, wantMerkle)
+			"got %v, want %v", calcMerkleRoot, wantMerkle)
 	}
 }
 

--- a/blockchain/merkle_test.go
+++ b/blockchain/merkle_test.go
@@ -24,6 +24,36 @@ func TestMerkle(t *testing.T) {
 	}
 }
 
+// TestMerkleBlock46559 computes the merkle root of block 46559. The number of
+// transactions in this blocks forces the case where a left leaf must be hashed
+// with itself, since the block only has three transactions.
+func TestRollingMerkleBlock46559(t *testing.T) {
+	merkle := NewRollingMerkleTree(3)
+
+	coinbase, _ := chainhash.NewHashFromStr(
+		"70e208b60ef5156b5f48d64999115195412b3fec607065099effc17a44af8902",
+	)
+	tx1, _ := chainhash.NewHashFromStr(
+		"5a9e2d301cd7d08b1a920d262d4b0ea4e3fd0a4b4e28c8e104470f031d79f787",
+	)
+	tx2, _ := chainhash.NewHashFromStr(
+		"c945e8e02aaccb74f0a12fac98ffeb57d9e3f235d1819df28705690e1d01312f",
+	)
+
+	merkle.Push(coinbase)
+	merkle.Push(tx1)
+	merkle.Push(tx2)
+
+	root := merkle.Root()
+
+	expRoot, _ := chainhash.NewHashFromStr(
+		"c6f00b209da9234b18f8995aad9aaddd8bc5bcd3d5455d8c87cb942265ab5464",
+	)
+	if root != *expRoot {
+		t.Fatalf("root mismatch, want: %v, got %v", *expRoot, root)
+	}
+}
+
 func makeHashes(size int) []*chainhash.Hash {
 	var hashes = make([]*chainhash.Hash, size)
 	for i := range hashes {

--- a/blockchain/merkle_test.go
+++ b/blockchain/merkle_test.go
@@ -5,8 +5,10 @@
 package blockchain
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
 )
 
@@ -19,5 +21,53 @@ func TestMerkle(t *testing.T) {
 	if !wantMerkle.IsEqual(calculatedMerkleRoot) {
 		t.Errorf("BuildMerkleTreeStore: merkle root mismatch - "+
 			"got %v, want %v", calculatedMerkleRoot, wantMerkle)
+	}
+}
+
+func makeHashes(size int) []*chainhash.Hash {
+	var hashes = make([]*chainhash.Hash, size)
+	for i := range hashes {
+		hashes[i] = new(chainhash.Hash)
+	}
+	return hashes
+}
+
+// BenchmarkRollingMerkle benches the RollingMerkleTree while varying the number
+// of leaves pushed to the tree.
+func BenchmarkRollingMerkle(b *testing.B) {
+	sizes := []int{
+		1000,
+		2000,
+		4000,
+		8000,
+		16000,
+		32000,
+	}
+
+	hashes := make([][]*chainhash.Hash, len(sizes))
+	for i, size := range sizes {
+		hashes[i] = makeHashes(size)
+	}
+
+	for i, size := range sizes {
+		name := fmt.Sprintf("%d", size)
+		b.Run(name, func(b *testing.B) {
+			benchmarkRollingMerkleSlice(b, hashes[i])
+		})
+	}
+}
+
+var root chainhash.Hash
+
+func benchmarkRollingMerkleSlice(b *testing.B, hashes []*chainhash.Hash) {
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		merkle := NewRollingMerkleTree(len(hashes))
+		for _, hash := range hashes {
+			merkle.Push(hash)
+		}
+		root = merkle.Root()
 	}
 }

--- a/blockchain/rolling_merkle.go
+++ b/blockchain/rolling_merkle.go
@@ -1,0 +1,208 @@
+package blockchain
+
+import (
+	"math"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+// RollingMerkleTree computes the double SHA256 merkle root over a set of leaf
+// hashes. Interior nodes are opportunistically computed as new leaves are
+// added to the tree, consolidating any nodes that have both a left and right
+// child before permitting another leaf to be added. As a result, a
+// RollingMerkleTree only requires O(log n) additional storage to compute the
+// final root.
+type RollingMerkleTree struct {
+	// nodes contains all nodes in the tree. The nodes may correspond to
+	// interior nodes if their children have already been pruned.
+	nodes map[uint32]chainhash.Hash
+
+	// num is the number of leaf nodes ever pushed to the tree.
+	num uint32
+
+	// buf is a statically allocated array that will be used to concatenate
+	// left and right nodes and serve as the digest to interior hashes.
+	buf [2 * chainhash.HashSize]byte
+
+	// both is slice that points to all of buf.
+	both []byte
+
+	// left is a slice pointing to the left half of buf.
+	left []byte
+
+	// right is a slice pointing to the right half of buf.
+	right []byte
+}
+
+// MakeRollingMerkleTree creates a RollingMerkleTree that is preallocated for
+// size leaves. More than size leaves may be pushed onto the tree, though may
+// result in more wasteful allocations than is necessary.
+func MakeRollingMerkleTree(size int) RollingMerkleTree {
+	// Compute log2(size) in order to preallocate the amount of space
+	// required by the rolling hash algorithm.
+	logn := int(math.Log2(float64(size)) + 1)
+
+	t := RollingMerkleTree{
+		nodes: make(map[uint32]chainhash.Hash, logn),
+	}
+
+	// Construct long-lived slices to avoid reslicing the underlying arrays.
+	t.both = t.buf[:]
+	t.left = t.buf[:chainhash.HashSize]
+	t.right = t.buf[chainhash.HashSize:]
+
+	return t
+}
+
+// NewRollingMerkleTree initializes a RollingMerkleTree on the heap that is
+// preallocated for size leaves. More than size leaves may be pushed onto the
+// tree, though may result in more wasteful allocations than is necessary.
+func NewRollingMerkleTree(size int) *RollingMerkleTree {
+	merkle := MakeRollingMerkleTree(size)
+	return &merkle
+}
+
+// Push adds the next leaf to the RollingMerkleTree. When adding a left leaf,
+// the hash is copied and stored in the tree under its leaf index. When a right
+// node is added, it is immediately consolidated with the preceding left node
+// that was stored without actually adding it to the tree. If the resulting
+// interior node then has a sibling, the interior nodes are hashed again and
+// the resulting interior node is stored one level higher in the tree. This
+// process is applied iteratively until all complete subtrees are represented by
+// a single hash after a call to Push. Since there can be at most O(log n) such
+// subtrees, this bounds the maximal state required at any point during the
+// computation.
+func (t *RollingMerkleTree) Push(hash *chainhash.Hash) {
+	// Increment the number of elements contained in the tree. This is done
+	// before calling prune, since we expect this count to be accurate when
+	// calling prune in Push, as well as when calling Root.
+	t.num++
+
+	// Compute the index of this hash in the base of the tree. This index is
+	// zero indexed, so even indexes correspond to left nodes in the base of
+	// the tree, and odd indexes correspond to right nodes.
+	idx := t.num - 1
+	if idx%2 == 0 {
+		// If we are pushing a left leaf, there will be no rolling
+		// consolidation that can be performed. Hence we simply add the
+		// node to our nodes index.
+		t.nodes[idx] = *hash
+	} else {
+		// Otherwise this is a right leaf, and there should be at least
+		// one interior hash we can opportunistically compute. The hash
+		// of right leaves is passed down instead of being added to the
+		// tree since it can be discarded immediately after computing
+		// the resulting interior node.
+		t.prune(hash)
+	}
+}
+
+// Root returns the final merkle root of all elements added via Push.
+func (t *RollingMerkleTree) Root() chainhash.Hash {
+	switch len(t.nodes) {
+
+	// If the tree is empty, the root is the empty hash.
+	case 0:
+		return chainhash.Hash{}
+
+	// If there is only one element in the pruned tree, it is the root.
+	case 1:
+		return t.nodes[0]
+
+	// Otherwise, we must perform the final round of pruning where any lone
+	// left-children are hashed with themselves to compute its parent
+	// interior node. This leaves a single element in the pruned tree
+	// corresponding to the root.
+	default:
+		t.prune(nil)
+		return t.nodes[0]
+	}
+
+}
+
+// prune iteratively consolidates all complete subtrees into a single hash
+// stored in nodes. When leaf is non-nil, it is assumed that the provided hash
+// is a right leaf, and there exists at least one consolidation available, e.g.
+// the left leaf added to nodes directly preceding. When no leaf is given, it
+// is assumed that no more leaves will be added and that we must compute the
+// final root of the tree. When this occurs, there may be lone left-nodes,
+// which are consolidated by hashing the leaf with itself, as is required by
+// consensus.
+func (t *RollingMerkleTree) prune(leaf *chainhash.Hash) {
+	// The final round of pruning is signaled by passing nil.
+	final := leaf == nil
+
+	// Attempt to consolidate the interior hashes by combining adjacent
+	// nodes.
+	for i := t.num - 1; i > 0; i /= 2 {
+		if i%2 == 0 {
+			// The next element to processes is a left node. If we
+			// are not in final mode, there is nothing else we can
+			// do until more elements are pushed and the right
+			// subtree is complete or the final root is computed.
+			if !final {
+				return
+			}
+
+			// Otherwise we are computing the final root. If the
+			// left item exists, we'll hash it with itself to mimic
+			// the idiosyncrasies of the bitcoin merkle tree
+			// structure. If the node doesn't exist, the interior
+			// nodes have already been consolidated to a lower
+			// index, so we simply continue to try and find them.
+			if left, ok := t.nodes[i]; ok {
+				delete(t.nodes, i)
+				t.nodes[i/2] = t.hashMerkleBranches(&left, &left)
+			}
+			continue
+		}
+
+		// The next element to process is a right node. Locate the node
+		// that should be directly to the left. If we are in final mode
+		// and the node is not found, we'll continue iterating until
+		// reaching the next interior node. Otherwise, we return and
+		// wait for more items to be pushed on.
+		left, ok := t.nodes[i-1]
+		if !ok && final {
+			continue
+		} else if !ok && !final {
+			return
+		}
+
+		// The left node was found and will be immediately used to
+		// compute the next interior hash. Thus we remove the node from
+		// the tree.
+		delete(t.nodes, i-1)
+
+		// Now, retrieve the right node from the tree. If this is the
+		// first iteration and we are not in final mode, then the right
+		// leaf has been threaded through. Otherwise, we lookup and
+		// remove the interior node from the tree using the current
+		// index. The right node should always exist in the latter case,
+		// as it is the interior node computed in the prior iteration.
+		var right chainhash.Hash
+		if !final && i == t.num-1 {
+			right = *leaf
+		} else {
+			right = t.nodes[i]
+			delete(t.nodes, i)
+		}
+
+		// Finally, compute the resulting interior node by computing the
+		// hash of left||right. The result is stored as the parent node
+		// within the nodes index.
+		t.nodes[i/2] = t.hashMerkleBranches(&left, &right)
+	}
+}
+
+// hashMerkleBranches concatenates the left and write hashes and computes the
+// SHA256 hash.
+func (t *RollingMerkleTree) hashMerkleBranches(
+	left, right *chainhash.Hash) chainhash.Hash {
+
+	// Concatenate the left and right nodes.
+	copy(t.left, left[:])
+	copy(t.right, right[:])
+
+	return chainhash.DoubleHashH(t.both)
+}

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -527,12 +527,11 @@ func checkBlockSanity(block *btcutil.Block, powLimit *big.Int, timeSource Median
 	// checks.  Bitcoind builds the tree here and checks the merkle root
 	// after the following checks, but there is no reason not to check the
 	// merkle root matches here.
-	merkles := BuildMerkleTreeStore(block.Transactions(), false)
-	calculatedMerkleRoot := merkles[len(merkles)-1]
-	if !header.MerkleRoot.IsEqual(calculatedMerkleRoot) {
+	calcMerkleRoot := CalcMerkleRoot(block.Transactions(), false)
+	if !header.MerkleRoot.IsEqual(&calcMerkleRoot) {
 		str := fmt.Sprintf("block merkle root is invalid - block "+
 			"header indicates %v, but calculated value is %v",
-			header.MerkleRoot, calculatedMerkleRoot)
+			header.MerkleRoot, calcMerkleRoot)
 		return ruleError(ErrBadMerkleRoot, str)
 	}
 

--- a/integration/rpctest/blockgen.go
+++ b/integration/rpctest/blockgen.go
@@ -181,12 +181,11 @@ func CreateBlock(prevBlock *btcutil.Block, inclusionTxs []*btcutil.Tx,
 	if inclusionTxs != nil {
 		blockTxns = append(blockTxns, inclusionTxs...)
 	}
-	merkles := blockchain.BuildMerkleTreeStore(blockTxns, false)
 	var block wire.MsgBlock
 	block.Header = wire.BlockHeader{
 		Version:    blockVersion,
 		PrevBlock:  *prevHash,
-		MerkleRoot: *merkles[len(merkles)-1],
+		MerkleRoot: blockchain.CalcMerkleRoot(blockTxns, false),
 		Timestamp:  ts,
 		Bits:       net.PowLimitBits,
 	}

--- a/mining/mining.go
+++ b/mining/mining.go
@@ -811,9 +811,7 @@ mempoolLoop:
 		// Next, obtain the merkle root of a tree which consists of the
 		// wtxid of all transactions in the block. The coinbase
 		// transaction will have a special wtxid of all zeroes.
-		witnessMerkleTree := blockchain.BuildMerkleTreeStore(blockTxns,
-			true)
-		witnessMerkleRoot := witnessMerkleTree[len(witnessMerkleTree)-1]
+		witnessMerkleRoot := blockchain.CalcMerkleRoot(blockTxns, true)
 
 		// The preimage to the witness commitment is:
 		// witnessRoot || coinbaseWitness
@@ -856,12 +854,11 @@ mempoolLoop:
 	}
 
 	// Create a new block ready to be solved.
-	merkles := blockchain.BuildMerkleTreeStore(blockTxns, false)
 	var msgBlock wire.MsgBlock
 	msgBlock.Header = wire.BlockHeader{
 		Version:    nextBlockVersion,
 		PrevBlock:  best.Hash,
-		MerkleRoot: *merkles[len(merkles)-1],
+		MerkleRoot: blockchain.CalcMerkleRoot(blockTxns, false),
 		Timestamp:  ts,
 		Bits:       reqDifficulty,
 	}
@@ -943,8 +940,8 @@ func (g *BlkTmplGenerator) UpdateExtraNonce(msgBlock *wire.MsgBlock, blockHeight
 
 	// Recalculate the merkle root with the updated extra nonce.
 	block := btcutil.NewBlock(msgBlock)
-	merkles := blockchain.BuildMerkleTreeStore(block.Transactions(), false)
-	msgBlock.Header.MerkleRoot = *merkles[len(merkles)-1]
+	merkleRoot := blockchain.CalcMerkleRoot(block.Transactions(), false)
+	msgBlock.Header.MerkleRoot = merkleRoot
 	return nil
 }
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1631,8 +1631,8 @@ func (state *gbtWorkState) updateBlockTemplate(s *rpcServer, useCoinbaseValue bo
 
 			// Update the merkle root.
 			block := btcutil.NewBlock(template.Block)
-			merkles := blockchain.BuildMerkleTreeStore(block.Transactions(), false)
-			template.Block.Header.MerkleRoot = *merkles[len(merkles)-1]
+			merkleRoot := blockchain.CalcMerkleRoot(block.Transactions(), false)
+			template.Block.Header.MerkleRoot = merkleRoot
 		}
 
 		// Set locals for convenience.
@@ -4281,7 +4281,7 @@ func newRPCServer(config *rpcserverConfig) (*rpcServer, error) {
 		gbtWorkState:           newGbtWorkState(config.TimeSource),
 		helpCacher:             newHelpCacher(),
 		requestProcessShutdown: make(chan struct{}),
-		quit: make(chan int),
+		quit:                   make(chan int),
 	}
 	if cfg.RPCUser != "" && cfg.RPCPass != "" {
 		login := cfg.RPCUser + ":" + cfg.RPCPass


### PR DESCRIPTION
This PR adds a new `RollingMerkleTree` type for efficiently computing merkle roots. The leaves
of the tree are iteratively pushed onto the tree, and any complete substrees are evaluated and
stored so that subsequent pushes may consume them when their sibling tree is complete. As a 
result, this requires `O(log n)` additional memory be allocated. The current `BuildMerkleTreeStore`
allocates an array of up to 4 times the number of leaves, which is used to store internal nodes and the root. 


For 2000 leaves, the benchmarks show that this method is about 7% slower (~90 microseconds), but uses 99.04% less memory and 99.85% fewer allocations. These allocations reduce gc pressure, especially during IBD when the large slices of hashes currently used are almost immediately discarded.
```
BenchmarkMerkle/rolling-1000-8              2000            694382 ns/op             858 B/op          3 allocs/op
BenchmarkMerkle/rolling-2000-8              1000           1367763 ns/op             923 B/op          3 allocs/op
BenchmarkMerkle/rolling-4000-8               500           2900103 ns/op            1210 B/op          6 allocs/op
BenchmarkMerkle/rolling-8000-8               300           5799806 ns/op            2034 B/op         10 allocs/op
BenchmarkMerkle/rolling-16000-8              100          11572403 ns/op            1578 B/op          3 allocs/op
BenchmarkMerkle/rolling-32000-8               50          22949069 ns/op            1720 B/op          5 allocs/op
BenchmarkMerkle/old-1000-8                  2000            655435 ns/op           48416 B/op       1002 allocs/op
BenchmarkMerkle/old-2000-8                  1000           1277192 ns/op           96800 B/op       2002 allocs/op
BenchmarkMerkle/old-4000-8                   500           2533821 ns/op          193568 B/op       4002 allocs/op
BenchmarkMerkle/old-8000-8                   300           5029310 ns/op          387104 B/op       8002 allocs/op              
BenchmarkMerkle/old-16000-8                  200          10135631 ns/op          774176 B/op      16002 allocs/op                     
BenchmarkMerkle/old-32000-8                  100          20442194 ns/op         1548340 B/op      32002 allocs/op
```

alternative to #1377 