### PR TITLE
BUG ： SignRawTransaction4 Params missing field "Amount"

### DIFF
--- a/btcjson/walletsvrcmds.go
+++ b/btcjson/walletsvrcmds.go
@@ -590,6 +590,7 @@ type RawTxInput struct {
 	Vout         uint32 `json:"vout"`
 	ScriptPubKey string `json:"scriptPubKey"`
 	RedeemScript string `json:"redeemScript"`
+	Amount	     float64 `json:"amount"`
 }
 
 // SignRawTransactionCmd defines the signrawtransaction JSON-RPC command.


### PR DESCRIPTION
the RawTxInput struct lost a field  "Amount" ,the RPC while return err