### PR TITLE
btcjson+rpcclient: add compatibility for bitcoind v0.19.0

### DIFF
--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -638,6 +638,7 @@ func NewSearchRawTransactionsCmd(address string, verbose, skip, count *int, vinE
 type SendRawTransactionCmd struct {
 	HexTx         string
 	AllowHighFees *bool `jsonrpcdefault:"false"`
+	MaxFeeRate    *int32
 }
 
 // NewSendRawTransactionCmd returns a new instance which can be used to issue a
@@ -649,6 +650,17 @@ func NewSendRawTransactionCmd(hexTx string, allowHighFees *bool) *SendRawTransac
 	return &SendRawTransactionCmd{
 		HexTx:         hexTx,
 		AllowHighFees: allowHighFees,
+	}
+}
+
+// NewSendRawTransactionCmd returns a new instance which can be used to issue a
+// sendrawtransaction JSON-RPC command to a bitcoind node.
+//
+// A 0 maxFeeRate indicates that a maximum fee rate won't be enforced.
+func NewBitcoindSendRawTransactionCmd(hexTx string, maxFeeRate int32) *SendRawTransactionCmd {
+	return &SendRawTransactionCmd{
+		HexTx:      hexTx,
+		MaxFeeRate: &maxFeeRate,
 	}
 }
 

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -97,21 +97,45 @@ type Bip9SoftForkDescription struct {
 	Since     int32  `json:"since"`
 }
 
