### PR TITLE
Fix memory leak in connmanager

### DIFF
--- a/connmgr/connmanager.go
+++ b/connmgr/connmanager.go
@@ -210,11 +210,16 @@ func (cm *ConnManager) handleFailedConn(c *ConnReq) {
 			log.Debugf("Max failed connection attempts reached: [%d] "+
 				"-- retrying connection in: %v", maxFailedAttempts,
 				cm.cfg.RetryDuration)
+			theId := c.id
 			time.AfterFunc(cm.cfg.RetryDuration, func() {
+				cm.Remove(theId)
 				cm.NewConnReq()
 			})
 		} else {
-			go cm.NewConnReq()
+			go func(theId uint64) {
+				cm.Remove(theId)
+				cm.NewConnReq()
+			}(c.id)
 		}
 	}
 }


### PR DESCRIPTION
In the case of an error the connection struct is never deleted from the **pending** hash map.

In some testing I observed leaks of 3MB in an hour

The problem stem from the fact that the handleFailedConn does not reuse the connect but allocate a new one
