### PR TITLE
Refactor GetBlockVerboseTx to reflect correct getblock RPC call parameters.

### DIFF
--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -130,8 +130,7 @@ func NewGetBestBlockHashCmd() *GetBestBlockHashCmd {
 // GetBlockCmd defines the getblock JSON-RPC command.
 type GetBlockCmd struct {
 	Hash      string
-	Verbose   *bool `jsonrpcdefault:"true"`
-	VerboseTx *bool `jsonrpcdefault:"false"`
+	Verbosity *int `jsonrpcdefault:"0"`
 }
 
 // NewGetBlockCmd returns a new instance which can be used to issue a getblock
@@ -139,11 +138,10 @@ type GetBlockCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewGetBlockCmd(hash string, verbose, verboseTx *bool) *GetBlockCmd {
+func NewGetBlockCmd(hash string, verbosity *int) *GetBlockCmd {
 	return &GetBlockCmd{
 		Hash:      hash,
-		Verbose:   verbose,
-		VerboseTx: verboseTx,
+		Verbosity: verbosity,
 	}
 }
 

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -25,8 +25,11 @@ type GetBlockHeaderVerboseResult struct {
 }
 
 // GetBlockVerboseResult models the data from the getblock command when the
-// verbose flag is set.  When the verbose flag is not set, getblock returns a
-// hex-encoded string.
+// verbose flag is set to 1.  When the verbose flag is set to 0, getblock returns a
+// hex-encoded string. When the verbose flag is set to 1, getblock returns an object
+// whose tx field is an array of transaction hashes. When the verbose flag is set to 2,
+// getblock returns an object whose tx field is an array of raw transactions.
+// Use GetBlockVerboseTxResult to unmarshal data received from passing verbose=2 to getblock.
 type GetBlockVerboseResult struct {
 	Hash          string        `json:"hash"`
 	Confirmations int64         `json:"confirmations"`
@@ -38,7 +41,32 @@ type GetBlockVerboseResult struct {
 	VersionHex    string        `json:"versionHex"`
 	MerkleRoot    string        `json:"merkleroot"`
 	Tx            []string      `json:"tx,omitempty"`
-	RawTx         []TxRawResult `json:"rawtx,omitempty"`
+	RawTx         []TxRawResult `json:"rawtx,omitempty"` // Note: this field is always empty when verbose != 2.
+	Time          int64         `json:"time"`
+	Nonce         uint32        `json:"nonce"`
+	Bits          string        `json:"bits"`
+	Difficulty    float64       `json:"difficulty"`
+	PreviousHash  string        `json:"previousblockhash"`
+	NextHash      string        `json:"nextblockhash,omitempty"`
+}
+
+// GetBlockVerboseTxResult models the data from the getblock command when the
+// verbose flag is set to 2.  When the verbose flag is set to 0, getblock returns a
+// hex-encoded string. When the verbose flag is set to 1, getblock returns an object
+// whose tx field is an array of transaction hashes. When the verbose flag is set to 2,
+// getblock returns an object whose tx field is an array of raw transactions.
+// Use GetBlockVerboseResult to unmarshal data received from passing verbose=1 to getblock.
+type GetBlockVerboseTxResult struct {
+	Hash          string        `json:"hash"`
+	Confirmations int64         `json:"confirmations"`
+	StrippedSize  int32         `json:"strippedsize"`
+	Size          int32         `json:"size"`
+	Weight        int32         `json:"weight"`
+	Height        int64         `json:"height"`
+	Version       int32         `json:"version"`
+	VersionHex    string        `json:"versionHex"`
+	MerkleRoot    string        `json:"merkleroot"`
+	Tx            []TxRawResult `json:"tx,omitempty"`
 	Time          int64         `json:"time"`
 	Nonce         uint32        `json:"nonce"`
 	Bits          string        `json:"bits"`


### PR DESCRIPTION
Currently, rpcclient.GetBlockVerboseTx(...) does not return raw transaction data. This is due to how GetBlockCmd is implemented in btcjson; in upstream/master, `getblock` sends two boolean parameters (`verbose` and `verbosetx`), which throws an error. 

According to the bitcoin JSON RPC documentation, `getblock` accepts two parameters: `blockhash` (as a string) and `verbosity` (as an integer). `verbosity` can be any of `0`, `1`, or `2`, with `0` being the default. 

```
getblock "blockhash" ( verbosity ) 

If verbosity is 0, returns a string that is serialized, hex-encoded data for block 'hash'.
If verbosity is 1, returns an Object with information about block .
If verbosity is 2, returns an Object with information about block  and information about each transaction. 

Arguments:
1. "blockhash"          (string, required) The block hash
2. verbosity              (numeric, optional, default=1) 0 for hex encoded data, 1 for a json object, and 2 for json object with transaction data
```

This pull request aims to correctly implement `verbosity` as a parameter to `getblock` by refactoring `GetBlockCmd` (in `btcjson/chainsvrcmds.go`) to have two fields: `Hash` and `Verbosity`, with `Verbosity` being an optional int pointer. 

In order to implement correct behavior, three primary changes are necessary: the above refactor, an additional type specific to `getblock verbosity=2`, and a new `Future` type to enable proper (and error-free) unmarshalling of `verbosity=2` data. 

The new type (`GetBlockVerboseTxResult`) is almost entirely the same as  `GetBlockVerboseResult`, but with the minor modification of changing the `Tx` field from a `[]string` to a `[]TxRawResult` so as to enable proper unmarshalling. 

The new `Future` type (`FutureGetBlockVerboseTxResult`) returns a `GetBlockVerboseTxResult` rather than a `GetBlockVerboseResult` so that data can be properly returned to the user without error. 