### PR TITLE
Remove unnecessary GOMAXPROCS function calls

### DIFF
--- a/blockchain/scriptval_test.go
+++ b/blockchain/scriptval_test.go
@@ -6,7 +6,6 @@ package blockchain
 
 import (
 	"fmt"
-	"runtime"
 	"testing"
 
 	"github.com/btcsuite/btcd/txscript"
@@ -15,8 +14,6 @@ import (
 // TestCheckBlockScripts ensures that validating the all of the scripts in a
 // known-good block doesn't return an error.
 func TestCheckBlockScripts(t *testing.T) {
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	testBlockNum := 277647
 	blockDataFile := fmt.Sprintf("%d.dat.bz2", testBlockNum)
 	blocks, err := loadBlocks(blockDataFile)

--- a/btcd.go
+++ b/btcd.go
@@ -297,9 +297,6 @@ func loadBlockDB() (database.DB, error) {
 }
 
 func main() {
-	// Use all processor cores.
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	// Block and transaction processing can cause bursty allocations.  This
 	// limits the garbage collector from excessively overallocating during
 	// bursts.  This value was arrived at with the help of profiling live

--- a/cmd/addblock/addblock.go
+++ b/cmd/addblock/addblock.go
@@ -7,7 +7,6 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/blockchain/indexers"
@@ -119,8 +118,7 @@ func realMain() error {
 }
 
 func main() {
-	// Use all processor cores and up some limits.
-	runtime.GOMAXPROCS(runtime.NumCPU())
+	// up some limits.
 	if err := limits.SetLimits(); err != nil {
 		os.Exit(1)
 	}

--- a/database/cmd/dbtool/main.go
+++ b/database/cmd/dbtool/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/btcsuite/btcd/database"
@@ -106,9 +105,6 @@ func realMain() error {
 }
 
 func main() {
-	// Use all processor cores.
-	runtime.GOMAXPROCS(runtime.NumCPU())
-
 	// Work around defer not working after os.Exit()
 	if err := realMain(); err != nil {
 		os.Exit(1)

--- a/database/ffldb/driver_test.go
+++ b/database/ffldb/driver_test.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"testing"
 
 	"github.com/btcsuite/btcd/chaincfg"
@@ -278,7 +277,6 @@ func TestInterface(t *testing.T) {
 	}
 
 	// Run all of the interface tests against the database.
-	runtime.GOMAXPROCS(runtime.NumCPU())
 
 	// Change the maximum file size to a small value to force multiple flat
 	// files with the test data set.


### PR DESCRIPTION
According to [go 1.5 release notes](https://golang.org/doc/go1.5):

> By default, Go programs run with GOMAXPROCS set to the number of cores available; in prior releases it defaulted to 1.

There's no need anymore to call it with `runtime.NumCPU()` argument, it is now used as a default. Removed legacy `GOMAXPROCS` calls from the project.