### PR TITLE
make a block with an invalid orphan child a valid block

### DIFF
--- a/blockchain/process.go
+++ b/blockchain/process.go
@@ -117,7 +117,12 @@ func (b *BlockChain) processOrphans(hash *chainhash.Hash, flags BehaviorFlags) e
 			// Potentially accept the block into the block chain.
 			_, err := b.maybeAcceptBlock(orphan.block, flags)
 			if err != nil {
-				return err
+				// Since we don't want to reject the original block because of
+				// a bad unorphaned child, only return an error if it's not a RuleError.
+				if _, ok := err.(RuleError); !ok {
+					return err
+				}
+				log.Warnf("Verification failed for orphan block %s: %s", orphanHash, err)
 			}
 
 			// Add this block to the list of blocks to process so


### PR DESCRIPTION
There is a bug where a block is considered invalid if it has an invalid orphan child