### PR TITLE
chaincfg: Add RegisterHDKeyID func to populate HD key ID pairs

### DIFF
--- a/chaincfg/params_test.go
+++ b/chaincfg/params_test.go
@@ -4,7 +4,10 @@
 
 package chaincfg
 
-import "testing"
+import (
+	"bytes"
+	"testing"
+)
 
 // TestInvalidHashStr ensures the newShaHashFromStr function panics when used to
 // with an invalid hash string.
@@ -32,4 +35,52 @@ func TestMustRegisterPanic(t *testing.T) {
 
 	// Intentionally try to register duplicate params to force a panic.
 	mustRegister(&MainNetParams)
+}
+
+func TestRegisterHDKeyID(t *testing.T) {
+	t.Parallel()
+
+	// Ref: https://github.com/satoshilabs/slips/blob/master/slip-0132.md
+	hdKeyIDZprv := []byte{0x02, 0xaa, 0x7a, 0x99}
+	hdKeyIDZpub := []byte{0x02, 0xaa, 0x7e, 0xd3}
+
+	if err := RegisterHDKeyID(hdKeyIDZpub, hdKeyIDZprv); err != nil {
+		t.Fatalf("RegisterHDKeyID: expected no error, got %v", err)
+	}
+
+	got, err := HDPrivateKeyToPublicKeyID(hdKeyIDZprv)
+	if err != nil {
+		t.Fatalf("HDPrivateKeyToPublicKeyID: expected no error, got %v", err)
+	}
+
+	if !bytes.Equal(got, hdKeyIDZpub) {
+		t.Fatalf("HDPrivateKeyToPublicKeyID: expected result %v, got %v",
+			hdKeyIDZpub, got)
+	}
+}
+
+func TestInvalidHDKeyID(t *testing.T) {
+	t.Parallel()
+
+	prvValid := []byte{0x02, 0xaa, 0x7a, 0x99}
+	pubValid := []byte{0x02, 0xaa, 0x7e, 0xd3}
+	prvInvalid := []byte{0x00}
+	pubInvalid := []byte{0x00}
+
+	if err := RegisterHDKeyID(pubInvalid, prvValid); err != ErrInvalidHDKeyID {
+		t.Fatalf("RegisterHDKeyID: want err ErrInvalidHDKeyID, got %v", err)
+	}
+
+	if err := RegisterHDKeyID(pubValid, prvInvalid); err != ErrInvalidHDKeyID {
+		t.Fatalf("RegisterHDKeyID: want err ErrInvalidHDKeyID, got %v", err)
+	}
+
+	if err := RegisterHDKeyID(pubInvalid, prvInvalid); err != ErrInvalidHDKeyID {
+		t.Fatalf("RegisterHDKeyID: want err ErrInvalidHDKeyID, got %v", err)
+	}
+
+	// FIXME: The error type should be changed to ErrInvalidHDKeyID.
+	if _, err := HDPrivateKeyToPublicKeyID(prvInvalid); err != ErrUnknownHDKeyID {
+		t.Fatalf("HDPrivateKeyToPublicKeyID: want err ErrUnknownHDKeyID, got %v", err)
+	}
 }


### PR DESCRIPTION
|Issue|https://github.com/btcsuite/btcutil/issues/179|
-|-

This is a first step towards allowing library packages (such as [btcutil](https://github.com/btcsuite/btcutil), but not limited to it) to register [**`SLIP-0132`**](https://github.com/satoshilabs/slips/blob/master/slip-0132.md) (or custom) HD version bytes. The version bytes itself are not included in this PR; it simply provides a public function to populate them.

Currently, the only way to register HD version bytes is by initializing `chaincfg.Params` struct, and registering it during package init. `RegisterHDKeyID` provides a way to populate custom HD version bytes, without having to create new `chaincfg.Params` instances. This is useful for library packages who want to use non-standard version bytes for serializing extended keys, such as the ones documented in SLIP-0132.

This function is complementary to `HDPrivateKeyToPublicKeyID`, which is used to lookup previously registered key IDs.