### PR TITLE
btcjson (client): Update fields in GetBlockChainInfoResult

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -221,9 +221,11 @@ type GetBlockChainInfoResult struct {
 	Difficulty           float64 `json:"difficulty"`
 	MedianTime           int64   `json:"mediantime"`
 	VerificationProgress float64 `json:"verificationprogress,omitempty"`
+	InitialBlockDownload bool    `json:"initialblockdownload,omitempty"`
 	Pruned               bool    `json:"pruned"`
 	PruneHeight          int32   `json:"pruneheight,omitempty"`
 	ChainWork            string  `json:"chainwork,omitempty"`
+	SizeOnDisk           int64   `json:"size_on_disk,omitempty"`
 	*SoftForks
 	*UnifiedSoftForks
 }

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -181,6 +181,8 @@ var helpDescsEnUS = map[string]string{
 	"getblockchaininforesult-pruned":               "A bool that indicates if the node is pruned or not",
 	"getblockchaininforesult-pruneheight":          "The lowest block retained in the current pruned chain",
 	"getblockchaininforesult-chainwork":            "The total cumulative work in the best chain",
+	"getblockchaininforesult-size_on_disk":         "The estimated size of the block and undo files on disk",
+	"getblockchaininforesult-initialblockdownload": "Estimate of whether this node is in Initial Block Download mode",
 	"getblockchaininforesult-softforks":            "The status of the super-majority soft-forks",
 	"getblockchaininforesult-unifiedsoftforks":     "The status of the super-majority soft-forks used by bitcoind on or after v0.19.0",
 


### PR DESCRIPTION
Update the fields of GetBlockChainInfoResult to reflect the current state of
the RPC returned by other full-node implementations.

 * InitialBlockDownload - Node is in Initial Block Download mode if True.
 * SizeOnDisk - The estimated size of the block and undo files on disk.