### PR TITLE
Change more convenice variable in readElement function

### DIFF
--- a/wire/common.go
+++ b/wire/common.go
@@ -238,7 +238,7 @@ func readElement(r io.Reader, element interface{}) error {
 
 	// Unix timestamp encoded as a uint32.
 	case *uint32Time:
-		rv, err := binarySerializer.Uint32(r, binary.LittleEndian)
+		rv, err := binarySerializer.Uint32(r, littleEndian)
 		if err != nil {
 			return err
 		}
@@ -247,7 +247,7 @@ func readElement(r io.Reader, element interface{}) error {
 
 	// Unix timestamp encoded as an int64.
 	case *int64Time:
-		rv, err := binarySerializer.Uint64(r, binary.LittleEndian)
+		rv, err := binarySerializer.Uint64(r, littleEndian)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We are using `littleEndian` variable for `binary.LittleEndian` is quite long.
And I have changed this part for uniformity in the use of variables.