### PR TITLE
btcec: Avoid panic in fieldVal.SetByteSlice for large inputs

### DIFF
--- a/btcec/field.go
+++ b/btcec/field.go
@@ -226,20 +226,24 @@ func (f *fieldVal) SetBytes(b *[32]byte) *fieldVal {
 	return f
 }
 
-// SetByteSlice packs the passed big-endian value into the internal field value
-// representation.  Only the first 32-bytes are used.  As a result, it is up to
-// the caller to ensure numbers of the appropriate size are used or the value
-// will be truncated.
+// SetByteSlice interprets the provided slice as a 256-bit big-endian unsigned
+// integer (meaning it is truncated to the first 32 bytes), packs it into the
+// internal field value representation, and returns the updated field value.
+//
+// Note that since passing a slice with more than 32 bytes is truncated, it is
+// possible that the truncated value is less than the field prime.  It is up to
+// the caller to decide whether it needs to provide numbers of the appropriate
+// size or if it is acceptable to use this function with the described
+// truncation behavior.
 //
 // The field value is returned to support chaining.  This enables syntax like:
 // f := new(fieldVal).SetByteSlice(byteSlice)
 func (f *fieldVal) SetByteSlice(b []byte) *fieldVal {
 	var b32 [32]byte
-	for i := 0; i < len(b); i++ {
-		if i < 32 {
-			b32[i+(32-len(b))] = b[i]
-		}
+	if len(b) > 32 {
+		b = b[:32]
 	}
+	copy(b32[32-len(b):], b)
 	return f.SetBytes(&b32)
 }
 


### PR DESCRIPTION
## Summary

The implementation has been adapted from the dcrec module in dcrd. The bug was initially fixed in decred/dcrd@3d9cda1 while transitioning to a constant time algorithm. A large set of test vectors were subsequently added in decred/dcrd@8c6b52d.

The function signature has been preserved for backwards compatibility. This means that returning whether the value has overflowed, and the corresponding test vectors have not been backported.

This fixes #1170 and closes a previous attempt to fix the bug in #1178.

## Benchmarks

With changes from #1178:

```
benchmark                              iter     time/iter
---------                              ----     ---------
BenchmarkFieldVal_SetByteSlice-8   27170966   40.60 ns/op
```

With this PR:  (~2.8 times faster)

```
benchmark                              iter     time/iter
---------                              ----     ---------
BenchmarkFieldVal_SetByteSlice-8   72301308   14.60 ns/op
```