### PR TITLE
peer: include verack as part of version handshake

### DIFF
--- a/wire/message.go
+++ b/wire/message.go
@@ -321,9 +321,13 @@ func WriteMessageWithEncodingN(w io.Writer, msg Message, pver uint32,
 		return totalBytes, err
 	}
 
-	// Write payload.
-	n, err = w.Write(payload)
-	totalBytes += n
+	// Only write the payload if there is one, e.g., verack messages don't
+	// have one.
+	if len(payload) > 0 {
+		n, err = w.Write(payload)
+		totalBytes += n
+	}
+
 	return totalBytes, err
 }
 


### PR DESCRIPTION
It was possible for connections to bitcoind nodes to be closed from their side if the OnVersion callback queued a message to send. This is because bitcoind expects a verack message before attempting to process any other messages. To address this, we ensure the verack is sent as part of the handshake process, such that any queued messages happen after the fact.