### PR TITLE
Remove $GOPATH Caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 cache:
   directories:
     - $GOCACHE
-    - $GOPATH
     - $GOPATH/pkg/mod
     - $GOPATH/github.com/golang
     - $GOPATH/gopkg.in/alecthomas


### PR DESCRIPTION
$GOPATH caching has led to flaky tests as per #1503 and #1536. The speedup is marginal and while the false negatives are a headache, false positives are potentially dangerous.