### PR TITLE
rpcclient: support listtransactions RPC with watchonly argument

### DIFF
--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -164,6 +164,25 @@ func (c *Client) ListTransactionsCountFrom(account string, count, from int) ([]b
 	return c.ListTransactionsCountFromAsync(account, count, from).Receive()
 }
 
+// ListTransactionsCountFromWatchOnlyAsync returns an instance of a type that can be used
+// to get the result of the RPC at some future time by invoking the Receive
+// function on the returned instance.
+//
+// See ListTransactionsCountFromWatchOnly for the blocking version and more details.
+func (c *Client) ListTransactionsCountFromWatchOnlyAsync(account string, count, from int, watchOnly bool) FutureListTransactionsResult {
+	cmd := btcjson.NewListTransactionsCmd(&account, &count, &from, &watchOnly)
+	return c.sendCmd(cmd)
+}
+
+// ListTransactionsCountFromWatchOnly returns a list of the most recent transactions up
+// to the passed count while skipping the first 'from' transactions. It will include or
+// exclude transactions from watch-only addresses based on the passed value for the watchOnly parameter
+//
+// See the ListTransactions and ListTransactionsCount functions to use defaults.
+func (c *Client) ListTransactionsCountFromWatchOnly(account string, count, from int, watchOnly bool) ([]btcjson.ListTransactionsResult, error) {
+	return c.ListTransactionsCountFromWatchOnlyAsync(account, count, from, watchOnly).Receive()
+}
+
 // FutureListUnspentResult is a future promise to deliver the result of a
 // ListUnspentAsync, ListUnspentMinAsync, ListUnspentMinMaxAsync, or
 // ListUnspentMinMaxAddressesAsync RPC invocation (or an applicable error).


### PR DESCRIPTION
There are a total of 3 pull requests for the same thing - #1163, #1505, and #1368. This PR is just a rebase of #1163, which is more ready than the others.

Recommend doing a squash-and-merge, so that the PR title is used as the commit message.