### PR TITLE
server: add addressesMtx to fix race condition

### DIFF
--- a/server.go
+++ b/server.go
@@ -273,6 +273,7 @@ type serverPeer struct {
 	sentAddrs      bool
 	isWhitelisted  bool
 	filter         *bloom.Filter
+	addressesMtx   sync.RWMutex
 	knownAddresses map[string]struct{}
 	banScore       connmgr.DynamicBanScore
 	quit           chan struct{}
@@ -305,14 +306,18 @@ func (sp *serverPeer) newestBlock() (*chainhash.Hash, int32, error) {
 // addKnownAddresses adds the given addresses to the set of known addresses to
 // the peer to prevent sending duplicate addresses.
 func (sp *serverPeer) addKnownAddresses(addresses []*wire.NetAddress) {
+	sp.addressesMtx.Lock()
 	for _, na := range addresses {
 		sp.knownAddresses[addrmgr.NetAddressKey(na)] = struct{}{}
 	}
+	sp.addressesMtx.Unlock()
 }
 
 // addressKnown true if the given address is already known to the peer.
 func (sp *serverPeer) addressKnown(na *wire.NetAddress) bool {
+	sp.addressesMtx.RLock()
 	_, exists := sp.knownAddresses[addrmgr.NetAddressKey(na)]
+	sp.addressesMtx.RUnlock()
 	return exists
 }
 


### PR DESCRIPTION
Running with the race detector gave this.
Two goroutines were accessing the `knownAddresses` map on a `serverPeer` object:
```
==================
WARNING: DATA RACE
Read at 0x00c01cf18450 by goroutine 37:
  runtime.mapaccess2_faststr()
      /usr/local/Cellar/go/1.13/libexec/src/runtime/map_faststr.go:107 +0x0
  main.(*serverPeer).pushAddrMsg()
      /Users/nsa/go/src/github.com/btcsuite/btcd/server.go:315 +0x14b
  main.(*server).handleAddPeerMsg()
      /Users/nsa/go/src/github.com/btcsuite/btcd/server.go:1651 +0xce4
  main.(*server).peerHandler()
      /Users/nsa/go/src/github.com/btcsuite/btcd/server.go:2116 +0xbff

Previous write at 0x00c01cf18450 by goroutine 53:
  runtime.mapassign_faststr()
      /usr/local/Cellar/go/1.13/libexec/src/runtime/map_faststr.go:202 +0x0
  main.(*serverPeer).addKnownAddresses()
      /Users/nsa/go/src/github.com/btcsuite/btcd/server.go:309 +0xbd
  main.(*serverPeer).OnAddr()
      /Users/nsa/go/src/github.com/btcsuite/btcd/server.go:1279 +0x15f
  main.(*serverPeer).OnAddr-fm()
      /Users/nsa/go/src/github.com/btcsuite/btcd/server.go:1242 +0x55
  github.com/btcsuite/btcd/peer.(*Peer).inHandler()
      /Users/nsa/go/src/github.com/btcsuite/btcd/peer/peer.go:1394 +0x2038

Goroutine 37 (running) created at:
  main.(*server).Start()
      /Users/nsa/go/src/github.com/btcsuite/btcd/server.go:2321 +0x1aa
  main.btcdMain()
      /Users/nsa/go/src/github.com/btcsuite/btcd/btcd.go:162 +0x1100
  fmt.Fscanf()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:143 +0xcf
  github.com/btcsuite/goleveldb/leveldb/storage.fsParseName()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:114 +0x192
  github.com/btcsuite/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/storage/file_storage.go:370 +0x2c4
  fmt.Fscanf()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:143 +0xcf
  github.com/btcsuite/goleveldb/leveldb/storage.fsParseName()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:114 +0x192
  github.com/btcsuite/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/storage/file_storage.go:370 +0x2c4
  fmt.Fscanf()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:143 +0xcf
  github.com/btcsuite/goleveldb/leveldb/storage.fsParseName()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:114 +0x192
  github.com/btcsuite/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/storage/file_storage.go:370 +0x2c4
  fmt.Fscanf()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:143 +0xcf
  github.com/btcsuite/goleveldb/leveldb/storage.fsParseName()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:114 +0x192
  github.com/btcsuite/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/storage/file_storage.go:370 +0x2c4
  github.com/btcsuite/goleveldb/leveldb.(*DB).checkAndCleanFiles()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/db_util.go:52 +0x2da
  github.com/btcsuite/goleveldb/leveldb.openDB()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/db.go:129 +0xaa1
  fmt.(*ss).doScanf()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:143 +0xcf
  github.com/btcsuite/goleveldb/leveldb/storage.fsParseName()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:114 +0x192
  github.com/btcsuite/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/storage/file_storage.go:370 +0x2c4
  fmt.Fscanf()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:143 +0xcf
  github.com/btcsuite/goleveldb/leveldb/storage.fsParseName()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:114 +0x192
  github.com/btcsuite/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/storage/file_storage.go:370 +0x2c4
  fmt.Fscanf()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:143 +0xcf
  github.com/btcsuite/goleveldb/leveldb/storage.fsParseName()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:114 +0x192
  github.com/btcsuite/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/storage/file_storage.go:370 +0x2c4
  fmt.Fscanf()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:143 +0xcf
  github.com/btcsuite/goleveldb/leveldb/storage.fsParseName()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:114 +0x192
  github.com/btcsuite/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/storage/file_storage.go:370 +0x2c4
  fmt.Fscanf()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:143 +0xcf
  github.com/btcsuite/goleveldb/leveldb/storage.fsParseName()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:114 +0x192
  github.com/btcsuite/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/storage/file_storage.go:370 +0x2c4
  fmt.Fscanf()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:143 +0xcf
  github.com/btcsuite/goleveldb/leveldb/storage.fsParseName()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:114 +0x192
  github.com/btcsuite/goleveldb/leveldb/storage.(*fileStorage).List()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/storage/file_storage.go:370 +0x2c4
  github.com/btcsuite/goleveldb/leveldb.(*DB).recoverJournal()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/db.go:475 +0xa7
  github.com/btcsuite/goleveldb/leveldb.openDB()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/db.go:124 +0xa7d
  github.com/btcsuite/goleveldb/leveldb.Open()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/db.go:196 +0x1c6
  fmt.(*ss).doScanf()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:1217 +0x382
  fmt.Fscanf()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:143 +0xcf
  github.com/btcsuite/goleveldb/leveldb/storage.fsParseName()
      /usr/local/Cellar/go/1.13/libexec/src/fmt/scan.go:114 +0x192
  github.com/btcsuite/goleveldb/leveldb/storage.(*fileStorage).GetMeta()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/storage/file_storage.go:578 +0x172a
  github.com/btcsuite/goleveldb/leveldb.(*session).recover()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/session.go:116 +0xd9
  github.com/btcsuite/goleveldb/leveldb.Open()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/db.go:182 +0xf8
  github.com/btcsuite/goleveldb/leveldb.OpenFile()
      /Users/nsa/go/pkg/mod/github.com/btcsuite/goleveldb@v0.0.0-20160330041536-7834afc9e8cd/leveldb/db.go:218 +0xa5
  github.com/btcsuite/btcd/database/ffldb.openDB()
      /Users/nsa/go/src/github.com/btcsuite/btcd/database/ffldb/db.go:2009 +0x189
  github.com/btcsuite/btcd/database/ffldb.openDBDriver()
      /Users/nsa/go/src/github.com/btcsuite/btcd/database/ffldb/driver.go:52 +0xf7
  github.com/btcsuite/btcd/database.Open()
      /Users/nsa/go/src/github.com/btcsuite/btcd/database/driver.go:88 +0x102
  main.loadBlockDB()
      /Users/nsa/go/src/github.com/btcsuite/btcd/btcd.go:274 +0x4e4
  main.btcdMain()
      /Users/nsa/go/src/github.com/btcsuite/btcd/btcd.go:102 +0x479
  main.main()
      /Users/nsa/go/src/github.com/btcsuite/btcd/btcd.go:330 +0xeb

Goroutine 53 (running) created at:
  github.com/btcsuite/btcd/peer.(*Peer).start()
      /Users/nsa/go/src/github.com/btcsuite/btcd/peer/peer.go:2153 +0x370
  github.com/btcsuite/btcd/peer.(*Peer).AssociateConnection.func1()
      /Users/nsa/go/src/github.com/btcsuite/btcd/peer/peer.go:2188 +0x3c
==================
```