### PR TITLE
add clang support to goclean.sh

### DIFF
--- a/goclean.sh
+++ b/goclean.sh
@@ -8,6 +8,32 @@
 
 set -ex
 
+# Check if we have gcc, if not then use clang, else exit. More compilers can be
+# added if needed.
+if command -v gcc &> /dev/null
+then
+
+    export CC=gcc
+
+elif command -v clang &> /dev/null
+then
+
+    export CC=clang
+
+else
+
+    echo "neither gcc nor clang are in the PATH (they may not be installed),
+    btcd will not compile due to cgo requiring a C compiler, exiting..."
+    exit
+
+fi
+
+if ! command -v golangci-lint &> /dev/null
+then
+    echo "golangci-lint is not in the PATH, it will not run, exiting..."
+    exit
+fi
+
 go test -tags="rpctest" ./...
 
 # Automatic checks


### PR DESCRIPTION
I recently switched to a setup without gcc, only clang, so I added some checks in the `goclean.sh` script to check whether or not clang or gcc are in the PATH.