### PR TITLE
rpcserver: add gettxoutsetinfo

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -449,6 +449,26 @@ type GetTxOutSetInfoResult struct {
 	TotalAmount    btcutil.Amount `json:"total_amount"`
 }
 
+// MarshalJSON marshals the response of the gettxoutsetinfo JSON-RPC call
+func (g *GetTxOutSetInfoResult) MarshalJSON() ([]byte, error) {
+
+	type Alias GetTxOutSetInfoResult
+
+	aux := struct {
+		BestBlock      string  `json:"bestblock"`
+		HashSerialized string  `json:"hash_serialized_2"`
+		TotalAmount    float64 `json:"total_amount"`
+		*Alias
+	}{
+		BestBlock:      g.BestBlock.String(),
+		HashSerialized: g.HashSerialized.String(),
+		TotalAmount:    g.TotalAmount.ToBTC(),
+		Alias:          (*Alias)(g),
+	}
+
+	return json.Marshal(aux)
+}
+
 // UnmarshalJSON unmarshals the result of the gettxoutsetinfo JSON-RPC call
 func (g *GetTxOutSetInfoResult) UnmarshalJSON(data []byte) error {
 	// Step 1: Create type aliases of the original struct.

--- a/database/ffldb/db.go
+++ b/database/ffldb/db.go
@@ -942,6 +942,23 @@ func (b *bucket) Delete(key []byte) error {
 	return nil
 }
 
+// DiskSize returns the approximate size of the bucket on disk.
+// Recently written data may not be included.
+//
+// This function is part of the database.Bucket interface implementation.
+func (b *bucket) DiskSize() (int64, error) {
+	keyRange := util.BytesPrefix(b.id[:])
+
+	sizes, err := b.tx.db.cache.ldb.SizeOf([]util.Range{*keyRange})
+	if err != nil {
+		return 0, fmt.Errorf("could not estimate size of bucket: %w", err)
+	}
+
+	size := sizes[0]
+
+	return size, nil
+}
+
 // pendingBlock houses a block that will be written to disk when the database
 // transaction is committed.
 type pendingBlock struct {

--- a/database/interface.go
+++ b/database/interface.go
@@ -193,6 +193,9 @@ type Bucket interface {
 	//   - ErrTxNotWritable if attempted against a read-only transaction
 	//   - ErrTxClosed if the transaction has already been closed
 	Delete(key []byte) error
+
+	// DiskSize returns the approximate size of the bucket on disk.
+	DiskSize() (int64, error)
 }
 
 // BlockRegion specifies a particular region of a block identified by the

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -161,6 +161,7 @@ var rpcHandlersBeforeInit = map[string]commandHandler{
 	"getrawmempool":          handleGetRawMempool,
 	"getrawtransaction":      handleGetRawTransaction,
 	"gettxout":               handleGetTxOut,
+	"gettxoutsetinfo":        handleGetTxOutSetInfo,
 	"help":                   handleHelp,
 	"node":                   handleNode,
 	"ping":                   handlePing,
@@ -197,7 +198,6 @@ var rpcAskWallet = map[string]struct{}{
 	"getreceivedbyaccount":   {},
 	"getreceivedbyaddress":   {},
 	"gettransaction":         {},
-	"gettxoutsetinfo":        {},
 	"getunconfirmedbalance":  {},
 	"getwalletinfo":          {},
 	"importprivkey":          {},
@@ -2795,6 +2795,28 @@ func handleGetTxOut(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (i
 		Coinbase: isCoinbase,
 	}
 	return txOutReply, nil
+}
+
+// handleGetTxOutSetInfo implements the gettxoutsetinfo command
+func handleGetTxOutSetInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
+	utxoSetInfo, err := s.cfg.Chain.FetchUtxoSetInfo()
+	if err != nil {
+		context := "Failed to fetch utxo set info"
+		return nil, internalRPCError(err.Error(), context)
+	}
+
+	best := s.cfg.Chain.BestSnapshot()
+	result := &btcjson.GetTxOutSetInfoResult{
+		Height:         int64(best.Height),
+		BestBlock:      best.Hash,
+		Transactions:   utxoSetInfo.Transactions,
+		TxOuts:         utxoSetInfo.TxOuts,
+		BogoSize:       utxoSetInfo.BogoSize,
+		HashSerialized: utxoSetInfo.HashSerialized,
+		DiskSize:       utxoSetInfo.DiskSize,
+		TotalAmount:    utxoSetInfo.TotalAmount,
+	}
+	return result, nil
 }
 
 // handleHelp implements the help command.

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -531,6 +531,19 @@ var helpDescsEnUS = map[string]string{
 	"gettxout-vout":           "The index of the output",
 	"gettxout-includemempool": "Include the mempool when true",
 
+	// GetTxOutSetResult help.
+	"gettxoutsetinforesult-height":            "Height of the best block",
+	"gettxoutsetinforesult-bestblock":         "Hex-encoded bytes of the best block hash",
+	"gettxoutsetinforesult-transactions":      "The number of transactions with unspent outputs",
+	"gettxoutsetinforesult-txouts":            "The number of unspent transaction outputs",
+	"gettxoutsetinforesult-bogosize":          "A meaningless metric for the UTXO set size",
+	"gettxoutsetinforesult-hash_serialized_2": "The hash of the serialized UTXO set",
+	"gettxoutsetinforesult-disk_size":         "The estimated size of the UTXO set on disk",
+	"gettxoutsetinforesult-total_amount":      "The total amount in BTC",
+
+	// GetTxOutSetInfoCmd help.
+	"gettxoutsetinfo--synopsis": "Returns statistics about the unspent transaction output. This call may take awhile.",
+
 	// HelpCmd help.
 	"help--synopsis":   "Returns a list of all commands or help for a specified command.",
 	"help-command":     "The command to retrieve help for",
@@ -744,6 +757,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getrawmempool":          {(*[]string)(nil), (*btcjson.GetRawMempoolVerboseResult)(nil)},
 	"getrawtransaction":      {(*string)(nil), (*btcjson.TxRawResult)(nil)},
 	"gettxout":               {(*btcjson.GetTxOutResult)(nil)},
+	"gettxoutsetinfo":        {(*btcjson.GetTxOutSetInfoResult)(nil)},
 	"node":                   nil,
 	"help":                   {(*string)(nil), (*string)(nil)},
 	"ping":                   nil,


### PR DESCRIPTION
This PR adds gettxoutsetinfo to the RPC server.

Not sure whether or not to lock the blockchain during the call. Naturally it may take some time due to the size of the UTXO set, so locking may leave the node temporarily nonfunctional. However, not doing so may lead to inconsistent data.

Closes #142