### PR TITLE
config+service_windows: add flag to disable win service

### DIFF
--- a/config.go
+++ b/config.go
@@ -132,6 +132,7 @@ type config struct {
 	NoOnion              bool          `long:"noonion" description:"Disable connecting to tor hidden services"`
 	NoPeerBloomFilters   bool          `long:"nopeerbloomfilters" description:"Disable bloom filtering support"`
 	NoRelayPriority      bool          `long:"norelaypriority" description:"Do not require free or low-fee transactions to have high priority for relaying"`
+	NoWinService         bool          `long:"nowinservice" description:"Do not start as a background service on Windows -- NOTE: This flag only works on the command line, not in the config file"`
 	DisableRPC           bool          `long:"norpc" description:"Disable built-in RPC server -- NOTE: The RPC server is disabled by default if no rpcuser/rpcpass or rpclimituser/rpclimitpass is specified"`
 	DisableTLS           bool          `long:"notls" description:"Disable TLS for the RPC server -- NOTE: This is only allowed if the RPC server is bound to localhost"`
 	OnionProxy           string        `long:"onion" description:"Connect to tor hidden services via SOCKS5 proxy (eg. 127.0.0.1:9050)"`

--- a/service_windows.go
+++ b/service_windows.go
@@ -275,6 +275,22 @@ func performServiceCommand(command string) error {
 // returned to the caller so the application can determine whether to exit (when
 // running as a service) or launch in normal interactive mode.
 func serviceMain() (bool, error) {
+	// Don't run as a service if the user explicitly requested it. This is
+	// needed to run btcd on Windows in CI environments like Travis.
+	// We can't use the config struct to access the value because that's not
+	// parsed yet. But we add the flag to the struct anyway so the parser
+	// won't complain about it later.
+	noService := false
+	for _, arg := range os.Args {
+		if arg == "--nowinservice" {
+			noService = true
+			break
+		}
+	}
+	if noService {
+		return false, nil
+	}
+
 	// Don't run as a service if we're running interactively (or that can't
 	// be determined due to an error).
 	isInteractive, err := svc.IsAnInteractiveSession()


### PR DESCRIPTION
To run integration tests with `btcd` on Windows in non-interactive
environments (such as the Travis build with Windows machines), we
need to make sure we can still spawn a child process instead of only a
windows background service.

For this, we add a new command line flag called `--nowinservice` to disable creating and starting a windows service instead of running a child process.