### PR TITLE
rpcserver: add parity with bitcoind for validateaddress

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -671,9 +671,17 @@ type TxRawDecodeResult struct {
 
 // ValidateAddressChainResult models the data returned by the chain server
 // validateaddress command.
+//
+// Compared to the Bitcoin Core version, this struct lacks the scriptPubKey
+// field since it requires wallet access, which is outside the scope of btcd.
+// Ref: https://bitcoincore.org/en/doc/0.20.0/rpc/util/validateaddress/
 type ValidateAddressChainResult struct {
-	IsValid bool   `json:"isvalid"`
-	Address string `json:"address,omitempty"`
+	IsValid        bool    `json:"isvalid"`
+	Address        string  `json:"address,omitempty"`
+	IsScript       *bool   `json:"isscript,omitempty"`
+	IsWitness      *bool   `json:"iswitness,omitempty"`
+	WitnessVersion *int32  `json:"witness_version,omitempty"`
+	WitnessProgram *string `json:"witness_program,omitempty"`
 }
 
 // EstimateSmartFeeResult models the data returned buy the chain server

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3493,6 +3493,37 @@ func handleValidateAddress(s *rpcServer, cmd interface{}, closeChan <-chan struc
 		return result, nil
 	}
 
+	switch addr := addr.(type) {
+	case *btcutil.AddressPubKeyHash:
+		result.IsScript = btcjson.Bool(false)
+		result.IsWitness = btcjson.Bool(false)
+
+	case *btcutil.AddressScriptHash:
+		result.IsScript = btcjson.Bool(true)
+		result.IsWitness = btcjson.Bool(false)
+
+	case *btcutil.AddressPubKey:
+		result.IsScript = btcjson.Bool(false)
+		result.IsWitness = btcjson.Bool(false)
+
+	case *btcutil.AddressWitnessPubKeyHash:
+		result.IsScript = btcjson.Bool(false)
+		result.IsWitness = btcjson.Bool(true)
+		result.WitnessVersion = btcjson.Int32(int32(addr.WitnessVersion()))
+		result.WitnessProgram = btcjson.String(hex.EncodeToString(addr.WitnessProgram()))
+
+	case *btcutil.AddressWitnessScriptHash:
+		result.IsScript = btcjson.Bool(true)
+		result.IsWitness = btcjson.Bool(true)
+		result.WitnessVersion = btcjson.Int32(int32(addr.WitnessVersion()))
+		result.WitnessProgram = btcjson.String(hex.EncodeToString(addr.WitnessProgram()))
+
+	default:
+		// Handle the case when a new Address is supported by btcutil, but none
+		// of the cases were matched in the switch block. The current behaviour
+		// is to do nothing, and only populate the Address and IsValid fields.
+	}
+
 	result.Address = addr.EncodeAddress()
 	result.IsValid = true
 

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -575,8 +575,12 @@ var helpDescsEnUS = map[string]string{
 	"submitblock--result1":    "The reason the block was rejected",
 
 	// ValidateAddressResult help.
-	"validateaddresschainresult-isvalid": "Whether or not the address is valid",
-	"validateaddresschainresult-address": "The bitcoin address (only when isvalid is true)",
+	"validateaddresschainresult-isvalid":         "Whether or not the address is valid",
+	"validateaddresschainresult-address":         "The bitcoin address (only when isvalid is true)",
+	"validateaddresschainresult-isscript":        "If the key is a script",
+	"validateaddresschainresult-iswitness":       "If the address is a witness address",
+	"validateaddresschainresult-witness_version": "The version number of the witness program",
+	"validateaddresschainresult-witness_program": "The hex value of the witness program",
 
 	// ValidateAddressCmd help.
 	"validateaddress--synopsis": "Verify an address is valid.",


### PR DESCRIPTION
### What is this about?

Updated the `rpcserver` handler for [**`validateaddress`**](https://bitcoincore.org/en/doc/0.20.0/rpc/util/validateaddress/) JSON-RPC command to have parity with the bitcoind 0.20.0 interface.

The new fields included are - `isscript`, `iswitness`, `witness_version`, and `witness_program`. The `scriptPubKey` field has been left out since it requires wallet access.

This update has no impact on the `rpcclient.ValidateAddress` method, which uses the `btcjson.ValidateAddressWalletResult` type for modelling the response from bitcoind.

### How to test?

Unfortunately, we lack a proper framework to write rpcserver tests, so here's you can test this PR:

#### Prepare

```sh
$ go build .
$ ./btcd --testnet --rpcuser=aaaa --rpcpass=bbbb
```

In another tab,

```sh
$ cd cmd/btcctl
$ go build .
```

#### P2PKH valid

```sh
$ ./btcctl --testnet --rpcuser=aaaa --rpcpass=bbbb validateaddress mkpZhYtJu2r87Js3pDiWJDmPte2NRZ8bJV
{
  "isvalid": true,
  "address": "mkpZhYtJu2r87Js3pDiWJDmPte2NRZ8bJV",
  "isscript": false,
  "iswitness": false
}
```

#### P2SH-P2WPKH valid

```sh
$ ./btcctl --testnet --rpcuser=aaaa --rpcpass=bbbb validateaddress 2N4Q5FhU2497BryFfUgbqkAJE87aKHUhXMp
{
  "isvalid": true,
  "address": "2N4Q5FhU2497BryFfUgbqkAJE87aKHUhXMp",
  "isscript": true,
  "iswitness": false
}
```

#### P2WPKH valid

```sh
$ ./btcctl --testnet --rpcuser=aaaa --rpcpass=bbbb validateaddress tb1qkwgskuzmmwwvqajnyr7yp9hgvh5y45kg8wvdmd
{
  "isvalid": true,
  "address": "tb1qkwgskuzmmwwvqajnyr7yp9hgvh5y45kg8wvdmd",
  "isscript": false,
  "iswitness": true,
  "witness_version": 0,
  "witness_program": "b3910b705bdb9cc0765320fc4096e865e84ad2c8"
}
```

#### Invalid address

```sh
$ ./btcctl --testnet --rpcuser=aaaa --rpcpass=bbbb validateaddress deadbeef
{
  "isvalid": false
}
```

#### Invalid network

```sh
$ ./btcctl --testnet --rpcuser=aaaa --rpcpass=bbbb validateaddress 1MirQ9bwyQcGVJPwKUgapu5ouK2E2Ey4gX
{
  "isvalid": false
}
```