### PR TITLE
btcec/pubkey: normalize sqrt(x^3) before checking parity

### DIFF
--- a/btcec/pubkey.go
+++ b/btcec/pubkey.go
@@ -38,11 +38,10 @@ func decompressPoint(curve *KoblitzCurve, bigX *big.Int, ybit bool) (*big.Int, e
 	// but this was replaced by the algorithms referenced in
 	// https://bitcointalk.org/index.php?topic=162805.msg1712294#msg1712294
 	var y fieldVal
-	y.SqrtVal(&x3)
+	y.SqrtVal(&x3).Normalize()
 	if ybit != y.IsOdd() {
-		y.Negate(1)
+		y.Negate(1).Normalize()
 	}
-	y.Normalize()
 
 	// Check that y is a square root of x^3 + B.
 	var y2 fieldVal


### PR DESCRIPTION
This commit fixes an issue introduced in the recent #1429, where
the output of SqrtVal is not normalized before using IsOdd() to compare
with the expected parity of the y-coordinate. The IsOdd() is only
guaranteed to work if the value has been denormalized, so a denormalized
sqrt >= p would report the opposite parity. We fix this by normalizing
both after compute sqrt(x^3+b) and when negating the root as directed by
the ybit.