### PR TITLE
Formatting Fixes (go fmt)

### DIFF
--- a/mempool/estimatefee.go
+++ b/mempool/estimatefee.go
@@ -47,7 +47,7 @@ const (
 
 	bytePerKb = 1000
 
-	btcPerSatoshi = 1E-8
+	btcPerSatoshi = 1e-8
 )
 
 var (


### PR DESCRIPTION
Running `go fmt ./...` changes `E` to `e`. Since this has come up on #1505 and is happening as I put together a PR for #1522/#1524 and I've seen this happen to a few other people I figure we might as well get it merged in a separate pr [as per](https://github.com/btcsuite/btcd/pull/1503#discussion_r354182377) @torkelrogstad 