### PR TITLE
btcd+netsync: support witness tx and block in notfound msg

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1031,11 +1031,16 @@ func (sm *SyncManager) handleNotFoundMsg(nfmsg *notFoundMsg) {
 		// verify the hash was actually announced by the peer
 		// before deleting from the global requested maps.
 		switch inv.Type {
+		case wire.InvTypeWitnessBlock:
+			fallthrough
 		case wire.InvTypeBlock:
 			if _, exists := state.requestedBlocks[inv.Hash]; exists {
 				delete(state.requestedBlocks, inv.Hash)
 				delete(sm.requestedBlocks, inv.Hash)
 			}
+
+		case wire.InvTypeWitnessTx:
+			fallthrough
 		case wire.InvTypeTx:
 			if _, exists := state.requestedTxns[inv.Hash]; exists {
 				delete(state.requestedTxns, inv.Hash)

--- a/server.go
+++ b/server.go
@@ -1321,7 +1321,11 @@ func (sp *serverPeer) OnNotFound(p *peer.Peer, msg *wire.MsgNotFound) {
 		switch inv.Type {
 		case wire.InvTypeBlock:
 			numBlocks++
+		case wire.InvTypeWitnessBlock:
+			numBlocks++
 		case wire.InvTypeTx:
+			numTxns++
+		case wire.InvTypeWitnessTx:
 			numTxns++
 		default:
 			peerLog.Debugf("Invalid inv type '%d' in notfound message from %s",


### PR DESCRIPTION
When handling `MsgNotFound`, it's missing the check on `wire.InvTypeWitnessBlock` and `wire.InvTypeWitnessTx`. This PR fixes it.