+// SoftForks describes the current softforks enabled by the backend. Softforks
+// activated through BIP9 are grouped together separate from any other softforks
+// with different activation types.
+type SoftForks struct {
+	SoftForks     []*SoftForkDescription              `json:"softforks"`
+	Bip9SoftForks map[string]*Bip9SoftForkDescription `json:"bip9_softforks"`
+}
+
+// UnifiedSoftForks describes a softforks in a general manner, irrespective of
+// its activation type. This was a format introduced by bitcoind v0.19.0
+type UnifiedSoftFork struct {
+	Type                    string                   `json:"type"`
+	BIP9SoftForkDescription *Bip9SoftForkDescription `json:"bip9"`
+	Height                  int32                    `json:"height"`
+	Active                  bool                     `json:"active"`
+}
+
+// UnifiedSoftForks describes the current softforks enabled the by the backend
+// in a unified manner, i.e, softforks with different activation types are
+// grouped together. This was a format introduced by bitcoind v0.19.0
+type UnifiedSoftForks struct {
+	SoftForks map[string]*UnifiedSoftFork `json:"softforks"`
+}
+
 // GetBlockChainInfoResult models the data returned from the getblockchaininfo
 // command.
 type GetBlockChainInfoResult struct {
-	Chain                string                              `json:"chain"`
-	Blocks               int32                               `json:"blocks"`
-	Headers              int32                               `json:"headers"`
-	BestBlockHash        string                              `json:"bestblockhash"`
-	Difficulty           float64                             `json:"difficulty"`
-	MedianTime           int64                               `json:"mediantime"`
-	VerificationProgress float64                             `json:"verificationprogress,omitempty"`
-	Pruned               bool                                `json:"pruned"`
-	PruneHeight          int32                               `json:"pruneheight,omitempty"`
-	ChainWork            string                              `json:"chainwork,omitempty"`
-	SoftForks            []*SoftForkDescription              `json:"softforks"`
-	Bip9SoftForks        map[string]*Bip9SoftForkDescription `json:"bip9_softforks"`
+	Chain                string  `json:"chain"`
+	Blocks               int32   `json:"blocks"`
+	Headers              int32   `json:"headers"`
+	BestBlockHash        string  `json:"bestblockhash"`
+	Difficulty           float64 `json:"difficulty"`
+	MedianTime           int64   `json:"mediantime"`
+	VerificationProgress float64 `json:"verificationprogress,omitempty"`
+	Pruned               bool    `json:"pruned"`
+	PruneHeight          int32   `json:"pruneheight,omitempty"`
+	ChainWork            string  `json:"chainwork,omitempty"`
+	*SoftForks
+	*UnifiedSoftForks
 }
 
 // GetBlockTemplateResultTx models the transactions field of the

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -90,11 +90,20 @@ type SoftForkDescription struct {
 // Bip9SoftForkDescription describes the current state of a defined BIP0009
 // version bits soft-fork.
 type Bip9SoftForkDescription struct {
-	Status    string `json:"status"`
-	Bit       uint8  `json:"bit"`
-	StartTime int64  `json:"startTime"`
-	Timeout   int64  `json:"timeout"`
-	Since     int32  `json:"since"`
+	Status     string `json:"status"`
+	Bit        uint8  `json:"bit"`
+	StartTime1 int64  `json:"startTime"`
+	StartTime2 int64  `json:"start_time"`
+	Timeout    int64  `json:"timeout"`
+	Since      int32  `json:"since"`
+}
+
+// StartTime returns the starting time of the softfork as a Unix epoch.
+func (d *Bip9SoftForkDescription) StartTime() int64 {
+	if d.StartTime1 != 0 {
+		return d.StartTime1
+	}
+	return d.StartTime2
 }
 
 // SoftForks describes the current softforks enabled by the backend. Softforks

--- a/integration/bip0009_test.go
+++ b/integration/bip0009_test.go
@@ -102,7 +102,7 @@ func assertSoftForkStatus(r *rpctest.Harness, t *testing.T, forkKey string, stat
 	}
 
 	// Ensure the key is available.
-	desc, ok := info.Bip9SoftForks[forkKey]
+	desc, ok := info.SoftForks.Bip9SoftForks[forkKey]
 	if !ok {
 		_, _, line, _ := runtime.Caller(1)
 		t.Fatalf("assertion failed at line %d: softfork status for %q "+

--- a/rpcclient/chain_test.go
+++ b/rpcclient/chain_test.go
@@ -1,0 +1,92 @@
+package rpcclient
+
+import "testing"
+
+// TestUnmarshalGetBlockChainInfoResult ensures that the SoftForks and
+// UnifiedSoftForks fields of GetBlockChainInfoResult are properly unmarshaled
+// when using the expected backend version.
+func TestUnmarshalGetBlockChainInfoResultSoftForks(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		version    BackendVersion
+		res        []byte
+		compatible bool
+	}{
+		{
+			name:       "bitcoind < 0.19.0 with separate softforks",
+			version:    BitcoindPre19,
+			res:        []byte(`{"softforks": [{"version": 2}]}`),
+			compatible: true,
+		},
+		{
+			name:       "bitcoind >= 0.19.0 with separate softforks",
+			version:    BitcoindPost19,
+			res:        []byte(`{"softforks": [{"version": 2}]}`),
+			compatible: false,
+		},
+		{
+			name:       "bitcoind < 0.19.0 with unified softforks",
+			version:    BitcoindPre19,
+			res:        []byte(`{"softforks": {"segwit": {"type": "bip9"}}}`),
+			compatible: false,
+		},
+		{
+			name:       "bitcoind >= 0.19.0 with unified softforks",
+			version:    BitcoindPost19,
+			res:        []byte(`{"softforks": {"segwit": {"type": "bip9"}}}`),
+			compatible: true,
+		},
+	}
+
+	for _, test := range tests {
+		success := t.Run(test.name, func(t *testing.T) {
+			// We'll start by unmarshaling the JSON into a struct.
+			// The SoftForks and UnifiedSoftForks field should not
+			// be set yet, as they are unmarshaled within a
+			// different function.
+			info, err := unmarshalPartialGetBlockChainInfoResult(test.res)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if info.SoftForks != nil {
+				t.Fatal("expected SoftForks to be empty")
+			}
+			if info.UnifiedSoftForks != nil {
+				t.Fatal("expected UnifiedSoftForks to be empty")
+			}
+
+			// Proceed to unmarshal the softforks of the response
+			// with the expected version. If the version is
+			// incompatible with the response, then this should
+			// fail.
+			err = unmarshalGetBlockChainInfoResultSoftForks(
+				info, test.version, test.res,
+			)
+			if test.compatible && err != nil {
+				t.Fatalf("unable to unmarshal softforks: %v", err)
+			}
+			if !test.compatible && err == nil {
+				t.Fatal("expected to not unmarshal softforks")
+			}
+			if !test.compatible {
+				return
+			}
+
+			// If the version is compatible with the response, we
+			// should expect to see the proper softforks field set.
+			if test.version == BitcoindPost19 &&
+				info.SoftForks != nil {
+				t.Fatal("expected SoftForks to be empty")
+			}
+			if test.version == BitcoindPre19 &&
+				info.UnifiedSoftForks != nil {
+				t.Fatal("expected UnifiedSoftForks to be empty")
+			}
+		})
+		if !success {
+			return
+		}
+	}
+}

--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -103,6 +104,22 @@ type jsonRequest struct {
 	responseChan   chan *response
 }
 
+// BackendVersion represents the version of the backend the client is currently
+// connected to.
+type BackendVersion uint8
+
+const (
+	// BitcoindPre19 represents a bitcoind version before 0.19.0.
+	BitcoindPre19 BackendVersion = iota
+
+	// BitcoindPost19 represents a bitcoind version equal to or greater than
+	// 0.19.0.
+	BitcoindPost19
+
+	// Btcd represents a catch-all btcd version.
+	Btcd
+)
+
 // Client represents a Bitcoin RPC client which allows easy access to the
 // various RPC methods available on a Bitcoin RPC server.  Each of the wrapper
 // functions handle the details of converting the passed and return types to and
@@ -128,6 +145,11 @@ type Client struct {
 	// httpClient is the underlying HTTP client to use when running in HTTP
 	// POST mode.
 	httpClient *http.Client
+
+	// backendVersion is the version of the backend the client is currently
+	// connected to. This should be retrieved through GetVersion.
+	backendVersionMu sync.Mutex
+	backendVersion   *BackendVersion
 
 	// mtx is a mutex to protect access to connection related fields.
 	mtx sync.Mutex
@@ -658,6 +680,12 @@ out:
 
 			log.Infof("Reestablished connection to RPC server %s",
 				c.config.Host)
+
+			// Reset the version in case the backend was
+			// disconnected due to an upgrade.
+			c.backendVersionMu.Lock()
+			c.backendVersion = nil
+			c.backendVersionMu.Unlock()
 
 			// Reset the connection state and signal the reconnect
 			// has happened.
@@ -1331,4 +1359,85 @@ func (c *Client) Connect(tries int) error {
 
 	// All connection attempts failed, so return the last error.
 	return err
+}
+
+const (
+	// bitcoind19Str is the string representation of bitcoind v0.19.0.
+	bitcoind19Str = "0.19.0"
+
+	// bitcoindVersionPrefix specifies the prefix included in every bitcoind
+	// version exposed through GetNetworkInfo.
+	bitcoindVersionPrefix = "/Satoshi:"
+
+	// bitcoindVersionSuffix specifies the suffix included in every bitcoind
+	// version exposed through GetNetworkInfo.
+	bitcoindVersionSuffix = "/"
+)
+
+// parseBitcoindVersion parses the bitcoind version from its string
+// representation.
+func parseBitcoindVersion(version string) BackendVersion {
+	// Trim the version of its prefix and suffix to determine the
+	// appropriate version number.
+	version = strings.TrimPrefix(
+		strings.TrimSuffix(version, bitcoindVersionSuffix),
+		bitcoindVersionPrefix,
+	)
+	switch {
+	case version < bitcoind19Str:
+		return BitcoindPre19
+	default:
+		return BitcoindPost19
+	}
+}
+
+// BackendVersion retrieves the version of the backend the client is currently
+// connected to.
+func (c *Client) BackendVersion() (BackendVersion, error) {
+	c.backendVersionMu.Lock()
+	defer c.backendVersionMu.Unlock()
+
+	if c.backendVersion != nil {
+		return *c.backendVersion, nil
+	}
+
+	// We'll start by calling GetInfo. This method doesn't exist for
+	// bitcoind nodes as of v0.16.0, so we'll assume the client is connected
+	// to a btcd backend if it does exist.
+	info, err := c.GetInfo()
+
+	switch err := err.(type) {
+	// Parse the btcd version and cache it.
+	case nil:
+		log.Debugf("Detected btcd version: %v", info.Version)
+		version := Btcd
+		c.backendVersion = &version
+		return *c.backendVersion, nil
+
+	// Inspect the RPC error to ensure the method was not found, otherwise
+	// we actually ran into an error.
+	case *btcjson.RPCError:
+		if err.Code != btcjson.ErrRPCMethodNotFound.Code {
+			return 0, fmt.Errorf("unable to detect btcd version: "+
+				"%v", err)
+		}
+
+	default:
+		return 0, fmt.Errorf("unable to detect btcd version: %v", err)
+	}
+
+	// Since the GetInfo method was not found, we assume the client is
+	// connected to a bitcoind backend, which exposes its version through
+	// GetNetworkInfo.
+	networkInfo, err := c.GetNetworkInfo()
+	if err != nil {
+		return 0, fmt.Errorf("unable to detect bitcoind version: %v", err)
+	}
+
+	// Parse the bitcoind version and cache it.
+	log.Debugf("Detected bitcoind version: %v", networkInfo.SubVersion)
+	version := parseBitcoindVersion(networkInfo.SubVersion)
+	c.backendVersion = &version
+
+	return *c.backendVersion, nil
 }

--- a/rpcclient/net.go
+++ b/rpcclient/net.go
@@ -244,6 +244,43 @@ func (c *Client) Ping() error {
 	return c.PingAsync().Receive()
 }
 
+// FutureGetNetworkInfoResult is a future promise to deliver the result of a
+// GetNetworkInfoAsync RPC invocation (or an applicable error).
+type FutureGetNetworkInfoResult chan *response
+
+// Receive waits for the response promised by the future and returns data about
+// the current network.
+func (r FutureGetNetworkInfoResult) Receive() (*btcjson.GetNetworkInfoResult, error) {
+	res, err := receiveFuture(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal result as an array of getpeerinfo result objects.
+	var networkInfo btcjson.GetNetworkInfoResult
+	err = json.Unmarshal(res, &networkInfo)
+	if err != nil {
+		return nil, err
+	}
+
+	return &networkInfo, nil
+}
+
+// GetNetworkInfoAsync returns an instance of a type that can be used to get the
+// result of the RPC at some future time by invoking the Receive function on the
+// returned instance.
+//
+// See GetNetworkInfo for the blocking version and more details.
+func (c *Client) GetNetworkInfoAsync() FutureGetNetworkInfoResult {
+	cmd := btcjson.NewGetNetworkInfoCmd()
+	return c.sendCmd(cmd)
+}
+
+// GetNetworkInfo returns data about the current network.
+func (c *Client) GetNetworkInfo() (*btcjson.GetNetworkInfoResult, error) {
+	return c.GetNetworkInfoAsync().Receive()
+}
+
 // FutureGetPeerInfoResult is a future promise to deliver the result of a
 // GetPeerInfoAsync RPC invocation (or an applicable error).
 type FutureGetPeerInfoResult chan *response

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1198,14 +1198,16 @@ func handleGetBlockChainInfo(s *rpcServer, cmd interface{}, closeChan <-chan str
 		Difficulty:    getDifficultyRatio(chainSnapshot.Bits, params),
 		MedianTime:    chainSnapshot.MedianTime.Unix(),
 		Pruned:        false,
-		Bip9SoftForks: make(map[string]*btcjson.Bip9SoftForkDescription),
+		SoftForks: &btcjson.SoftForks{
+			Bip9SoftForks: make(map[string]*btcjson.Bip9SoftForkDescription),
+		},
 	}
 
 	// Next, populate the response with information describing the current
 	// status of soft-forks deployed via the super-majority block
 	// signalling mechanism.
 	height := chainSnapshot.Height
-	chainInfo.SoftForks = []*btcjson.SoftForkDescription{
+	chainInfo.SoftForks.SoftForks = []*btcjson.SoftForkDescription{
 		{
 			ID:      "bip34",
 			Version: 2,
@@ -1281,7 +1283,7 @@ func handleGetBlockChainInfo(s *rpcServer, cmd interface{}, closeChan <-chan str
 
 		// Finally, populate the soft-fork description with all the
 		// information gathered above.
-		chainInfo.Bip9SoftForks[forkName] = &btcjson.Bip9SoftForkDescription{
+		chainInfo.SoftForks.Bip9SoftForks[forkName] = &btcjson.Bip9SoftForkDescription{
 			Status:    strings.ToLower(statusString),
 			Bit:       deploymentDetails.BitNumber,
 			StartTime: int64(deploymentDetails.StartTime),

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1284,10 +1284,10 @@ func handleGetBlockChainInfo(s *rpcServer, cmd interface{}, closeChan <-chan str
 		// Finally, populate the soft-fork description with all the
 		// information gathered above.
 		chainInfo.SoftForks.Bip9SoftForks[forkName] = &btcjson.Bip9SoftForkDescription{
-			Status:    strings.ToLower(statusString),
-			Bit:       deploymentDetails.BitNumber,
-			StartTime: int64(deploymentDetails.StartTime),
-			Timeout:   int64(deploymentDetails.ExpireTime),
+			Status:     strings.ToLower(statusString),
+			Bit:        deploymentDetails.BitNumber,
+			StartTime2: int64(deploymentDetails.StartTime),
+			Timeout:    int64(deploymentDetails.ExpireTime),
 		}
 	}
 

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -172,27 +172,37 @@ var helpDescsEnUS = map[string]string{
 	"getblockchaininfo--synopsis": "Returns information about the current blockchain state and the status of any active soft-fork deployments.",
 
 	// GetBlockChainInfoResult help.
-	"getblockchaininforesult-chain":                 "The name of the chain the daemon is on (testnet, mainnet, etc)",
-	"getblockchaininforesult-blocks":                "The number of blocks in the best known chain",
-	"getblockchaininforesult-headers":               "The number of headers that we've gathered for in the best known chain",
-	"getblockchaininforesult-bestblockhash":         "The block hash for the latest block in the main chain",
-	"getblockchaininforesult-difficulty":            "The current chain difficulty",
-	"getblockchaininforesult-mediantime":            "The median time from the PoV of the best block in the chain",
-	"getblockchaininforesult-verificationprogress":  "An estimate for how much of the best chain we've verified",
-	"getblockchaininforesult-pruned":                "A bool that indicates if the node is pruned or not",
-	"getblockchaininforesult-pruneheight":           "The lowest block retained in the current pruned chain",
-	"getblockchaininforesult-chainwork":             "The total cumulative work in the best chain",
-	"getblockchaininforesult-softforks":             "The status of the super-majority soft-forks",
-	"getblockchaininforesult-bip9_softforks":        "JSON object describing active BIP0009 deployments",
-	"getblockchaininforesult-bip9_softforks--key":   "bip9_softforks",
-	"getblockchaininforesult-bip9_softforks--value": "An object describing a particular BIP009 deployment",
-	"getblockchaininforesult-bip9_softforks--desc":  "The status of any defined BIP0009 soft-fork deployments",
+	"getblockchaininforesult-chain":                "The name of the chain the daemon is on (testnet, mainnet, etc)",
+	"getblockchaininforesult-blocks":               "The number of blocks in the best known chain",
+	"getblockchaininforesult-headers":              "The number of headers that we've gathered for in the best known chain",
+	"getblockchaininforesult-bestblockhash":        "The block hash for the latest block in the main chain",
+	"getblockchaininforesult-difficulty":           "The current chain difficulty",
+	"getblockchaininforesult-mediantime":           "The median time from the PoV of the best block in the chain",
+	"getblockchaininforesult-verificationprogress": "An estimate for how much of the best chain we've verified",
+	"getblockchaininforesult-pruned":               "A bool that indicates if the node is pruned or not",
+	"getblockchaininforesult-pruneheight":          "The lowest block retained in the current pruned chain",
+	"getblockchaininforesult-chainwork":            "The total cumulative work in the best chain",
+	"getblockchaininforesult-softforks":            "The status of the super-majority soft-forks",
+	"getblockchaininforesult-unifiedsoftforks":     "The status of the super-majority soft-forks used by bitcoind on or after v0.19.0",
 
 	// SoftForkDescription help.
 	"softforkdescription-reject":  "The current activation status of the softfork",
 	"softforkdescription-version": "The block version that signals enforcement of this softfork",
 	"softforkdescription-id":      "The string identifier for the soft fork",
 	"-status":                     "A bool which indicates if the soft fork is active",
+
+	// SoftForks help.
+	"softforks-softforks":             "The status of the super-majority soft-forks",
+	"softforks-bip9_softforks":        "JSON object describing active BIP0009 deployments",
+	"softforks-bip9_softforks--key":   "bip9_softforks",
+	"softforks-bip9_softforks--value": "An object describing a particular BIP009 deployment",
+	"softforks-bip9_softforks--desc":  "The status of any defined BIP0009 soft-fork deployments",
+
+	// UnifiedSoftForks help.
+	"unifiedsoftforks-softforks":        "The status of the super-majority soft-forks used by bitcoind on or after v0.19.0",
+	"unifiedsoftforks-softforks--key":   "softforks",
+	"unifiedsoftforks-softforks--value": "An object describing an active softfork deployment used by bitcoind on or after v0.19.0",
+	"unifiedsoftforks-softforks--desc":  "JSON object describing an active softfork deployment used by bitcoind on or after v0.19.0",
 
 	// TxRawResult help.
 	"txrawresult-hex":           "Hex-encoded transaction",

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -552,6 +552,7 @@ var helpDescsEnUS = map[string]string{
 	"sendrawtransaction--synopsis":     "Submits the serialized, hex-encoded transaction to the local peer and relays it to the network.",
 	"sendrawtransaction-hextx":         "Serialized, hex-encoded signed transaction",
 	"sendrawtransaction-allowhighfees": "Whether or not to allow insanely high fees (btcd does not yet implement this parameter, so it has no effect)",
+	"sendrawtransaction-maxfeerate":    "Used by bitcoind on or after v0.19.0",
 	"sendrawtransaction--result0":      "The hash of the transaction",
 
 	// SetGenerateCmd help.


### PR DESCRIPTION
This PR aims to remedy the breaking RPC changes introduced in `bitcoind v0.19.0`:

* https://github.com/bitcoin/bitcoin/pull/13541
* https://github.com/bitcoin/bitcoin/pull/16060

This required being able to interpret the backend version the client connects to, which wasn't previously supported. `btcd` and `bitcoind` have different methods to expose this, `GetInfo` and `GetNetworkInfo` respectively.