### PR TITLE
GitHub Actions: Enable Go Race detector and code coverage

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -25,3 +25,8 @@ jobs:
           GO111MODULE: "on"
         run: |
           sh ./goclean.sh
+
+      - name: Send coverage
+        uses: shogo82148/actions-goveralls@v1
+        with:
+          path-to-profile: profile.cov

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+# Code coverage files
+profile.tmp
+profile.cov

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ btcd
 ====
 
 [![Build Status](https://github.com/btcsuite/btcd/workflows/Build%20and%20Test/badge.svg)](https://github.com/btcsuite/btcd/actions)
+[![Coverage Status](https://coveralls.io/repos/github/btcsuite/btcd/badge.svg?branch=master)](https://coveralls.io/github/btcsuite/btcd?branch=master)
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://godoc.org/github.com/btcsuite/btcd)
 

--- a/goclean.sh
+++ b/goclean.sh
@@ -4,11 +4,12 @@
 # 3. go vet        (http://golang.org/cmd/vet)
 # 4. gosimple      (https://github.com/dominikh/go-simple)
 # 5. unconvert     (https://github.com/mdempsky/unconvert)
-#
+# 6. race detector (http://blog.golang.org/race-detector)
+# 7. test coverage (http://blog.golang.org/cover)
 
 set -ex
 
-go test -tags="rpctest" ./...
+env GORACE="halt_on_error=1" go test -race -tags="rpctest" -covermode atomic -coverprofile=profile.cov ./...
 
 # Automatic checks
 golangci-lint run --deadline=10m --disable-all \


### PR DESCRIPTION
This modifies the `goclean.sh` script to run tests with the race detector enabled. It also enables code coverage, and uploads the results to coveralls.io.

Running tests with `-race` and `-cover` flags was disabled in 6487ba1 and 6788df7 respectively, due to some limits on time/goroutines being hit on Travis CI. Since we have migrated to GitHub Actions, and don't have those same limitations, it is desirable to enable them back.

I have also simplified the way we run code coverage in the `goclean.sh` file, by launching it directly with `go test  ...`. I'm using `-covermode atomic` flag, which is the recommended setting for running with the race detector.

Here's the coverage report on my fork: https://coveralls.io/builds/31944135