### PR TITLE
rpcclient: implement getwalletinfo command

### DIFF
--- a/btcjson/walletsvrresults_test.go
+++ b/btcjson/walletsvrresults_test.go
@@ -78,3 +78,50 @@ func TestGetAddressInfoResult(t *testing.T) {
 		}
 	}
 }
+
+// TestGetWalletInfoResult ensures that custom unmarshalling of
+// GetWalletInfoResult works as intended.
+func TestGetWalletInfoResult(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		result string
+		want   GetWalletInfoResult
+	}{
+		{
+			name:   "GetWalletInfoResult - not scanning",
+			result: `{"scanning":false}`,
+			want: GetWalletInfoResult{
+				Scanning: ScanningOrFalse{Value: false},
+			},
+		},
+		{
+			name:   "GetWalletInfoResult - scanning",
+			result: `{"scanning":{"duration":10,"progress":1.0}}`,
+			want: GetWalletInfoResult{
+				Scanning: ScanningOrFalse{
+					Value: ScanProgress{Duration: 10, Progress: 1.0},
+				},
+			},
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		var out GetWalletInfoResult
+		err := json.Unmarshal([]byte(test.result), &out)
+		if err != nil {
+			t.Errorf("Test #%d (%s) unexpected error: %v", i,
+				test.name, err)
+			continue
+		}
+
+		if !reflect.DeepEqual(out, test.want) {
+			t.Errorf("Test #%d (%s) unexpected unmarshalled data - "+
+				"got %v, want %v", i, test.name, spew.Sdump(out),
+				spew.Sdump(test.want))
+			continue
+		}
+	}
+}

--- a/rpcclient/example_test.go
+++ b/rpcclient/example_test.go
@@ -82,14 +82,6 @@ func ExampleClient_DeriveAddresses() {
 }
 
 func ExampleClient_GetAddressInfo() {
-	connCfg = &ConnConfig{
-		Host:         "localhost:18332",
-		User:         "user",
-		Pass:         "pass",
-		HTTPPostMode: true,
-		DisableTLS:   true,
-	}
-
 	client, err := New(connCfg, nil)
 	if err != nil {
 		panic(err)
@@ -105,4 +97,22 @@ func ExampleClient_GetAddressInfo() {
 	fmt.Println(info.ScriptType.String()) // witness_v0_keyhash
 	fmt.Println(*info.HDKeyPath)          // m/49'/1'/0'/0/4
 	fmt.Println(info.Embedded.Address)    // tb1q3x2h2kh57wzg7jz00jhwn0ycvqtdk2ane37j27
+}
+
+func ExampleClient_GetWalletInfo() {
+	client, err := New(connCfg, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer client.Shutdown()
+
+	info, err := client.GetWalletInfo()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(info.WalletVersion)    // 169900
+	fmt.Println(info.TransactionCount) // 22
+	fmt.Println(*info.HDSeedID)        // eb44e4e9b864ef17e7ba947da746375b000f5d94
+	fmt.Println(info.Scanning.Value)   // false
 }


### PR DESCRIPTION
**Note to the reviewers:**
* The [official documentation](https://bitcoincore.org/en/doc/0.20.0/rpc/wallet/getwalletinfo/) is not accurate in pointing out the optional fields, so I'm relying on the [implementation in Bitcoin Core](https://github.com/bitcoin/bitcoin/blob/v0.20.1/src/wallet/rpcwallet.cpp#L2431-L2520).
* I have not included fields that have been deprecated and will be removed soon.