### PR TITLE
Fix error message returned by EstimateFee

### DIFF
--- a/mempool/estimatefee.go
+++ b/mempool/estimatefee.go
@@ -563,7 +563,7 @@ func (ef *FeeEstimator) EstimateFee(numBlocks uint32) (BtcPerKilobyte, error) {
 	if numBlocks > estimateFeeDepth {
 		return -1, fmt.Errorf(
 			"can only estimate fees for up to %d blocks from now",
-			estimateFeeBinSize)
+			estimateFeeDepth)
 	}
 
 	// If there are no cached results, generate them.


### PR DESCRIPTION
When you provide an argument to EstimateFee(numblocks uint32) that exceeds the estimateFeeDepth (which is set to 25), you get an error message that says "can only estimate fees for up to 100 blocks from now".  The variable used in the if condition and the variable used for creating the error message should be the same.