### PR TITLE
[connmgr] remove pending entry on failed connection

### DIFF
--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -328,7 +328,11 @@ out:
 					connReq.updateState(ConnPending)
 					log.Debugf("Reconnecting to %v",
 						connReq)
-					pending[msg.id] = connReq
+					if connReq.Permanent {
+						pending[msg.id] = connReq
+					} else {
+						delete(pending, msg.id)
+					}
 					cm.handleFailedConn(connReq)
 				}
 
@@ -344,6 +348,9 @@ out:
 				connReq.updateState(ConnFailing)
 				log.Debugf("Failed to connect to %v: %v",
 					connReq, msg.err)
+				if !connReq.Permanent {
+					delete(pending, connReq.id)
+				}
 				cm.handleFailedConn(connReq)
 			}
 


### PR DESCRIPTION
fix memory leak in connmanager caused by:
* pending entries are never removed on error
* new connection always allocates new struct

Signed-off-by: Christopher Hall <hsw@bitmark.com>