### PR TITLE
rpcserver: Fix Error message returned by processRequest

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -4066,9 +4066,13 @@ func (s *rpcServer) processRequest(request *btcjson.Request, isAdmin bool, close
 			result, err = s.standardCmdResult(parsedCmd,
 				closeChan)
 			if err != nil {
-				jsonErr = &btcjson.RPCError{
-					Code:    btcjson.ErrRPCInvalidRequest.Code,
-					Message: "Invalid request: malformed",
+				if rpcErr, ok := err.(*btcjson.RPCError); ok {
+					jsonErr = rpcErr
+				} else {
+					jsonErr = &btcjson.RPCError{
+						Code:    btcjson.ErrRPCInvalidRequest.Code,
+						Message: "Invalid request: malformed",
+					}
 				}
 			}
 		}


### PR DESCRIPTION
When processRequest can't find a rpc command, `standardCmdResult` returns a `btcjson.ErrRPCMethodNotFound` but it gets ignored and a `btcjson.ErrRPCInvalidRequest` is returned instead.

For example when I run the `createwallet` command

```
btcctl --simnet --rpcuser=foo --rpcpass=bar createwallet testWallet
```

This is the error message  I get:
```
-32600: Invalid request: malformed
```

But instead I should get this (returned by `standardCmdResult`)
```
-32601: Method not found
```

This fixes `processRequest` behavior to return the right error message.