### PR TITLE
Try both TX serialization formats in createrawtransaction

### DIFF
--- a/rpcclient/rawtransactions.go
+++ b/rpcclient/rawtransactions.go
@@ -233,8 +233,13 @@ func (r FutureCreateRawTransactionResult) Receive() (*wire.MsgTx, error) {
 
 	// Deserialize the transaction and return it.
 	var msgTx wire.MsgTx
-	if err := msgTx.Deserialize(bytes.NewReader(serializedTx)); err != nil {
-		return nil, err
+	// we try both the new and old encoding format
+	witnessErr := msgTx.Deserialize(bytes.NewReader(serializedTx))
+	if witnessErr != nil {
+		legacyErr := msgTx.DeserializeNoWitness(bytes.NewReader(serializedTx))
+		if legacyErr != nil {
+			return nil, legacyErr
+		}
 	}
 	return &msgTx, nil
 }


### PR DESCRIPTION
Currently, it is not possible to use the `rpcclient` package to create a raw TX with Bitcoin Core if the transaction you're creating has no inputs. This is a realistic scenario, as you would typically call `createrawtransaction` with your outputs specified, and then follow up with `fundrawtransaction`. 

The reason the RPC call fails is that we assume the returned transaction is encoded with the new witness format that was introduced with Segwit. We solve this by simply trying both serialization formats. If its possible to detect which format is used (so we avoid doing it twice) I'll update the PR. 