### PR TITLE
Improve gc for isunspendable method

### DIFF
--- a/txscript/script_test.go
+++ b/txscript/script_test.go
@@ -4301,6 +4301,28 @@ func TestIsUnspendable(t *testing.T) {
 				0xfa, 0x0b, 0x5c, 0x88, 0xac},
 			expected: false,
 		},
+		{
+			// Spendable
+			pkScript: []byte{0xa9, 0x14, 0x82, 0x1d, 0xba, 0x94, 0xbc, 0xfb,
+				0xa2, 0x57, 0x36, 0xa3, 0x9e, 0x5d, 0x14, 0x5d, 0x69, 0x75,
+				0xba, 0x8c, 0x0b, 0x42, 0x87},
+			expected: false,
+		},
+		{
+			// Not Necessarily Unspendable
+			pkScript: []byte{},
+			expected: false,
+		},
+		{
+			// Spendable
+			pkScript: []byte{OP_TRUE},
+			expected: false,
+		},
+		{
+			// Unspendable
+			pkScript: []byte{OP_RETURN},
+			expected: true,
+		},
 	}
 
 	for i, test := range tests {
@@ -4310,5 +4332,18 @@ func TestIsUnspendable(t *testing.T) {
 				i, res, test.expected)
 			continue
 		}
+	}
+}
+
+// BenchmarkIsUnspendable adds a benchmark to compare the time and allocations
+// necessary for the IsUnspendable function.
+func BenchmarkIsUnspendable(b *testing.B) {
+	pkScriptToUse := []byte{0xa9, 0x14, 0x82, 0x1d, 0xba, 0x94, 0xbc, 0xfb, 0xa2, 0x57, 0x36, 0xa3, 0x9e, 0x5d, 0x14, 0x5d, 0x69, 0x75, 0xba, 0x8c, 0x0b, 0x42, 0x87}
+	var res bool = false
+	for i := 0; i < b.N; i++ {
+		res = IsUnspendable(pkScriptToUse)
+	}
+	if res {
+		b.Fatalf("Benchmark should never have res be %t\n", res)
 	}
 }


### PR DESCRIPTION
Through profiling, I've found that the `IsUnspendable` method is a large source of allocations during the sync process.
<!-- through UTXO view methods which eventually call [`addTxOut`](https://github.com/btcsuite/btcd/blob/1db1b6f8217f5b489505c5c7e5235b53a7484779/blockchain/utxoviewpoint.go#L166) and mempool methods which eventually call [`isDust`](https://github.com/btcsuite/btcd/blob/1db1b6f8217f5b489505c5c7e5235b53a7484779/mempool/policy.go#L180). -->
<!-- The above statement isn't super clear as to why the method is used a lot in the sync process, keeping as a comment -->
In an effort to reduce the allocations made by this method, and in the sync process overall, I've simply removed the part of `parseScriptTemplate` which allocates and appends to an array (which never ends up being used by `IsUnspendable`) and pointed `IsUnspendable` to that method, called `checkScriptTemplateParseable`.

To show that this actually did reduce the allocations (and runtime) of the `IsUnspendable` method, I've created a benchmark and run it on both versions of the code, once on the [`e761244`](https://github.com/btcsuite/btcd/commit/e7612446051c390a4372d7604029b1eaff8a7f1d) commit, and once on the [`0963732`](https://github.com/btcsuite/btcd/commit/096373242c26946aabaf87f554003675aed6dfcd) commit.
I used the command on the older commit:
```
go test -v -bench=BenchmarkIsUnspendable -run=^\$ -benchmem -benchtime 10s -count 30 >> ~/unspendableold.txt
```
I then used this command on the newer commit:
```
go test -v -bench=BenchmarkIsUnspendable -run=^\$ -benchmem -benchtime 10s -count 30 >> ~/unspendablenew.txt
```


After running these, `benchstat` yielded the following result:
```
name             old time/op    new time/op    delta
IsUnspendable-8     283ns ± 3%      47ns ± 2%  -83.34%  (p=0.000 n=28+27)

name             old alloc/op   new alloc/op   delta
IsUnspendable-8      768B ± 0%       32B ± 0%  -95.83%  (p=0.000 n=30+30)

name             old allocs/op  new allocs/op  delta
IsUnspendable-8      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```
The benchtime and count in my benchmarks are unnecessarily high, I get similar results with a lower count and deleted benchtime parameter:
```
go test -v -bench=BenchmarkIsUnspendable -run=^\$ -benchmem -count 10 >> ~/unspendablenew.txt
```

This shows that in at least my benchmarks, the allocations and runtime of this method were significantly reduced.
In the future we should definitely backport changes from [dcrd #1656](https://github.com/decred/dcrd/pull/1656) (I will make an issue for this), but that would be a massive PR to consensus critical code, would likely need to be adapted, and the improvements for this method seem good enough for a single, easily reviewable PR.
The point of this PR is to:
1. Improve allocations of `IsUnspendable`.
2. Show that there is significant work to be done on the `txscript` package, and it would go a very long way towards improving the sync time if we focus on performance using benchmarking and profiling tools.

This is a draft right now because a test isn't passing but this will be fixed soon.

Backporting the benchmark changes would be a great future addition in itself, and hopefully this PR highlights this.