### PR TITLE
btcjson+rpc: match bitcoind's RPC error codes for rejected transactions

### DIFF
--- a/btcjson/jsonrpcerr.go
+++ b/btcjson/jsonrpcerr.go
@@ -76,6 +76,9 @@ const (
 	ErrRPCInvalidTxVout     RPCErrorCode = -5
 	ErrRPCRawTxString       RPCErrorCode = -32602
 	ErrRPCDecodeHexString   RPCErrorCode = -22
+	ErrRPCTxError           RPCErrorCode = -25
+	ErrRPCTxRejected        RPCErrorCode = -26
+	ErrRPCTxAlreadyInChain  RPCErrorCode = -27
 )
 
 // Errors that are specific to btcd.


### PR DESCRIPTION
`bitcoind`'s behavior can be referenced [here](https://github.com/bitcoin/bitcoin/blob/master/src/node/transaction.cpp#L34).