### PR TITLE
server: miscellaneous connection management fixes

### DIFF
--- a/server.go
+++ b/server.go
@@ -1651,6 +1651,12 @@ func (s *server) handleAddPeerMsg(state *peerState, sp *serverPeer) bool {
 		}
 	}
 
+	// Update the address' last seen time if the peer has acknowledged
+	// our version and has sent us its version as well.
+	if sp.VerAckReceived() && sp.VersionKnown() && sp.NA() != nil {
+		s.addrManager.Connected(sp.NA())
+	}
+
 	return true
 }
 
@@ -1679,12 +1685,6 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 
 	if sp.connReq != nil {
 		s.connManager.Disconnect(sp.connReq.ID())
-	}
-
-	// Update the address' last seen time if the peer has acknowledged
-	// our version and has sent us its version as well.
-	if sp.VerAckReceived() && sp.VersionKnown() && sp.NA() != nil {
-		s.addrManager.Connected(sp.NA())
 	}
 
 	// If we get here it means that either we didn't know about the peer

--- a/server.go
+++ b/server.go
@@ -1680,6 +1680,7 @@ func (s *server) handleDonePeerMsg(state *peerState, sp *serverPeer) {
 			s.connManager.Disconnect(sp.connReq.ID())
 		} else {
 			s.connManager.Remove(sp.connReq.ID())
+			go s.connManager.NewConnReq()
 		}
 	}
 
@@ -2031,6 +2032,7 @@ func (s *server) outboundPeerConnected(c *connmgr.ConnReq, conn net.Conn) {
 			s.connManager.Disconnect(c.ID())
 		} else {
 			s.connManager.Remove(c.ID())
+			go s.connManager.NewConnReq()
 		}
 		return
 	}

--- a/server.go
+++ b/server.go
@@ -2032,7 +2032,6 @@ func (s *server) outboundPeerConnected(c *connmgr.ConnReq, conn net.Conn) {
 	sp.isWhitelisted = isWhitelisted(conn.RemoteAddr())
 	sp.AssociateConnection(conn)
 	go s.peerDoneHandler(sp)
-	s.addrManager.Attempt(sp.NA())
 }
 
 // peerDoneHandler handles peer disconnects by notifiying the server that it's
@@ -2801,6 +2800,9 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 					activeNetParams.DefaultPort {
 					continue
 				}
+
+				// Mark an attempt for the valid address.
+				s.addrManager.Attempt(addr.NetAddress())
 
 				addrString := addrmgr.NetAddressKey(addr.NetAddress())
 				return addrStringToNetAddr(addrString)


### PR DESCRIPTION
In this PR, we include a series of connection management fixes that were discovered in https://github.com/lightninglabs/neutrino/pull/178. Since most of the code there was inspired by `btcd`, the fixes also happen to apply here as well. Each fix has been included in its own commit along with a descriptive message of the issue it's addressing. Mainly, this PR attempts to ensure we can more aggressively connect to peers through the underlying connection manager.