### PR TITLE
btcd: fix conversion of int to string failing in Go 1.15

### DIFF
--- a/btcjson/cmdparse_test.go
+++ b/btcjson/cmdparse_test.go
@@ -201,7 +201,7 @@ func TestAssignFieldErrors(t *testing.T) {
 	}{
 		{
 			name: "general incompatible int -> string",
-			dest: string(0),
+			dest: "\x00",
 			src:  int(0),
 			err:  btcjson.Error{ErrorCode: btcjson.ErrInvalidType},
 		},

--- a/upnp.go
+++ b/upnp.go
@@ -36,6 +36,7 @@ import (
 	"bytes"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
 	"os"
@@ -229,7 +230,7 @@ func getServiceURL(rootURL string) (url string, err error) {
 	}
 	defer r.Body.Close()
 	if r.StatusCode >= 400 {
-		err = errors.New(string(r.StatusCode))
+		err = errors.New(fmt.Sprint(r.StatusCode))
 		return
 	}
 	var root root

--- a/wire/message.go
+++ b/wire/message.go
@@ -213,7 +213,7 @@ func readMessageHeader(r io.Reader) (int, *messageHeader, error) {
 	readElements(hr, &hdr.magic, &command, &hdr.length, &hdr.checksum)
 
 	// Strip trailing zeros from command string.
-	hdr.command = string(bytes.TrimRight(command[:], string(0)))
+	hdr.command = string(bytes.TrimRight(command[:], "\x00"))
 
 	return n, &hdr, nil
 }


### PR DESCRIPTION
Without this, `btcd` fails to build in Go 1.15 with the following message:
````
./upnp.go:232:20: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
````