### PR TITLE
blockchain: remove unknown block version warning

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -174,11 +174,7 @@ type BlockChain struct {
 	//
 	// unknownRulesWarned refers to warnings due to unknown rules being
 	// activated.
-	//
-	// unknownVersionsWarned refers to warnings due to unknown versions
-	// being mined.
-	unknownRulesWarned    bool
-	unknownVersionsWarned bool
+	unknownRulesWarned bool
 
 	// The notifications field stores a slice of callbacks to be executed on
 	// certain blockchain events.
@@ -574,18 +570,11 @@ func (b *BlockChain) connectBlock(node *blockNode, block *btcutil.Block,
 			"spent transaction out information")
 	}
 
-	// No warnings about unknown rules or versions until the chain is
-	// current.
+	// No warnings about unknown rules until the chain is current.
 	if b.isCurrent() {
 		// Warn if any unknown new rules are either about to activate or
 		// have already been activated.
 		if err := b.warnUnknownRuleActivations(node); err != nil {
-			return err
-		}
-
-		// Warn if a high enough percentage of the last blocks have
-		// unexpected versions.
-		if err := b.warnUnknownVersions(node); err != nil {
 			return err
 		}
 	}

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -310,7 +310,7 @@ func (b *BlockChain) deploymentState(prevNode *blockNode, deploymentID uint32) (
 
 // initThresholdCaches initializes the threshold state caches for each warning
 // bit and defined deployment and provides warnings if the chain is current per
-// the warnUnknownVersions and warnUnknownRuleActivations functions.
+// the warnUnknownRuleActivations function.
 func (b *BlockChain) initThresholdCaches() error {
 	// Initialize the warning and deployment caches by calculating the
 	// threshold state for each of them.  This will ensure the caches are
@@ -335,15 +335,9 @@ func (b *BlockChain) initThresholdCaches() error {
 		}
 	}
 
-	// No warnings about unknown rules or versions until the chain is
-	// current.
+	// No warnings about unknown rules until the chain is current.
 	if b.isCurrent() {
-		// Warn if a high enough percentage of the last blocks have
-		// unexpected versions.
 		bestNode := b.bestChain.Tip()
-		if err := b.warnUnknownVersions(bestNode); err != nil {
-			return err
-		}
 
 		// Warn if any unknown new rules are either about to activate or
 		// have already been activated.

--- a/blockchain/versionbits.go
+++ b/blockchain/versionbits.go
@@ -26,15 +26,6 @@ const (
 	// vbNumBits is the total number of bits available for use with the
 	// version bits scheme.
 	vbNumBits = 29
-
-	// unknownVerNumToCheck is the number of previous blocks to consider
-	// when checking for a threshold of unknown block versions for the
-	// purposes of warning the user.
-	unknownVerNumToCheck = 100
-
-	// unknownVerWarnNum is the threshold of previous blocks that have an
-	// unknown version to use for the purposes of warning the user.
-	unknownVerWarnNum = unknownVerNumToCheck / 2
 )
 
 // bitConditionChecker provides a thresholdConditionChecker which can be used to
@@ -260,41 +251,6 @@ func (b *BlockChain) warnUnknownRuleActivations(node *blockNode) error {
 			log.Warnf("Unknown new rules are about to activate in "+
 				"%d blocks (bit %d)", activationHeight, bit)
 		}
-	}
-
-	return nil
-}
-
-// warnUnknownVersions logs a warning if a high enough percentage of the last
-// blocks have unexpected versions.
-//
-// This function MUST be called with the chain state lock held (for writes)
-func (b *BlockChain) warnUnknownVersions(node *blockNode) error {
-	// Nothing to do if already warned.
-	if b.unknownVersionsWarned {
-		return nil
-	}
-
-	// Warn if enough previous blocks have unexpected versions.
-	numUpgraded := uint32(0)
-	for i := uint32(0); i < unknownVerNumToCheck && node != nil; i++ {
-		expectedVersion, err := b.calcNextBlockVersion(node.parent)
-		if err != nil {
-			return err
-		}
-		if expectedVersion > vbLegacyBlockVersion &&
-			(node.version & ^expectedVersion) != 0 {
-
-			numUpgraded++
-		}
-
-		node = node.parent
-	}
-	if numUpgraded > unknownVerWarnNum {
-		log.Warn("Unknown block versions are being mined, so new " +
-			"rules might be in effect.  Are you running the " +
-			"latest version of the software?")
-		b.unknownVersionsWarned = true
 	}
 
 	return nil


### PR DESCRIPTION
Received this warning while syncing, and this warning is being called when >50 of the last 100 blocks have unexpected version numbers. Due to AsicBoost this is triggering many false positives.
The warning was removed from Core for 0.18.0 in https://github.com/bitcoin/bitcoin/pull/15471/.