### PR TITLE
Fix getmininginfo unmarshal error

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -673,8 +673,8 @@ type GetMiningInfoResult struct {
 	Errors             string  `json:"errors"`
 	Generate           bool    `json:"generate"`
 	GenProcLimit       int32   `json:"genproclimit"`
-	HashesPerSec       int64   `json:"hashespersec"`
-	NetworkHashPS      int64   `json:"networkhashps"`
+	HashesPerSec       float64 `json:"hashespersec"`
+	NetworkHashPS      float64 `json:"networkhashps"`
 	PooledTx           uint64  `json:"pooledtx"`
 	TestNet            bool    `json:"testnet"`
 }

--- a/btcjson/chainsvrresults_test.go
+++ b/btcjson/chainsvrresults_test.go
@@ -9,11 +9,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcutil"
 	"github.com/davecgh/go-spew/spew"
-
-	"github.com/btcsuite/btcd/btcjson"
 )
 
 // TestChainSvrCustomResults ensures any results that have custom marshalling
@@ -153,6 +152,49 @@ func TestGetTxOutSetInfoResult(t *testing.T) {
 			t.Errorf("Test #%d (%s) unexpected unmarshalled data - "+
 				"got %v, want %v", i, test.name, spew.Sdump(out),
 				spew.Sdump(test.want))
+			continue
+		}
+	}
+}
+
+// TestChainSvrMiningInfoResults ensures GetMiningInfoResults are unmarshalled correctly
+func TestChainSvrMiningInfoResults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		result   string
+		expected btcjson.GetMiningInfoResult
+	}{
+		{
+			name:   "mining info with integer networkhashps",
+			result: `{"networkhashps": 89790618491361}`,
+			expected: btcjson.GetMiningInfoResult{
+				NetworkHashPS: 89790618491361,
+			},
+		},
+		{
+			name:   "mining info with scientific notation networkhashps",
+			result: `{"networkhashps": 8.9790618491361e+13}`,
+			expected: btcjson.GetMiningInfoResult{
+				NetworkHashPS: 89790618491361,
+			},
+		},
+	}
+
+	t.Logf("Running %d tests", len(tests))
+	for i, test := range tests {
+		var miningInfoResult btcjson.GetMiningInfoResult
+		err := json.Unmarshal([]byte(test.result), &miningInfoResult)
+		if err != nil {
+			t.Errorf("Test #%d (%s) unexpected error: %v", i,
+				test.name, err)
+			continue
+		}
+		if miningInfoResult != test.expected {
+			t.Errorf("Test #%d (%s) unexpected marhsalled data - "+
+				"got %+v, want %+v", i, test.name, miningInfoResult,
+				test.expected)
 			continue
 		}
 	}

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -2366,8 +2366,8 @@ func handleGetMiningInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 		Difficulty:         getDifficultyRatio(best.Bits, s.cfg.ChainParams),
 		Generate:           s.cfg.CPUMiner.IsMining(),
 		GenProcLimit:       s.cfg.CPUMiner.NumWorkers(),
-		HashesPerSec:       int64(s.cfg.CPUMiner.HashesPerSecond()),
-		NetworkHashPS:      networkHashesPerSec,
+		HashesPerSec:       s.cfg.CPUMiner.HashesPerSecond(),
+		NetworkHashPS:      float64(networkHashesPerSec),
 		PooledTx:           uint64(s.cfg.TxMemPool.Count()),
 		TestNet:            cfg.TestNet3,
 	}


### PR DESCRIPTION
Since JSON doesn't distinguish between ints and floats in its number type, Go will fail to decode valid integers in scientific notation as noted in #1458 

1. Added a unit test for this condition that fails before the fix and passes after
2. Verified that output values and format were unchanged when running `btcctl getmininginfo`