### PR TITLE
rpcclient: implement getaddressinfo command

### DIFF
--- a/btcjson/walletsvrcmds.go
+++ b/btcjson/walletsvrcmds.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2014-2020 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -175,6 +175,19 @@ type GetAddressesByAccountCmd struct {
 func NewGetAddressesByAccountCmd(account string) *GetAddressesByAccountCmd {
 	return &GetAddressesByAccountCmd{
 		Account: account,
+	}
+}
+
+// GetAddressInfoCmd defines the getaddressinfo JSON-RPC command.
+type GetAddressInfoCmd struct {
+	Address string
+}
+
+// NewGetAddressInfoCmd returns a new instance which can be used to issue a
+// getaddressinfo JSON-RPC command.
+func NewGetAddressInfoCmd(address string) *GetAddressInfoCmd {
+	return &GetAddressInfoCmd{
+		Address: address,
 	}
 }
 
@@ -993,6 +1006,7 @@ func init() {
 	MustRegisterCmd("getaccount", (*GetAccountCmd)(nil), flags)
 	MustRegisterCmd("getaccountaddress", (*GetAccountAddressCmd)(nil), flags)
 	MustRegisterCmd("getaddressesbyaccount", (*GetAddressesByAccountCmd)(nil), flags)
+	MustRegisterCmd("getaddressinfo", (*GetAddressInfoCmd)(nil), flags)
 	MustRegisterCmd("getbalance", (*GetBalanceCmd)(nil), flags)
 	MustRegisterCmd("getbalances", (*GetBalancesCmd)(nil), flags)
 	MustRegisterCmd("getnewaddress", (*GetNewAddressCmd)(nil), flags)

--- a/btcjson/walletsvrcmds_test.go
+++ b/btcjson/walletsvrcmds_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2014 The btcsuite developers
+// Copyright (c) 2014-2020 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -207,6 +207,19 @@ func TestWalletSvrCmds(t *testing.T) {
 			marshalled: `{"jsonrpc":"1.0","method":"getaddressesbyaccount","params":["acct"],"id":1}`,
 			unmarshalled: &btcjson.GetAddressesByAccountCmd{
 				Account: "acct",
+			},
+		},
+		{
+			name: "getaddressinfo",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("getaddressinfo", "1234")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewGetAddressInfoCmd("1234")
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getaddressinfo","params":["1234"],"id":1}`,
+			unmarshalled: &btcjson.GetAddressInfoCmd{
+				Address: "1234",
 			},
 		},
 		{

--- a/btcjson/walletsvrresults_test.go
+++ b/btcjson/walletsvrresults_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2020 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package btcjson
+
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/davecgh/go-spew/spew"
+)
+
+// TestGetAddressInfoResult ensures that custom unmarshalling of
+// GetAddressInfoResult works as intended.
+func TestGetAddressInfoResult(t *testing.T) {
+	t.Parallel()
+
+	// arbitrary script class to use in tests
+	nonStandard, _ := txscript.NewScriptClass("nonstandard")
+
+	tests := []struct {
+		name    string
+		result  string
+		want    GetAddressInfoResult
+		wantErr error
+	}{
+		{
+			name:   "GetAddressInfoResult - no ScriptType",
+			result: `{}`,
+			want:   GetAddressInfoResult{},
+		},
+		{
+			name:   "GetAddressInfoResult - ScriptType",
+			result: `{"script":"nonstandard","address":"1abc"}`,
+			want: GetAddressInfoResult{
+				embeddedAddressInfo: embeddedAddressInfo{
+					Address:    "1abc",
+					ScriptType: nonStandard,
+				},
+			},
+		},
+		{
+			name:   "GetAddressInfoResult - embedded ScriptType",
+			result: `{"embedded": {"script":"nonstandard","address":"121313"}}`,
+			want: GetAddressInfoResult{
+				Embedded: &embeddedAddressInfo{
+					Address:    "121313",
+					ScriptType: nonStandard,
+				},
+			},
+		},
+		{
+			name:    "GetAddressInfoResult - invalid ScriptType",
+			result:  `{"embedded": {"script":"foo","address":"121313"}}`,
+			wantErr: txscript.ErrUnsupportedScriptType,
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		var out GetAddressInfoResult
+		err := json.Unmarshal([]byte(test.result), &out)
+		if err != nil && !errors.Is(err, test.wantErr) {
+			t.Errorf("Test #%d (%s) unexpected error: %v, want: %v", i,
+				test.name, err, test.wantErr)
+			continue
+		}
+
+		if !reflect.DeepEqual(out, test.want) {
+			t.Errorf("Test #%d (%s) unexpected unmarshalled data - "+
+				"got %v, want %v", i, test.name, spew.Sdump(out),
+				spew.Sdump(test.want))
+			continue
+		}
+	}
+}

--- a/rpcclient/example_test.go
+++ b/rpcclient/example_test.go
@@ -1,8 +1,11 @@
+// Copyright (c) 2020 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
 package rpcclient
 
 import (
 	"fmt"
-
 	"github.com/btcsuite/btcd/btcjson"
 )
 
@@ -76,4 +79,30 @@ func ExampleClient_DeriveAddresses() {
 
 	fmt.Printf("%+v\n", addrs)
 	// &[14NjenDKkGGq1McUgoSkeUHJpW3rrKLbPW 1Pn6i3cvdGhqbdgNjXHfbaYfiuviPiymXj 181x1NbgGYKLeMXkDdXEAqepG75EgU8XtG]
+}
+
+func ExampleClient_GetAddressInfo() {
+	connCfg = &ConnConfig{
+		Host:         "localhost:18332",
+		User:         "user",
+		Pass:         "pass",
+		HTTPPostMode: true,
+		DisableTLS:   true,
+	}
+
+	client, err := New(connCfg, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer client.Shutdown()
+
+	info, err := client.GetAddressInfo("2NF1FbxtUAsvdU4uW1UC2xkBVatp6cYQuJ3")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(info.Address)             // 2NF1FbxtUAsvdU4uW1UC2xkBVatp6cYQuJ3
+	fmt.Println(info.ScriptType.String()) // witness_v0_keyhash
+	fmt.Println(*info.HDKeyPath)          // m/49'/1'/0'/0/4
+	fmt.Println(info.Embedded.Address)    // tb1q3x2h2kh57wzg7jz00jhwn0ycvqtdk2ane37j27
 }

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2017 The btcsuite developers
+// Copyright (c) 2013-2020 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -58,6 +58,7 @@ const (
 	WitnessV0ScriptHashTy                    // Pay to witness script hash.
 	MultiSigTy                               // Multi signature.
 	NullDataTy                               // Empty data-only (provably prunable).
+	WitnessUnknownTy                         // Witness unknown
 )
 
 // scriptClassToName houses the human-readable strings which describe each
@@ -71,6 +72,7 @@ var scriptClassToName = []string{
 	WitnessV0ScriptHashTy: "witness_v0_scripthash",
 	MultiSigTy:            "multisig",
 	NullDataTy:            "nulldata",
+	WitnessUnknownTy:      "witness_unknown",
 }
 
 // String implements the Stringer interface by returning the name of
@@ -186,6 +188,22 @@ func GetScriptClass(script []byte) ScriptClass {
 		return NonStandardTy
 	}
 	return typeOfScript(pops)
+}
+
+// NewScriptClass returns the ScriptClass corresponding to the string name
+// provided as argument. ErrUnsupportedScriptType error is returned if the
+// name doesn't correspond to any known ScriptClass.
+//
+// Not to be confused with GetScriptClass.
+func NewScriptClass(name string) (*ScriptClass, error) {
+	for i, n := range scriptClassToName {
+		if n == name {
+			value := ScriptClass(i)
+			return &value, nil
+		}
+	}
+
+	return nil, fmt.Errorf("%w: %s", ErrUnsupportedScriptType, name)
 }
 
 // expectedInputs returns the number of arguments required by a script.

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2017 The btcsuite developers
+// Copyright (c) 2013-2020 The btcsuite developers
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
@@ -7,6 +7,7 @@ package txscript
 import (
 	"bytes"
 	"encoding/hex"
+	"errors"
 	"reflect"
 	"testing"
 
@@ -1211,5 +1212,42 @@ func TestNullDataScript(t *testing.T) {
 				test.class)
 			continue
 		}
+	}
+}
+
+// TestNewScriptClass tests whether NewScriptClass returns a valid ScriptClass.
+func TestNewScriptClass(t *testing.T) {
+	tests := []struct {
+		name       string
+		scriptName string
+		want       *ScriptClass
+		wantErr    error
+	}{
+		{
+			name:       "NewScriptClass - ok",
+			scriptName: NullDataTy.String(),
+			want: func() *ScriptClass {
+				s := NullDataTy
+				return &s
+			}(),
+		},
+		{
+			name:       "NewScriptClass - invalid",
+			scriptName: "foo",
+			wantErr:    ErrUnsupportedScriptType,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NewScriptClass(tt.scriptName)
+			if err != nil && !errors.Is(err, tt.wantErr) {
+				t.Errorf("NewScriptClass() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewScriptClass() got = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
| Docs | [getaddressinfo](https://bitcoincore.org/en/doc/0.20.0/rpc/wallet/getaddressinfo) |
-|-

Fields such as `label`, and `labels->purpose` are not included, since they are deprecated, and will be removed in Bitcoin Core 0.21.

Most of the fields in the results struct are repeated in the `embedded` field if (for example) the address itself is a script embedding another address. To have minimal code duplication, I have factored them out to a private struct.

Another noteworthy thing in this PR is the custom unmarshalling I did to support loading a `script` to a `txscript.ScriptClass`, without duplicating the entire struct with raw fields. I learnt about this technique in [this article](http://choly.ca/post/go-json-marshalling) if you want to read.

Tested locally with Bitcoin Core v0.20.1. See `rpcclient/example_test.go` for details.