### PR TITLE
rpc: fix rescan bug if client disconnects

### DIFF
--- a/rpcwebsocket.go
+++ b/rpcwebsocket.go
@@ -2602,6 +2602,13 @@ func handleRescan(wsc *wsClient, icmd interface{}) (interface{}, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		// If the last block is nil, then this means that the client
+		// disconnected mid-rescan. As a result, we don't need to send
+		// anything back to them.
+		if lastBlock == nil {
+			return nil, nil
+		}
 	} else {
 		rpcsLog.Infof("Skipping rescan as client has no addrs/utxos")
 


### PR DESCRIPTION
In this commit, we fix a bug in the rescan logic after a recent
refactoring that would cause the scanning node to potentially panic. If
the client disconnected, before the rescan was finished, then we would
return a nil `lastBlock` and `lastBlockHash`. We would then attempt to
send the rescan finished notification, causing a panic.

We remedy this by simply detecting this case (client disconnect), and
existing once again as the prior code would, pre-refactoring.