### PR TITLE
server: remove peer from SyncManager on VerAckReceived

### DIFF
--- a/server.go
+++ b/server.go
@@ -2058,7 +2058,7 @@ func (s *server) peerDoneHandler(sp *serverPeer) {
 	s.donePeers <- sp
 
 	// Only tell sync manager we are gone if we ever told it we existed.
-	if sp.VersionKnown() {
+	if sp.VerAckReceived() {
 		s.syncManager.DonePeer(sp.Peer)
 
 		// Evict any remaining orphans that were sent by the peer.


### PR DESCRIPTION
Peers are now added to the SyncManager if we receive their verack, but we'd still attempt to remove them from the SyncManager if we didn't receive it.