### PR TITLE
Nullable optional JSON-RPC parameters

### DIFF
--- a/btcjson/cmdparse_test.go
+++ b/btcjson/cmdparse_test.go
@@ -162,6 +162,18 @@ func TestAssignField(t *testing.T) {
 			src:      `{"1Address":1.5}`,
 			expected: map[string]float64{"1Address": 1.5},
 		},
+		{
+			name:     `null optional field - "null" -> *int32`,
+			dest:     btcjson.Int32(0),
+			src:      "null",
+			expected: nil,
+		},
+		{
+			name:     `null optional field - "null" -> *string`,
+			dest:     btcjson.String(""),
+			src:      "null",
+			expected: nil,
+		},
 	}
 
 	t.Logf("Running %d tests", len(tests))
@@ -172,6 +184,15 @@ func TestAssignField(t *testing.T) {
 		if err != nil {
 			t.Errorf("Test #%d (%s) unexpected error: %v", i,
 				test.name, err)
+			continue
+		}
+
+		// Check case where null string is used on optional field
+		if dst.Kind() == reflect.Ptr && test.src == "null" {
+			if !dst.IsNil() {
+				t.Errorf("Test #%d (%s) unexpected value - got %v, "+
+					"want nil", i, test.name, dst.Interface())
+			}
 			continue
 		}
 
@@ -396,6 +417,59 @@ func TestNewCmdErrors(t *testing.T) {
 			t.Errorf("Test #%d (%s) mismatched error code - got "+
 				"%v (%v), want %v", i, test.name, gotErrorCode,
 				err, test.err.ErrorCode)
+			continue
+		}
+	}
+}
+
+// TestMarshalCmd tests the MarshalCmd function.
+func TestMarshalCmd(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		id       interface{}
+		cmd      interface{}
+		expected string
+	}{
+		{
+			name:     "include all parameters",
+			id:       1,
+			cmd:      btcjson.NewGetNetworkHashPSCmd(btcjson.Int(100), btcjson.Int(2000)),
+			expected: `{"jsonrpc":"1.0","method":"getnetworkhashps","params":[100,2000],"id":1}`,
+		},
+		{
+			name:     "include padding null parameter",
+			id:       1,
+			cmd:      btcjson.NewGetNetworkHashPSCmd(nil, btcjson.Int(2000)),
+			expected: `{"jsonrpc":"1.0","method":"getnetworkhashps","params":[null,2000],"id":1}`,
+		},
+		{
+			name:     "omit single unnecessary null parameter",
+			id:       1,
+			cmd:      btcjson.NewGetNetworkHashPSCmd(btcjson.Int(100), nil),
+			expected: `{"jsonrpc":"1.0","method":"getnetworkhashps","params":[100],"id":1}`,
+		},
+		{
+			name:     "omit unnecessary null parameters",
+			id:       1,
+			cmd:      btcjson.NewGetNetworkHashPSCmd(nil, nil),
+			expected: `{"jsonrpc":"1.0","method":"getnetworkhashps","params":[],"id":1}`,
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		bytes, err := btcjson.MarshalCmd(test.id, test.cmd)
+		if err != nil {
+			t.Errorf("Test #%d (%s) wrong error - got %T (%v)",
+				i, test.name, err, err)
+			continue
+		}
+		marshalled := string(bytes)
+		if marshalled != test.expected {
+			t.Errorf("Test #%d (%s) mismatched marshall result - got "+
+				"%v, want %v", i, test.name, marshalled, test.expected)
 			continue
 		}
 	}


### PR DESCRIPTION
### Command marshalling null value
Fixes command marshalling dropping params that follow params with `nil` value. For instance the command:
```
btcjson.NewGetNetworkHashPSCmd(nil, btcjson.Int(2000))
```
Would previously marshall with empty params: `"params":[]`. Now the second optional parameter is included and padded with a `null` value: `"params":[null,2000]`.

The JSON-RPC server will substitute `null` values with the command's default values where possible.

### Command line null value
#1591 Allows providing `null` value from command line (similarly to Core command line utility):
```
btcctl getnetworkhashps null 10000
```

### Rationale

`getchaintxstats` is a good example where the ability to provide `null` parameter is especially critical. Default value of the first optional parameter is only known server-side. The fix in marshalling allows taking full advantage of default values of all commands in both `rpcclient` and command line.

In command line the ability to provide `null` not only unlocks all default values but also simplifies and allows for cleaner CLI usage.

This implementation does seem right however I haven't used Golang `reflect` all that much.