### PR TITLE
ci: add go 1.15 to tests

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [1.13, 1.14]
+        go: [1.14, 1.15]
     steps:
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ which are both under active development.
 
 ## Requirements
 
-[Go](http://golang.org) 1.12 or newer.
+[Go](http://golang.org) 1.14 or newer.
 
 ## Installation
 

--- a/go.mod
+++ b/go.mod
@@ -14,4 +14,4 @@ require (
 	golang.org/x/crypto v0.0.0-20200510223506-06a226fb4e37
 )
 
-go 1.12
+go 1.14

--- a/release/README.md
+++ b/release/README.md
@@ -3,10 +3,7 @@
 This package contains the build script that the `btcd` project uses in order to
 build binaries for each new release. As of `go1.13`, with some new build flags,
 binaries are now reproducible, allowing developers to build the binary on
-distinct machines, and end up with a byte-for-byte identical binary. However,
-this wasn't _fully_ solved in `go1.13`, as the build system still includes the
-directory the binary is built into the binary itself. As a result, our scripts
-utilize a work around needed until `go1.13.2`.
+distinct machines, and end up with a byte-for-byte identical binary.
 Every release should note which Go version was used to build the release, so
 that version should be used for verifying the release.
 

--- a/release/release.sh
+++ b/release/release.sh
@@ -39,7 +39,6 @@ cd $MAINDIR
 # If BTCDBUILDSYS is set the default list is ignored. Useful to release
 # for a subset of systems/architectures.
 SYS=${BTCDBUILDSYS:-"
-        darwin-386
         darwin-amd64
         dragonfly-amd64
         freebsd-386


### PR DESCRIPTION
Note: this requires #1619 before it can be merged. 