### PR TITLE
rpcclient: Add getdescriptorinfo RPC call

### DIFF
--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -882,6 +882,19 @@ func NewVerifyTxOutProofCmd(proof string) *VerifyTxOutProofCmd {
 	}
 }
 
+// GetDescriptorInfoCmd defines the getdescriptorinfo JSON-RPC command.
+type GetDescriptorInfoCmd struct {
+	Descriptor string
+}
+
+// NewGetDescriptorInfoCmd returns a new instance which can be used to issue a
+// getdescriptorinfo JSON-RPC command.
+func NewGetDescriptorInfoCmd(descriptor string) *GetDescriptorInfoCmd {
+	return &GetDescriptorInfoCmd{
+		Descriptor: descriptor,
+	}
+}
+
 func init() {
 	// No special flags for commands in this file.
 	flags := UsageFlag(0)
@@ -937,4 +950,5 @@ func init() {
 	MustRegisterCmd("verifychain", (*VerifyChainCmd)(nil), flags)
 	MustRegisterCmd("verifymessage", (*VerifyMessageCmd)(nil), flags)
 	MustRegisterCmd("verifytxoutproof", (*VerifyTxOutProofCmd)(nil), flags)
+	MustRegisterCmd("getdescriptorinfo", (*GetDescriptorInfoCmd)(nil), flags)
 }

--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -1302,6 +1302,17 @@ func TestChainSvrCmds(t *testing.T) {
 				Proof: "test",
 			},
 		},
+		{
+			name: "getdescriptorinfo",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("getdescriptorinfo", "123")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewGetDescriptorInfoCmd("123")
+			},
+			marshalled:   `{"jsonrpc":"1.0","method":"getdescriptorinfo","params":["123"],"id":1}`,
+			unmarshalled: &btcjson.GetDescriptorInfoCmd{Descriptor: "123"},
+		},
 	}
 
 	t.Logf("Running %d tests", len(tests))

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -730,3 +730,12 @@ func (f *FundRawTransactionResult) UnmarshalJSON(data []byte) error {
 	f.ChangePosition = rawRes.ChangePosition
 	return nil
 }
+
+// GetDescriptorInfoResult models the data from the getdescriptorinfo command.
+type GetDescriptorInfoResult struct {
+	Descriptor     string `json:"descriptor"`     // descriptor in canonical form, without private keys
+	Checksum       string `json:"checksum"`       // checksum for the input descriptor
+	IsRange        bool   `json:"isrange"`        // whether the descriptor is ranged
+	IsSolvable     bool   `json:"issolvable"`     // whether the descriptor is solvable
+	HasPrivateKeys bool   `json:"hasprivatekeys"` // whether the descriptor has at least one private key
+}

--- a/rpcclient/example_test.go
+++ b/rpcclient/example_test.go
@@ -1,0 +1,31 @@
+package rpcclient
+
+import (
+	"fmt"
+)
+
+func ExampleClient_GetDescriptorInfo() {
+	connCfg := &ConnConfig{
+		Host:         "localhost:8332",
+		User:         "yourrpcuser",
+		Pass:         "yourrpcpass",
+		HTTPPostMode: true,
+		DisableTLS:   true,
+	}
+	client, err := New(connCfg, nil)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+	defer client.Shutdown()
+
+	descriptorInfo, err := client.GetDescriptorInfo(
+		"wpkh([d34db33f/84h/0h/0h]0279be667ef9dcbbac55a06295Ce870b07029Bfcdb2dce28d959f2815b16f81798)")
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	fmt.Printf("%+v\n", descriptorInfo)
+	// &{Descriptor:wpkh([d34db33f/84'/0'/0']0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798)#n9g43y4k Checksum:qwlqgth7 IsRange:false IsSolvable:true HasPrivateKeys:false}
+}


### PR DESCRIPTION
This is a client-only implementation of the `getdescriptorinfo` RPC call.

Added a new file `rpcclient/example_test.go` containing an example that gets embedded by godoc. Let's try to include more of these in future.