### PR TITLE
rpcclient: implement createwallet with functional options

### DIFF
--- a/btcjson/walletsvrcmds.go
+++ b/btcjson/walletsvrcmds.go
@@ -63,6 +63,28 @@ func NewCreateMultisigCmd(nRequired int, keys []string) *CreateMultisigCmd {
 	}
 }
 
+// CreateWalletCmd defines the createwallet JSON-RPC command.
+type CreateWalletCmd struct {
+	WalletName         string
+	DisablePrivateKeys *bool   `jsonrpcdefault:"false"`
+	Blank              *bool   `jsonrpcdefault:"false"`
+	Passphrase         *string `jsonrpcdefault:"\"\""`
+	AvoidReuse         *bool   `jsonrpcdefault:"false"`
+}
+
+// NewCreateWalletCmd returns a new instance which can be used to issue a
+// createwallet JSON-RPC command.
+func NewCreateWalletCmd(walletName string, disablePrivateKeys *bool,
+	blank *bool, passphrase *string, avoidReuse *bool) *CreateWalletCmd {
+	return &CreateWalletCmd{
+		WalletName:         walletName,
+		DisablePrivateKeys: disablePrivateKeys,
+		Blank:              blank,
+		Passphrase:         passphrase,
+		AvoidReuse:         avoidReuse,
+	}
+}
+
 // DumpPrivKeyCmd defines the dumpprivkey JSON-RPC command.
 type DumpPrivKeyCmd struct {
 	Address string
@@ -1065,6 +1087,7 @@ func init() {
 	MustRegisterCmd("addwitnessaddress", (*AddWitnessAddressCmd)(nil), flags)
 	MustRegisterCmd("backupwallet", (*BackupWalletCmd)(nil), flags)
 	MustRegisterCmd("createmultisig", (*CreateMultisigCmd)(nil), flags)
+	MustRegisterCmd("createwallet", (*CreateWalletCmd)(nil), flags)
 	MustRegisterCmd("dumpprivkey", (*DumpPrivKeyCmd)(nil), flags)
 	MustRegisterCmd("encryptwallet", (*EncryptWalletCmd)(nil), flags)
 	MustRegisterCmd("estimatesmartfee", (*EstimateSmartFeeCmd)(nil), flags)

--- a/btcjson/walletsvrcmds_test.go
+++ b/btcjson/walletsvrcmds_test.go
@@ -63,6 +63,61 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 		},
 		{
+			name: "createwallet",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("createwallet", "mywallet", true, true, "secret", true)
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewCreateWalletCmd("mywallet",
+					btcjson.Bool(true), btcjson.Bool(true),
+					btcjson.String("secret"), btcjson.Bool(true))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"createwallet","params":["mywallet",true,true,"secret",true],"id":1}`,
+			unmarshalled: &btcjson.CreateWalletCmd{
+				WalletName:         "mywallet",
+				DisablePrivateKeys: btcjson.Bool(true),
+				Blank:              btcjson.Bool(true),
+				Passphrase:         btcjson.String("secret"),
+				AvoidReuse:         btcjson.Bool(true),
+			},
+		},
+		{
+			name: "createwallet - optional1",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("createwallet", "mywallet")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewCreateWalletCmd("mywallet",
+					nil, nil, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"createwallet","params":["mywallet"],"id":1}`,
+			unmarshalled: &btcjson.CreateWalletCmd{
+				WalletName:         "mywallet",
+				DisablePrivateKeys: btcjson.Bool(false),
+				Blank:              btcjson.Bool(false),
+				Passphrase:         btcjson.String(""),
+				AvoidReuse:         btcjson.Bool(false),
+			},
+		},
+		{
+			name: "createwallet - optional2",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("createwallet", "mywallet", "null", "null", "secret")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewCreateWalletCmd("mywallet",
+					nil, nil, btcjson.String("secret"), nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"createwallet","params":["mywallet",null,null,"secret"],"id":1}`,
+			unmarshalled: &btcjson.CreateWalletCmd{
+				WalletName:         "mywallet",
+				DisablePrivateKeys: nil,
+				Blank:              nil,
+				Passphrase:         btcjson.String("secret"),
+				AvoidReuse:         btcjson.Bool(false),
+			},
+		},
+		{
 			name: "addwitnessaddress",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("addwitnessaddress", "1address")

--- a/btcjson/walletsvrresults.go
+++ b/btcjson/walletsvrresults.go
@@ -11,6 +11,12 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 )
 
+// CreateWalletResult models the result of the createwallet command.
+type CreateWalletResult struct {
+	Name    string `json:"name"`
+	Warning string `json:"warning"`
+}
+
 // embeddedAddressInfo includes all getaddressinfo output fields, excluding
 // metadata and relation to the wallet.
 //

--- a/rpcclient/example_test.go
+++ b/rpcclient/example_test.go
@@ -11,8 +11,8 @@ import (
 
 var connCfg = &ConnConfig{
 	Host:         "localhost:8332",
-	User:         "yourrpcuser",
-	Pass:         "yourrpcpass",
+	User:         "user",
+	Pass:         "pass",
 	HTTPPostMode: true,
 	DisableTLS:   true,
 }
@@ -134,4 +134,23 @@ func ExampleClient_GetTxOutSetInfo() {
 	fmt.Println(r.TxOuts)               // 24280607
 	fmt.Println(r.Transactions)         // 9285603
 	fmt.Println(r.DiskSize)             // 1320871611
+}
+
+func ExampleClient_CreateWallet() {
+	client, err := New(connCfg, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer client.Shutdown()
+
+	r, err := client.CreateWallet(
+		"mywallet",
+		WithCreateWalletBlank(),
+		WithCreateWalletPassphrase("secret"),
+	)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(r.Name) // mywallet
 }


### PR DESCRIPTION
Rebased on #1645, to avoid having to resolve merge conflicts later. This PR only implements `createwallet` as a first-step towards functional options.

### Background

I find the current way of dealing with optional parameters in RPC commands very hard to maintain, and also clunky from a user's perspective. We implement one rpcclient method per optional parameter, with long-winding names, closely following the order of the parameters!

This has been previously discussed a bit in #1589.

#### Current style

We have multiple methods to choose from, depending upon the options you want to use. In the example below, it is impossible to specify just `watchOnly` without specifying `count`. 😞 

```go
ListTransactions(account string)
ListTransactionsCount(account string, count int)
ListTransactionsCountFrom(account string, count int, from int)
ListTransactionsCountFromWatchOnly(account string, count int, from int, watchOnly bool)
```

#### Proposed style

```go
ListTransactions(
        "myaccount",
        WithListTransactionsWatchOnly(),  // btcjson.Bool(true) if specified, default (nil) otherwise
        WithListTransactionsCount(100),   // Use options in any order you like!
)
```

The above is known as functional options pattern, which is widely used in the Go community. Dave Cheney has written about it [here](https://dave.cheney.net/2014/10/17/functional-options-for-friendly-apis). Here's [another article](https://www.sohamkamani.com/golang/options-pattern) I really liked.

The API is made possible using the following variadic signature:

```
func (c *Client) ListTransactions(account string, opts ...ListTransactionsOpt) FutureListTransactionsResult
```