### PR TITLE
Add blockchain.NewUtxoEntry() 

### DIFF
--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -111,6 +111,22 @@ func (entry *UtxoEntry) Clone() *UtxoEntry {
 	}
 }
 
+// NewUtxoEntry returns a new UtxoEntry built from the arguments.
+func NewUtxoEntry(
+	txOut *wire.TxOut, blockHeight int32, isCoinbase bool) *UtxoEntry {
+	var cbFlag txoFlags
+	if isCoinbase {
+		cbFlag |= tfCoinBase
+	}
+
+	return &UtxoEntry{
+		amount:      txOut.Value,
+		pkScript:    txOut.PkScript,
+		blockHeight: blockHeight,
+		packedFlags: cbFlag,
+	}
+}
+
 // UtxoViewpoint represents a view into the set of unspent transaction outputs
 // from a specific point of view in the chain.  For example, it could be for
 // the end of the main chain, some point in the history of the main chain, or


### PR DESCRIPTION
In developing utreexo we're using btcd & libraries quite a bit.  The current exported methods for adding entries to a UtxoViewpoint don't work for utreexo though.  

`AddTxOut()` and `AddTxOuts()` both require a whole transaction, including the inputs, which are only there to calculate the txid.  In the utreexo setup, we only have the outpoint and txout data, but not the rest of the transaction we'd like to add into the UtxoViewpoint.  Directly creating one with `NewUtxoEntry()` seems like the smallest change that doesn't affect anything else in btcd.

Another way to do it would be exporting the current `addTxOut()` method, but that would conflict with the current exported `AddTxOut()` method.  (which, granted, is only used in 1 place in mempool.go, and that usage could be adapted to give the TxOut rather than whole transaction)  Adding a NewUtxoEntry() constructor seemed simplest but changing `AddTxOut()` would work just as well.

For reference, our usage of UtxoViewpoint is here: https://github.com/mit-dci/utreexo/pull/135/files#diff-3f7b8f9991ea957f1f4ad9f5a95415f0R96

If there are other options we'd also look at those.  Hope we can get something like this in and be able to use the master branch of btcd for uteexo software.  Thanks!