### PR TITLE
btcjson: add RPC_IN_WARMUP error code

### DIFF
--- a/btcjson/jsonrpcerr.go
+++ b/btcjson/jsonrpcerr.go
@@ -39,6 +39,7 @@ const (
 	ErrRPCDatabase            RPCErrorCode = -20
 	ErrRPCDeserialization     RPCErrorCode = -22
 	ErrRPCVerify              RPCErrorCode = -25
+	ErrRPCInWarmup            RPCErrorCode = -28
 )
 
 // Peer-to-peer client errors.


### PR DESCRIPTION
This adds an error code for the `RPC_IN_WARMUP` error code defined at https://github.com/bitcoin/bitcoin/blob/master/src/rpc/protocol.h#L49 which is thrown when bitcoind has started but has not yet finished verifying recent blocks and being ready for rpc calls.