### PR TITLE
server+addrmgr: add GetLastAttempt to fix race condition in connmgr

### DIFF
--- a/addrmgr/addrmanager.go
+++ b/addrmgr/addrmanager.go
@@ -844,6 +844,20 @@ func (a *AddrManager) find(addr *wire.NetAddress) *KnownAddress {
 	return a.addrIndex[NetAddressKey(addr)]
 }
 
+// GetLastAttempt retrieves an address' last attempt time.
+func (a *AddrManager) GetLastAttempt(addr *wire.NetAddress) time.Time {
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
+
+	ka := a.find(addr)
+	if ka == nil {
+		// If not found, return zero time.
+		return time.Time{}
+	}
+
+	return ka.LastAttempt()
+}
+
 // Attempt increases the given address' attempt counter and updates
 // the last attempt time.
 func (a *AddrManager) Attempt(addr *wire.NetAddress) {

--- a/server.go
+++ b/server.go
@@ -2813,7 +2813,8 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 
 				// only allow recent nodes (10mins) after we failed 30
 				// times
-				if tries < 30 && time.Since(addr.LastAttempt()) < 10*time.Minute {
+				lastTime := s.addrManager.GetLastAttempt(addr.NetAddress())
+				if tries < 30 && time.Since(lastTime) < 10*time.Minute {
 					continue
 				}
 


### PR DESCRIPTION
Happens because `ka.LastAttempt()` is called without a mutex while the `lastAttempt` field is being updated by the `addrmanager` via `Attempt`. Can happen if two individual `NewConnReq` goroutines are spawned and are trying the same address.

```
==================
WARNING: DATA RACE
Write at 0x00c014f829d8 by goroutine 67:
  github.com/btcsuite/btcd/addrmgr.(*AddrManager).Attempt()
      /Users/nsa/go/src/github.com/btcsuite/btcd/addrmgr/addrmanager.go:861 +0x1b3
  main.newServer.func5()
      /Users/nsa/go/src/github.com/btcsuite/btcd/server.go:2822 +0x26f
  github.com/btcsuite/btcd/connmgr.(*ConnManager).NewConnReq()
      /Users/nsa/go/src/github.com/btcsuite/btcd/connmgr/connmanager.go:391 +0x3e6

Previous read at 0x00c014f829d8 by goroutine 69:
  main.newServer.func5()
      /Users/nsa/go/src/github.com/btcsuite/btcd/addrmgr/knownaddress.go:33 +0x498
  github.com/btcsuite/btcd/connmgr.(*ConnManager).NewConnReq()
      /Users/nsa/go/src/github.com/btcsuite/btcd/connmgr/connmanager.go:391 +0x3e6

Goroutine 67 (running) created at:
  github.com/btcsuite/btcd/connmgr.(*ConnManager).Start()
      /Users/nsa/go/src/github.com/btcsuite/btcd/connmgr/connmanager.go:530 +0x170

Goroutine 69 (running) created at:
  github.com/btcsuite/btcd/connmgr.(*ConnManager).Start()
      /Users/nsa/go/src/github.com/btcsuite/btcd/connmgr/connmanager.go:530 +0x170
```