### PR TITLE
update GetMempoolEntryResult to v0.19.0

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -206,23 +206,35 @@ type GetBlockTemplateResult struct {
 	RejectReasion string   `json:"reject-reason,omitempty"`
 }
 
+// GetMempoolEntryResult models the data returned from the getmempoolentry's
+// fee field
+
+type MempoolFees struct {
+	Base       float64 `json:"base"`
+	Modified   float64 `json:"base"`
+	Ancestor   float64 `json:"ancestor"`
+	Descendant float64 `json:"descendant"`
+}
+
 // GetMempoolEntryResult models the data returned from the getmempoolentry
 // command.
 type GetMempoolEntryResult struct {
-	Size             int32    `json:"size"`
-	Fee              float64  `json:"fee"`
-	ModifiedFee      float64  `json:"modifiedfee"`
-	Time             int64    `json:"time"`
-	Height           int64    `json:"height"`
-	StartingPriority float64  `json:"startingpriority"`
-	CurrentPriority  float64  `json:"currentpriority"`
-	DescendantCount  int64    `json:"descendantcount"`
-	DescendantSize   int64    `json:"descendantsize"`
-	DescendantFees   float64  `json:"descendantfees"`
-	AncestorCount    int64    `json:"ancestorcount"`
-	AncestorSize     int64    `json:"ancestorsize"`
-	AncestorFees     float64  `json:"ancestorfees"`
-	Depends          []string `json:"depends"`
+	VSize           int32       `json:"vsize"`
+	Size            int32       `json:"size"`
+	Weight          int64       `json:"weight"`
+	Fee             float64     `json:"fee"`
+	ModifiedFee     float64     `json:"modifiedfee"`
+	Time            int64       `json:"time"`
+	Height          int64       `json:"height"`
+	DescendantCount int64       `json:"descendantcount"`
+	DescendantSize  int64       `json:"descendantsize"`
+	DescendantFees  float64     `json:"descendantfees"`
+	AncestorCount   int64       `json:"ancestorcount"`
+	AncestorSize    int64       `json:"ancestorsize"`
+	AncestorFees    float64     `json:"ancestorfees"`
+	WTxId           string      `json:"wtxid"`
+	Fees            MempoolFees `json:"fees"`
+	Depends         []string    `json:"depends"`
 }
 
 // GetMempoolInfoResult models the data returned from the getmempoolinfo


### PR DESCRIPTION
As per #1522, several fields of the [`getmempoolentry`](https://bitcoincore.org/en/doc/0.19.0/rpc/blockchain/getmempoolentry/) were missing when the method was implemented #905 (since it was created using [0.14.0](https://github.com/bitcoin/bitcoin/tree/v0.14.0) as the reference implementation and weren't updated with #1484. [As per](https://github.com/btcsuite/btcd/pull/905#pullrequestreview-19612400) @davecgh on #905, `getmempoolentry` was implemented on the client, but not the server. I think with the upgrades/implementation suggested in #1522, it makes the most sense to follow the path we did there and get this merged while we put together a comprehensive up to date `getmempoolentry` server implementation based off this branch