### PR TITLE
Add getnodeaddresses JSON-RPC support (rpc client & server)

### DIFF
--- a/btcjson/chainsvrcmds.go
+++ b/btcjson/chainsvrcmds.go
@@ -557,6 +557,22 @@ func NewGetNetworkHashPSCmd(numBlocks, height *int) *GetNetworkHashPSCmd {
 	}
 }
 
+// GetNodeAddressesCmd defines the getnodeaddresses JSON-RPC command.
+type GetNodeAddressesCmd struct {
+	Count *int32 `jsonrpcdefault:"1"`
+}
+
+// NewGetNodeAddressesCmd returns a new instance which can be used to issue a
+// getnodeaddresses JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewGetNodeAddressesCmd(count *int32) *GetNodeAddressesCmd {
+	return &GetNodeAddressesCmd{
+		Count: count,
+	}
+}
+
 // GetPeerInfoCmd defines the getpeerinfo JSON-RPC command.
 type GetPeerInfoCmd struct{}
 
@@ -974,6 +990,7 @@ func init() {
 	MustRegisterCmd("getnetworkinfo", (*GetNetworkInfoCmd)(nil), flags)
 	MustRegisterCmd("getnettotals", (*GetNetTotalsCmd)(nil), flags)
 	MustRegisterCmd("getnetworkhashps", (*GetNetworkHashPSCmd)(nil), flags)
+	MustRegisterCmd("getnodeaddresses", (*GetNodeAddressesCmd)(nil), flags)
 	MustRegisterCmd("getpeerinfo", (*GetPeerInfoCmd)(nil), flags)
 	MustRegisterCmd("getrawmempool", (*GetRawMempoolCmd)(nil), flags)
 	MustRegisterCmd("getrawtransaction", (*GetRawTransactionCmd)(nil), flags)

--- a/btcjson/chainsvrcmds_test.go
+++ b/btcjson/chainsvrcmds_test.go
@@ -754,6 +754,32 @@ func TestChainSvrCmds(t *testing.T) {
 			},
 		},
 		{
+			name: "getnodeaddresses",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("getnodeaddresses")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewGetNodeAddressesCmd(nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getnodeaddresses","params":[],"id":1}`,
+			unmarshalled: &btcjson.GetNodeAddressesCmd{
+				Count: btcjson.Int32(1),
+			},
+		},
+		{
+			name: "getnodeaddresses optional",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("getnodeaddresses", 10)
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewGetNodeAddressesCmd(btcjson.Int32(10))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getnodeaddresses","params":[10],"id":1}`,
+			unmarshalled: &btcjson.GetNodeAddressesCmd{
+				Count: btcjson.Int32(10),
+			},
+		},
+		{
 			name: "getpeerinfo",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("getpeerinfo")

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -365,6 +365,16 @@ type GetNetworkInfoResult struct {
 	Warnings        string                 `json:"warnings"`
 }
 
+// GetNodeAddressesResult models the data returned from the getnodeaddresses
+// command.
+type GetNodeAddressesResult struct {
+	// Timestamp in seconds since epoch (Jan 1 1970 GMT) keeping track of when the node was last seen
+	Time     int64  `json:"time"`
+	Services uint64 `json:"services"` // The services offered
+	Address  string `json:"address"`  // The address of the node
+	Port     uint16 `json:"port"`     // The port of the node
+}
+
 // GetPeerInfoResult models the data returned from the getpeerinfo command.
 type GetPeerInfoResult struct {
 	ID             int32   `json:"id"`

--- a/rpcadapters.go
+++ b/rpcadapters.go
@@ -223,6 +223,15 @@ func (cm *rpcConnManager) RelayTransactions(txns []*mempool.TxDesc) {
 	cm.server.relayTransactions(txns)
 }
 
+// NodeAddresses returns an array consisting node addresses which can
+// potentially be used to find new nodes in the network.
+//
+// This function is safe for concurrent access and is part of the
+// rpcserverConnManager interface implementation.
+func (cm *rpcConnManager) NodeAddresses() []*wire.NetAddress {
+	return cm.server.addrManager.AddressCache()
+}
+
 // rpcSyncMgr provides a block manager for use with the RPC server and
 // implements the rpcserverSyncManager interface.
 type rpcSyncMgr struct {

--- a/rpcclient/net.go
+++ b/rpcclient/net.go
@@ -281,6 +281,43 @@ func (c *Client) GetNetworkInfo() (*btcjson.GetNetworkInfoResult, error) {
 	return c.GetNetworkInfoAsync().Receive()
 }
 
+// FutureGetNodeAddressesResult is a future promise to deliver the result of a
+// GetNodeAddressesAsync RPC invocation (or an applicable error).
+type FutureGetNodeAddressesResult chan *response
+
+// Receive waits for the response promised by the future and returns data about
+// known node addresses.
+func (r FutureGetNodeAddressesResult) Receive() ([]btcjson.GetNodeAddressesResult, error) {
+	res, err := receiveFuture(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unmarshal result as an array of getnodeaddresses result objects.
+	var nodeAddresses []btcjson.GetNodeAddressesResult
+	err = json.Unmarshal(res, &nodeAddresses)
+	if err != nil {
+		return nil, err
+	}
+
+	return nodeAddresses, nil
+}
+
+// GetNodeAddressesAsync returns an instance of a type that can be used to get the
+// result of the RPC at some future time by invoking the Receive function on the
+// returned instance.
+//
+// See GetNodeAddresses for the blocking version and more details.
+func (c *Client) GetNodeAddressesAsync(count *int32) FutureGetNodeAddressesResult {
+	cmd := btcjson.NewGetNodeAddressesCmd(count)
+	return c.sendCmd(cmd)
+}
+
+// GetNodeAddresses returns data about known node addresses.
+func (c *Client) GetNodeAddresses(count *int32) ([]btcjson.GetNodeAddressesResult, error) {
+	return c.GetNodeAddressesAsync(count).Receive()
+}
+
 // FutureGetPeerInfoResult is a future promise to deliver the result of a
 // GetPeerInfoAsync RPC invocation (or an applicable error).
 type FutureGetPeerInfoResult chan *response

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -452,6 +452,17 @@ var helpDescsEnUS = map[string]string{
 	"getnettotalsresult-totalbytessent": "Total bytes sent",
 	"getnettotalsresult-timemillis":     "Number of milliseconds since 1 Jan 1970 GMT",
 
+	// GetNodeAddressesResult help.
+	"getnodeaddressesresult-time":     "Timestamp in seconds since epoch (Jan 1 1970 GMT) keeping track of when the node was last seen",
+	"getnodeaddressesresult-services": "The services offered",
+	"getnodeaddressesresult-address":  "The address of the node",
+	"getnodeaddressesresult-port":     "The port of the node",
+
+	// GetNodeAddressesCmd help.
+	"getnodeaddresses--synopsis": "Return known addresses which can potentially be used to find new nodes in the network",
+	"getnodeaddresses-count":     "How many addresses to return. Limited to the smaller of 2500 or 23% of all known addresses",
+	"getnodeaddresses--result0":  "List of node addresses",
+
 	// GetPeerInfoResult help.
 	"getpeerinforesult-id":             "A unique node ID",
 	"getpeerinforesult-addr":           "The ip address and port of the peer",
@@ -726,6 +737,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getmininginfo":          {(*btcjson.GetMiningInfoResult)(nil)},
 	"getnettotals":           {(*btcjson.GetNetTotalsResult)(nil)},
 	"getnetworkhashps":       {(*int64)(nil)},
+	"getnodeaddresses":       {(*[]btcjson.GetNodeAddressesResult)(nil)},
 	"getpeerinfo":            {(*[]btcjson.GetPeerInfoResult)(nil)},
 	"getrawmempool":          {(*[]string)(nil), (*btcjson.GetRawMempoolVerboseResult)(nil)},
 	"getrawtransaction":      {(*string)(nil), (*btcjson.TxRawResult)(nil)},


### PR DESCRIPTION
Add NodeAddresses function to rpcserverConnManager
interface for fetching known node addresses.