### PR TITLE
Implement 'getblockstats' JSON-RPC command

### DIFF
--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -236,6 +236,60 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 		},
 		{
+			name: "getblockstats height",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("getblockstats", btcjson.HashOrHeight{Value: 123})
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewGetBlockStatsCmd(btcjson.HashOrHeight{Value: 123}, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getblockstats","params":[123],"id":1}`,
+			unmarshalled: &btcjson.GetBlockStatsCmd{
+				HashOrHeight: btcjson.HashOrHeight{Value: 123},
+			},
+		},
+		{
+			name: "getblockstats hash",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("getblockstats", btcjson.HashOrHeight{Value: "deadbeef"})
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewGetBlockStatsCmd(btcjson.HashOrHeight{Value: "deadbeef"}, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getblockstats","params":["deadbeef"],"id":1}`,
+			unmarshalled: &btcjson.GetBlockStatsCmd{
+				HashOrHeight: btcjson.HashOrHeight{Value: "deadbeef"},
+			},
+		},
+		{
+			name: "getblockstats height optional stats",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("getblockstats", btcjson.HashOrHeight{Value: 123}, []string{"avgfee", "maxfee"})
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewGetBlockStatsCmd(btcjson.HashOrHeight{Value: 123}, &[]string{"avgfee", "maxfee"})
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getblockstats","params":[123,["avgfee","maxfee"]],"id":1}`,
+			unmarshalled: &btcjson.GetBlockStatsCmd{
+				HashOrHeight: btcjson.HashOrHeight{Value: 123},
+				Stats:        &[]string{"avgfee", "maxfee"},
+			},
+		},
+		{
+			name: "getblockstats hash optional stats",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("getblockstats", btcjson.HashOrHeight{Value: "deadbeef"}, []string{"avgfee", "maxfee"})
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewGetBlockStatsCmd(btcjson.HashOrHeight{Value: "deadbeef"}, &[]string{"avgfee", "maxfee"})
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getblockstats","params":["deadbeef",["avgfee","maxfee"]],"id":1}`,
+			unmarshalled: &btcjson.GetBlockStatsCmd{
+				HashOrHeight: btcjson.HashOrHeight{Value: "deadbeef"},
+				Stats:        &[]string{"avgfee", "maxfee"},
+			},
+		},
+		{
 			name: "getblocktemplate",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("getblocktemplate")

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -24,6 +24,38 @@ type GetBlockHeaderVerboseResult struct {
 	NextHash      string  `json:"nextblockhash,omitempty"`
 }
 
+// GetBlockStatsResult models the data from the getblockstats command.
+type GetBlockStatsResult struct {
+	AverageFee         int64   `json:"avgfee"`
+	AverageFeeRate     int64   `json:"avgfeerate"`
+	AverageTxSize      int64   `json:"avgtxsize"`
+	FeeratePercentiles []int64 `json:"feerate_percentiles"`
+	Hash               string  `json:"blockhash"`
+	Height             int64   `json:"height"`
+	Ins                int64   `json:"ins"`
+	MaxFee             int64   `json:"maxfee"`
+	MaxFeeRate         int64   `json:"maxfeerate"`
+	MaxTxSize          int64   `json:"maxtxsize"`
+	MedianFee          int64   `json:"medianfee"`
+	MedianTime         int64   `json:"mediantime"`
+	MedianTxSize       int64   `json:"mediantxsize"`
+	MinFee             int64   `json:"minfee"`
+	MinFeeRate         int64   `json:"minfeerate"`
+	MinTxSize          int64   `json:"mintxsize"`
+	Outs               int64   `json:"outs"`
+	SegWitTotalSize    int64   `json:"swtotal_size"`
+	SegWitTotalWeight  int64   `json:"swtotal_weight"`
+	SegWitTxs          int64   `json:"swtxs"`
+	Subsidy            int64   `json:"subsidy"`
+	Time               int64   `json:"time"`
+	TotalOut           int64   `json:"total_out"`
+	TotalSize          int64   `json:"total_size"`
+	TotalWeight        int64   `json:"total_weight"`
+	Txs                int64   `json:"txs"`
+	UTXOIncrease       int64   `json:"utxo_increase"`
+	UTXOSizeIncrease   int64   `json:"utxo_size_inc"`
+}
+
 // GetBlockVerboseResult models the data from the getblock command when the
 // verbose flag is set.  When the verbose flag is not set, getblock returns a
 // hex-encoded string.


### PR DESCRIPTION
I had to implement `HashOrHeight` type because `getblockstats` RPC command takes either block height or hash and `interface{}` is not allowed in command arguments. The new type basically wraps an `interface{}` and defines JSON marshaling and unmarshaling rules.