### PR TITLE
btcec: optimize square root using fieldVal

### DIFF
--- a/btcec/bench_test.go
+++ b/btcec/bench_test.go
@@ -4,7 +4,10 @@
 
 package btcec
 
-import "testing"
+import (
+	"encoding/hex"
+	"testing"
+)
 
 // BenchmarkAddJacobian benchmarks the secp256k1 curve addJacobian function with
 // Z values of 1 so that the associated optimizations are used.
@@ -120,4 +123,23 @@ func BenchmarkFieldNormalize(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		f.Normalize()
 	}
+}
+
+// BenchmarkParseCompressedPubKey benchmarks how long it takes to decompress and
+// validate a compressed public key from a byte array.
+func BenchmarkParseCompressedPubKey(b *testing.B) {
+	rawPk, _ := hex.DecodeString("0234f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6")
+
+	var (
+		pk  *PublicKey
+		err error
+	)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pk, err = ParsePubKey(rawPk, S256())
+	}
+	_ = pk
+	_ = err
 }

--- a/btcec/btcec.go
+++ b/btcec/btcec.go
@@ -36,9 +36,16 @@ var (
 // interface from crypto/elliptic.
 type KoblitzCurve struct {
 	*elliptic.CurveParams
-	q         *big.Int
+
+	// q is the value (P+1)/4 used to compute the square root of field
+	// elements.
+	q *big.Int
+
 	H         int      // cofactor of the curve.
 	halfOrder *big.Int // half the order N
+
+	// fieldB is the constant B of the curve as a fieldVal.
+	fieldB *fieldVal
 
 	// byteSize is simply the bit size / 8 and is provided for convenience
 	// since it is calculated repeatedly.
@@ -917,6 +924,7 @@ func initS256() {
 		big.NewInt(1)), big.NewInt(4))
 	secp256k1.H = 1
 	secp256k1.halfOrder = new(big.Int).Rsh(secp256k1.N, 1)
+	secp256k1.fieldB = new(fieldVal).SetByteSlice(secp256k1.B.Bytes())
 
 	// Provided for convenience since this gets computed repeatedly.
 	secp256k1.byteSize = secp256k1.BitSize / 8

--- a/btcec/btcec.go
+++ b/btcec/btcec.go
@@ -886,9 +886,19 @@ func (curve *KoblitzCurve) ScalarBaseMult(k []byte) (*big.Int, *big.Int) {
 	return curve.fieldJacobianToBigAffine(qx, qy, qz)
 }
 
-// QPlus1Div4 returns the Q+1/4 constant for the curve for use in calculating
-// square roots via exponention.
+// QPlus1Div4 returns the (P+1)/4 constant for the curve for use in calculating
+// square roots via exponentiation.
+//
+// DEPRECATED: The actual value returned is (P+1)/4, where as the original
+// method name implies that this value is (((P+1)/4)+1)/4. This method is kept
+// to maintain backwards compatibility of the API. Use Q() instead.
 func (curve *KoblitzCurve) QPlus1Div4() *big.Int {
+	return curve.q
+}
+
+// Q returns the (P+1)/4 constant for the curve for use in calculating square
+// roots via exponentiation.
+func (curve *KoblitzCurve) Q() *big.Int {
 	return curve.q
 }
 

--- a/btcec/pubkey.go
+++ b/btcec/pubkey.go
@@ -102,6 +102,17 @@ func ParsePubKey(pubKeyStr []byte, curve *KoblitzCurve) (key *PublicKey, err err
 		if format == pubkeyHybrid && ybit != isOdd(pubkey.Y) {
 			return nil, fmt.Errorf("ybit doesn't match oddness")
 		}
+
+		if pubkey.X.Cmp(pubkey.Curve.Params().P) >= 0 {
+			return nil, fmt.Errorf("pubkey X parameter is >= to P")
+		}
+		if pubkey.Y.Cmp(pubkey.Curve.Params().P) >= 0 {
+			return nil, fmt.Errorf("pubkey Y parameter is >= to P")
+		}
+		if !pubkey.Curve.IsOnCurve(pubkey.X, pubkey.Y) {
+			return nil, fmt.Errorf("pubkey isn't on secp256k1 curve")
+		}
+
 	case PubKeyBytesLenCompressed:
 		// format is 0x2 | solution, <X coordinate>
 		// solution determines which solution of the curve we use.
@@ -115,20 +126,12 @@ func ParsePubKey(pubKeyStr []byte, curve *KoblitzCurve) (key *PublicKey, err err
 		if err != nil {
 			return nil, err
 		}
+
 	default: // wrong!
 		return nil, fmt.Errorf("invalid pub key length %d",
 			len(pubKeyStr))
 	}
 
-	if pubkey.X.Cmp(pubkey.Curve.Params().P) >= 0 {
-		return nil, fmt.Errorf("pubkey X parameter is >= to P")
-	}
-	if pubkey.Y.Cmp(pubkey.Curve.Params().P) >= 0 {
-		return nil, fmt.Errorf("pubkey Y parameter is >= to P")
-	}
-	if !pubkey.Curve.IsOnCurve(pubkey.X, pubkey.Y) {
-		return nil, fmt.Errorf("pubkey isn't on secp256k1 curve")
-	}
 	return &pubkey, nil
 }
 

--- a/btcec/pubkey.go
+++ b/btcec/pubkey.go
@@ -22,41 +22,41 @@ func isOdd(a *big.Int) bool {
 	return a.Bit(0) == 1
 }
 
-// decompressPoint decompresses a point on the given curve given the X point and
+// decompressPoint decompresses a point on the secp256k1 curve given the X point and
 // the solution to use.
-func decompressPoint(curve *KoblitzCurve, x *big.Int, ybit bool) (*big.Int, error) {
-	// TODO: This will probably only work for secp256k1 due to
-	// optimizations.
+func decompressPoint(curve *KoblitzCurve, bigX *big.Int, ybit bool) (*big.Int, error) {
+	var x fieldVal
+	x.SetByteSlice(bigX.Bytes())
 
-	// Y = +-sqrt(x^3 + B)
-	x3 := new(big.Int).Mul(x, x)
-	x3.Mul(x3, x)
-	x3.Add(x3, curve.Params().B)
-	x3.Mod(x3, curve.Params().P)
+	// Compute x^3 + B mod p.
+	var x3 fieldVal
+	x3.SquareVal(&x).Mul(&x)
+	x3.Add(curve.fieldB).Normalize()
 
 	// Now calculate sqrt mod p of x^3 + B
 	// This code used to do a full sqrt based on tonelli/shanks,
 	// but this was replaced by the algorithms referenced in
 	// https://bitcointalk.org/index.php?topic=162805.msg1712294#msg1712294
-	y := new(big.Int).Exp(x3, curve.QPlus1Div4(), curve.Params().P)
-
-	if ybit != isOdd(y) {
-		y.Sub(curve.Params().P, y)
+	var y fieldVal
+	y.SqrtVal(&x3)
+	if ybit != y.IsOdd() {
+		y.Negate(1)
 	}
+	y.Normalize()
 
 	// Check that y is a square root of x^3 + B.
-	y2 := new(big.Int).Mul(y, y)
-	y2.Mod(y2, curve.Params().P)
-	if y2.Cmp(x3) != 0 {
+	var y2 fieldVal
+	y2.SquareVal(&y).Normalize()
+	if !y2.Equals(&x3) {
 		return nil, fmt.Errorf("invalid square root")
 	}
 
 	// Verify that y-coord has expected parity.
-	if ybit != isOdd(y) {
+	if ybit != y.IsOdd() {
 		return nil, fmt.Errorf("ybit doesn't match oddness")
 	}
 
-	return y, nil
+	return new(big.Int).SetBytes(y.Bytes()[:]), nil
 }
 
 const (


### PR DESCRIPTION
As of #1193, decompressPoint now
validates that the point is on the curve. The x and y coordinates are
also implicitly <= `P`, since the modular reduction is applied to both
before the method returns. The checks are moved so that they are still
applied when parsing an uncompressed pubkey, as the checks are not
redundant in that path.

We also optimize the decompressPoint subroutine, used in extracting
compressed pubkeys and performing pubkey recovery. We do so by replacing
the use of big.Int.Exp with with square-and-multiply exponentiation of
btcec's more optimized fieldVals, reducing the overall latency and
memory requirements of decompressPoint.

Instead of operating on bits of Q = (P+1)/4, the exponentiation applies
the square-and-multiply operations on full bytes of Q.  Compared to the
original speedup. Compared the bit-wise version, the improvement is
roughly 10%.

A new pair fieldVal methods called Sqrt and SqrtVal are added, which
applies the square-and-multiply exponentiation using precomputed
byte-slice of the value Q.

Comparison against big.Int sqrt and SAM sqrt over bytes of Q:

```
benchmark                            old ns/op     new ns/op     delta
BenchmarkParseCompressedPubKey-8     35545         23119         -34.96%

benchmark                            old allocs     new allocs     delta
BenchmarkParseCompressedPubKey-8     35             6            -82.86%

benchmark                            old bytes     new bytes     delta
BenchmarkParseCompressedPubKey-8     2777          256           -90.78%
```

Finally the `*KoblitzCurve.QPlus1Div4()` method is deprecated, and superseded
by `*KoblitzCurve.Q()`, to convey that the returned value is `Q = (P+1)/4`, and
not `(((P+1)/4)+1)/4) `.