### PR TITLE
remove redundant sending to msg.reply in processBlockMsg in blockHandler

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1308,16 +1308,9 @@ out:
 			case processBlockMsg:
 				_, isOrphan, err := sm.chain.ProcessBlock(
 					msg.block, msg.flags)
-				if err != nil {
-					msg.reply <- processBlockResponse{
-						isOrphan: false,
-						err:      err,
-					}
-				}
-
 				msg.reply <- processBlockResponse{
 					isOrphan: isOrphan,
-					err:      nil,
+					err:      err,
 				}
 
 			case isCurrentMsg:
@@ -1539,7 +1532,7 @@ func (sm *SyncManager) SyncPeerID() int32 {
 // ProcessBlock makes use of ProcessBlock on an internal instance of a block
 // chain.
 func (sm *SyncManager) ProcessBlock(block *btcutil.Block, flags blockchain.BehaviorFlags) (bool, error) {
-	reply := make(chan processBlockResponse, 1)
+	reply := make(chan processBlockResponse)
 	sm.msgChan <- processBlockMsg{block: block, flags: flags, reply: reply}
 	response := <-reply
 	return response.isOrphan, response.err


### PR DESCRIPTION
In case of an error, msg.reply get two responses, but reads only one. To prevent it from blocking, msg.reply was created with a buffer.
This PR makes sure that msg.reply will get only one response, and then removes the redundant buffer.