### PR TITLE
wire: decrease MaxGetCFiltersReqRange from 1000 to 100

### DIFF
--- a/wire/msgcfheaders.go
+++ b/wire/msgcfheaders.go
@@ -17,7 +17,7 @@ const (
 	MaxCFHeaderPayload = chainhash.HashSize
 
 	// MaxCFHeadersPerMsg is the maximum number of committed filter headers
-	// that can be in a single bitcoin cfheaders message.
+	// that can be in a single bitcoin cfheaders message according to BIP157.
 	MaxCFHeadersPerMsg = 2000
 )
 

--- a/wire/msggetcfilters.go
+++ b/wire/msggetcfilters.go
@@ -10,9 +10,9 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
 
-// MaxGetCFiltersReqRange the maximum number of filters that may be requested in
-// a getcfheaders message.
-const MaxGetCFiltersReqRange = 1000
+// MaxGetCFiltersReqRange is the maximum number of filters that may be requested in
+// a getcfilters message according to BIP157.
+const MaxGetCFiltersReqRange = 100
 
 // MsgGetCFilters implements the Message interface and represents a bitcoin
 // getcfilters message. It is used to request committed filters for a range of


### PR DESCRIPTION
BIP157 specificies a maximum of 100

Reverts ceb1caeb249cf3c7a8c1be2987af64bfffdd674d

This should prevent getting disconnected by Bitcoin Core nodes: https://github.com/bitcoin/bitcoin/pull/16442#issuecomment-545364727