### PR TITLE
server: suppressing the connection in regtest mode

### DIFF
--- a/server.go
+++ b/server.go
@@ -2792,7 +2792,7 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 	// discovered peers in order to prevent it from becoming a public test
 	// network.
 	var newAddressFunc func() (net.Addr, error)
-	if !cfg.SimNet && len(cfg.ConnectPeers) == 0 {
+	if !cfg.SimNet && !cfg.RegressionTest && len(cfg.ConnectPeers) == 0 {
 		newAddressFunc = func() (net.Addr, error) {
 			for tries := 0; tries < 100; tries++ {
 				addr := s.addrManager.GetAddress()


### PR DESCRIPTION
I got a log of trying to connect somewhere when I ran regtest.
`newAddressFunc` should be removed in regtest.

`btcd --regtest --rpcuser=aaaa --rpcpass=bbbb --debuglevel=trace`

```
2020-04-02 10:40:53.351 [INF] BTCD: Version 0.20.1-beta
2020-04-02 10:40:53.351 [INF] BTCD: Loading block database from '/home/wakiyamap/.btcd/data/regtest/blocks_ffldb'
2020-04-02 10:40:53.355 [TRC] BCDB: Scan found latest block file #-1 with length 0
2020-04-02 10:40:53.356 [INF] BTCD: Block database loaded
2020-04-02 10:40:53.359 [INF] INDX: Committed filter index is enabled
2020-04-02 10:40:53.359 [TRC] BCDB: Added block 0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206 to pending blocks
2020-04-02 10:40:53.359 [TRC] BCDB: Storing block 0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206
2020-04-02 10:40:53.359 [DBG] INDX: Current committed filter index tip (height -1, hash 0000000000000000000000000000000000000000000000000000000000000000)
2020-04-02 10:40:53.359 [INF] INDX: Catching up indexes from height -1 to 0
2020-04-02 10:40:53.360 [INF] INDX: Indexes caught up to height 0
2020-04-02 10:40:53.360 [INF] CHAN: Chain state (height 0, hash 0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206, totaltx 1, work 2)
2020-04-02 10:40:53.360 [INF] RPCS: Generating TLS certificates...
2020-04-02 10:40:53.379 [INF] RPCS: Done generating TLS certificates
2020-04-02 10:40:53.388 [TRC] SRVR: Starting server
2020-04-02 10:40:53.388 [TRC] RPCS: Starting RPC server
2020-04-02 10:40:53.388 [TRC] AMGR: Starting address manager
2020-04-02 10:40:53.388 [INF] RPCS: RPC server listening on 127.0.0.1:18334
2020-04-02 10:40:53.389 [INF] AMGR: Loaded 0 addresses from file '/home/wakiyamap/.btcd/data/regtest/peers.json'
2020-04-02 10:40:53.389 [TRC] SYNC: Starting sync manager
2020-04-02 10:40:53.389 [TRC] SRVR: Starting peer handler
2020-04-02 10:40:53.389 [TRC] CMGR: Connection manager started
2020-04-02 10:40:53.390 [INF] CMGR: Server listening on 0.0.0.0:18444
2020-04-02 10:40:53.390 [INF] CMGR: Server listening on [::]:18444
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 1: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 2: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 3: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 4: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 9: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 10: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 11: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 12: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 13: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 14: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 15: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 16: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 17: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 18: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 19: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 20: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 21: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 22: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 23: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 24: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 25: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 26: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 27: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 28: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Failed to connect to reqid 29: no valid connect address
2020-04-02 10:40:53.390 [DBG] CMGR: Max failed connection attempts reached: [25] -- retrying connection in: 5s
2020-04-02 10:40:53.391 [DBG] CMGR: Failed to connect to reqid 30: no valid connect address
2020-04-02 10:40:53.391 [DBG] CMGR: Max failed connection attempts reached: [25] -- retrying connection in: 5s
2020-04-02 10:40:53.391 [DBG] CMGR: Failed to connect to reqid 31: no valid connect address
2020-04-02 10:40:53.391 [DBG] CMGR: Max failed connection attempts reached: [25] -- retrying connection in: 5s
2020-04-02 10:40:53.391 [DBG] CMGR: Failed to connect to reqid 5: no valid connect address
2020-04-02 10:40:53.391 [DBG] CMGR: Max failed connection attempts reached: [25] -- retrying connection in: 5s
2020-04-02 10:40:53.391 [DBG] CMGR: Failed to connect to reqid 6: no valid connect address
2020-04-02 10:40:53.391 [DBG] CMGR: Max failed connection attempts reached: [25] -- retrying connection in: 5s
2020-04-02 10:40:53.391 [DBG] CMGR: Failed to connect to reqid 7: no valid connect address
2020-04-02 10:40:53.391 [DBG] CMGR: Max failed connection attempts reached: [25] -- retrying connection in: 5s
2020-04-02 10:40:53.391 [DBG] CMGR: Failed to connect to reqid 8: no valid connect address
2020-04-02 10:40:53.391 [DBG] CMGR: Max failed connection attempts reached: [25] -- retrying connection in: 5s
2020-04-02 10:40:53.391 [DBG] CMGR: Failed to connect to reqid 32: no valid connect address
2020-04-02 10:40:53.391 [DBG] CMGR: Max failed connection attempts reached: [25] -- retrying connection in: 5s
2020-04-02 10:40:58.390 [DBG] CMGR: Failed to connect to reqid 33: no valid connect address
2020-04-02 10:40:58.390 [DBG] CMGR: Max failed connection attempts reached: [25] -- retrying connection in: 5s
2020-04-02 10:40:58.391 [DBG] CMGR: Failed to connect to reqid 34: no valid connect address
```

I'm using google translate, so I'm sorry if my English is weird.