### PR TITLE
chaincfg+blockchain: abstract/refactor BIP 9 version bits implementation to work w/ BIP 8 block heights 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ DEPGET := cd /tmp && GO111MODULE=on go get -v
 GOBUILD := GO111MODULE=on go build -v
 GOINSTALL := GO111MODULE=on go install -v 
 DEV_TAGS := rpctest
-GOTEST := GO111MODULE=on go test -v -tags=$(DEV_TAGS)
+GOTEST_DEV = GO111MODULE=on go test -v -tags=$(DEV_TAGS)
+GOTEST := GO111MODULE=on go test -v
 
 GOFILES_NOVENDOR = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
@@ -78,9 +79,9 @@ check: unit
 
 unit:
 	@$(call print, "Running unit tests.")
-	$(GOTEST) ./... -test.timeout=20m
-	cd btcutil; $(GOTEST) ./... -test.timeout=20m
-	cd btcutil/psbt; $(GOTEST) ./... -test.timeout=20m
+	$(GOTEST_DEV) ./... -test.timeout=20m
+	cd btcutil; $(GOTEST_DEV) ./... -test.timeout=20m
+	cd btcutil/psbt; $(GOTEST_DEV) ./... -test.timeout=20m
 
 unit-cover: $(GOACC_BIN)
 	@$(call print, "Running unit coverage tests.")

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -11,12 +11,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/database"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcd/btcutil"
 )
 
 const (
@@ -1755,6 +1755,20 @@ func New(config *Config) (*BlockChain, error) {
 		prevOrphans:         make(map[chainhash.Hash][]*orphanBlock),
 		warningCaches:       newThresholdCaches(vbNumBits),
 		deploymentCaches:    newThresholdCaches(chaincfg.DefinedDeployments),
+	}
+
+	// Ensure all the deployments are synchronized with our clock if
+	// needed.
+	for _, deployment := range b.chainParams.Deployments {
+		deploymentStarter := deployment.DeploymentStarter
+		if clockStarter, ok := deploymentStarter.(chaincfg.ClockConsensusDeploymentStarter); ok {
+			clockStarter.SynchronizeClock(&b)
+		}
+
+		deploymentEnder := deployment.DeploymentEnder
+		if clockEnder, ok := deploymentEnder.(chaincfg.ClockConsensusDeploymentEnder); ok {
+			clockEnder.SynchronizeClock(&b)
+		}
 	}
 
 	// Initialize the chain state from the passed database.  When the db

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -14,13 +14,13 @@ import (
 	"strings"
 	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/database"
 	_ "github.com/btcsuite/btcd/database/ffldb"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcd/btcutil"
 )
 
 const (
@@ -357,7 +357,7 @@ func newFakeChain(params *chaincfg.Params) *BlockChain {
 	targetTimespan := int64(params.TargetTimespan / time.Second)
 	targetTimePerBlock := int64(params.TargetTimePerBlock / time.Second)
 	adjustmentFactor := params.RetargetAdjustmentFactor
-	return &BlockChain{
+	b := &BlockChain{
 		chainParams:         params,
 		timeSource:          NewMedianTime(),
 		minRetargetTimespan: targetTimespan / adjustmentFactor,
@@ -368,6 +368,20 @@ func newFakeChain(params *chaincfg.Params) *BlockChain {
 		warningCaches:       newThresholdCaches(vbNumBits),
 		deploymentCaches:    newThresholdCaches(chaincfg.DefinedDeployments),
 	}
+
+	for _, deployment := range params.Deployments {
+		deploymentStarter := deployment.DeploymentStarter
+		if clockStarter, ok := deploymentStarter.(chaincfg.ClockConsensusDeploymentStarter); ok {
+			clockStarter.SynchronizeClock(b)
+		}
+
+		deploymentEnder := deployment.DeploymentEnder
+		if clockEnder, ok := deploymentEnder.(chaincfg.ClockConsensusDeploymentEnder); ok {
+			clockEnder.SynchronizeClock(b)
+		}
+	}
+
+	return b
 }
 
 // newFakeNode creates a block node connected to the passed parent with the

--- a/blockchain/versionbits.go
+++ b/blockchain/versionbits.go
@@ -5,8 +5,6 @@
 package blockchain
 
 import (
-	"math"
-
 	"github.com/btcsuite/btcd/chaincfg"
 )
 
@@ -42,27 +40,26 @@ type bitConditionChecker struct {
 // interface.
 var _ thresholdConditionChecker = bitConditionChecker{}
 
-// BeginTime returns the unix timestamp for the median block time after which
-// voting on a rule change starts (at the next window).
+// HasStarted returns true if based on the passed block blockNode the consensus
+// is eligible for deployment.
 //
-// Since this implementation checks for unknown rules, it returns 0 so the rule
+// Since this implementation checks for unknown rules, it returns true so
 // is always treated as active.
 //
 // This is part of the thresholdConditionChecker interface implementation.
-func (c bitConditionChecker) BeginTime() uint64 {
-	return 0
+func (c bitConditionChecker) HasStarted(_ *blockNode) bool {
+	return true
 }
 
-// EndTime returns the unix timestamp for the median block time after which an
-// attempted rule change fails if it has not already been locked in or
-// activated.
+// HasStarted returns true if based on the passed block blockNode the consensus
+// is eligible for deployment.
 //
-// Since this implementation checks for unknown rules, it returns the maximum
-// possible timestamp so the rule is always treated as active.
+// Since this implementation checks for unknown rules, it returns false so the
+// rule is always treated as active.
 //
 // This is part of the thresholdConditionChecker interface implementation.
-func (c bitConditionChecker) EndTime() uint64 {
-	return math.MaxUint64
+func (c bitConditionChecker) HasEnded(_ *blockNode) bool {
+	return false
 }
 
 // RuleChangeActivationThreshold is the number of blocks for which the condition
@@ -123,27 +120,36 @@ type deploymentChecker struct {
 // interface.
 var _ thresholdConditionChecker = deploymentChecker{}
 
-// BeginTime returns the unix timestamp for the median block time after which
-// voting on a rule change starts (at the next window).
+// HasEnded returns true if the target consensus rule change has expired
+// or timed out (at the next window).
 //
 // This implementation returns the value defined by the specific deployment the
 // checker is associated with.
 //
 // This is part of the thresholdConditionChecker interface implementation.
-func (c deploymentChecker) BeginTime() uint64 {
-	return c.deployment.StartTime
+func (c deploymentChecker) HasStarted(blkNode *blockNode) bool {
+	// Can't fail as we make sure to set the clock above when we
+	// instantiate *BlockChain.
+	header := blkNode.Header()
+	started, _ := c.deployment.DeploymentStarter.HasStarted(&header)
+
+	return started
 }
 
-// EndTime returns the unix timestamp for the median block time after which an
-// attempted rule change fails if it has not already been locked in or
-// activated.
+// HasEnded returns true if the target consensus rule change has expired
+// or timed out.
 //
 // This implementation returns the value defined by the specific deployment the
 // checker is associated with.
 //
 // This is part of the thresholdConditionChecker interface implementation.
-func (c deploymentChecker) EndTime() uint64 {
-	return c.deployment.ExpireTime
+func (c deploymentChecker) HasEnded(blkNode *blockNode) bool {
+	// Can't fail as we make sure to set the clock above when we
+	// instantiate *BlockChain.
+	header := blkNode.Header()
+	ended, _ := c.deployment.DeploymentEnder.HasEnded(&header)
+
+	return ended
 }
 
 // RuleChangeActivationThreshold is the number of blocks for which the condition

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 
-	"github.com/btcsuite/btcd/wire"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
 )
 
 // GetBlockHeaderVerboseResult models the data from the getblockheader command when
@@ -172,12 +172,13 @@ type SoftForkDescription struct {
 // Bip9SoftForkDescription describes the current state of a defined BIP0009
 // version bits soft-fork.
 type Bip9SoftForkDescription struct {
-	Status     string `json:"status"`
-	Bit        uint8  `json:"bit"`
-	StartTime1 int64  `json:"startTime"`
-	StartTime2 int64  `json:"start_time"`
-	Timeout    int64  `json:"timeout"`
-	Since      int32  `json:"since"`
+	Status              string `json:"status"`
+	Bit                 uint8  `json:"bit"`
+	StartTime1          int64  `json:"startTime"`
+	StartTime2          int64  `json:"start_time"`
+	Timeout             int64  `json:"timeout"`
+	Since               int32  `json:"since"`
+	MinActivationHeight int32  `json:"min_activation_height"`
 }
 
 // StartTime returns the starting time of the softfork as a Unix epoch.

--- a/chaincfg/deployment_time_frame.go
+++ b/chaincfg/deployment_time_frame.go
@@ -80,7 +80,9 @@ type MedianTimeDeploymentStarter struct {
 }
 
 // NewMedianTimeDeploymentStarter returns a new instance of a
-// MedianTimeDeploymentStarter for a given start time.
+// MedianTimeDeploymentStarter for a given start time. Using a time.Time
+// instance where IsZero() is true, indicates that a deployment should be
+// considered to always have been started.
 func NewMedianTimeDeploymentStarter(startTime time.Time) *MedianTimeDeploymentStarter {
 	return &MedianTimeDeploymentStarter{
 		startTime: startTime,
@@ -134,7 +136,9 @@ type MedianTimeDeploymentEnder struct {
 }
 
 // NewMedianTimeDeploymentEnder returns a new instance of the
-// MedianTimeDeploymentEnder anchored around the passed endTime.
+// MedianTimeDeploymentEnder anchored around the passed endTime.  Using a
+// time.Time instance where IsZero() is true, indicates that a deployment
+// should be considered to never end.
 func NewMedianTimeDeploymentEnder(endTime time.Time) *MedianTimeDeploymentEnder {
 	return &MedianTimeDeploymentEnder{
 		endTime: endTime,

--- a/chaincfg/deployment_time_frame.go
+++ b/chaincfg/deployment_time_frame.go
@@ -1,0 +1,181 @@
+package chaincfg
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/btcsuite/btcd/wire"
+)
+
+var (
+	// ErrNoBlockClock is returned when an operation fails due to lack of
+	// synchornization with the current up to date block clock.
+	ErrNoBlockClock = fmt.Errorf("no block clock synchronized")
+)
+
+// BlockClock is an abstraction over the past median time computation. The past
+// median time computation is used in several consensus checks such as CSV, and
+// also BIP 9 version bits. This interface allows callers to abstract away the
+// computation of the past median time from the perspective of a given block
+// header.
+type BlockClock interface {
+	// PastMedianTime returns the past median time from the PoV of the
+	// passed block header. The past median time is the median time of the
+	// 11 blocks prior to the passed block header.
+	PastMedianTime(*wire.BlockHeader) (time.Time, error)
+}
+
+// ConsensusDeploymentStarter determines if a given consensus deployment has
+// started. A deployment has started once according to the current "time", the
+// deployment is eligible for activation once a perquisite condition has
+// passed.
+type ConsensusDeploymentStarter interface {
+	// HasStarted returns true if the consensus deployment has started.
+	HasStarted(*wire.BlockHeader) (bool, error)
+}
+
+// ClockConsensusDeploymentStarter is a more specialized version of the
+// ConsensusDeploymentStarter that uses a BlockClock in order to determine if a
+// deployment has started or not.
+//
+// NOTE: Any calls to HasStarted will _fail_ with ErrNoBlockClock if they
+// happen before SynchronizeClock is executed.
+type ClockConsensusDeploymentStarter interface {
+	ConsensusDeploymentStarter
+
+	// SynchronizeClock synchronizes the target ConsensusDeploymentStarter
+	// with the current up-to date BlockClock.
+	SynchronizeClock(clock BlockClock)
+}
+
+// ConsensusDeploymentEnder determines if a given consensus deployment has
+// ended. A deployment has ended once according got eh current "time", the
+// deployment is no longer eligible for activation.
+type ConsensusDeploymentEnder interface {
+	// HasEnded returns true if the consensus deployment has ended.
+	HasEnded(*wire.BlockHeader) (bool, error)
+}
+
+// ClockConsensusDeploymentEnder is a more specialized version of the
+// ConsensusDeploymentEnder that uses a BlockClock in order to determine if a
+// deployment has started or not.
+//
+// NOTE: Any calls to HasEnded will _fail_ with ErrNoBlockClock if they
+// happen before SynchronizeClock is executed.
+type ClockConsensusDeploymentEnder interface {
+	ConsensusDeploymentEnder
+
+	// SynchronizeClock synchronizes the target ConsensusDeploymentStarter
+	// with the current up-to date BlockClock.
+	SynchronizeClock(clock BlockClock)
+}
+
+// MedianTimeDeploymentStarter is a ClockConsensusDeploymentStarter that uses
+// the median time past of a target block node to determine if a deployment has
+// started.
+type MedianTimeDeploymentStarter struct {
+	blockClock BlockClock
+
+	startTime time.Time
+}
+
+// NewMedianTimeDeploymentStarter returns a new instance of a
+// MedianTimeDeploymentStarter for a given start time.
+func NewMedianTimeDeploymentStarter(startTime time.Time) *MedianTimeDeploymentStarter {
+	return &MedianTimeDeploymentStarter{
+		startTime: startTime,
+	}
+}
+
+// SynchronizeClock synchronizes the target ConsensusDeploymentStarter with the
+// current up-to date BlockClock.
+func (m *MedianTimeDeploymentStarter) SynchronizeClock(clock BlockClock) {
+	m.blockClock = clock
+}
+
+// HasStarted returns true if the consensus deployment has started.
+func (m *MedianTimeDeploymentStarter) HasStarted(blkHeader *wire.BlockHeader) (bool, error) {
+	switch {
+	// If we haven't yet been synchronized with a block clock, then we
+	// can't tell the time, so we'll fail.
+	case m.blockClock == nil:
+		return false, ErrNoBlockClock
+
+	// If the time is "zero", then the deployment has always started.
+	case m.startTime.IsZero():
+		return true, nil
+	}
+
+	medianTime, err := m.blockClock.PastMedianTime(blkHeader)
+	if err != nil {
+		return false, err
+	}
+
+	// We check both after and equal here as after will fail for equivalent
+	// times, and we want to be inclusive.
+	return medianTime.After(m.startTime) || medianTime.Equal(m.startTime), nil
+}
+
+// StartTime returns the raw start time of the deployment.
+func (m *MedianTimeDeploymentStarter) StartTime() time.Time {
+	return m.startTime
+}
+
+// A compile-time assertion to ensure MedianTimeDeploymentStarter implements
+// the ClockConsensusDeploymentStarter interface.
+var _ ClockConsensusDeploymentStarter = (*MedianTimeDeploymentStarter)(nil)
+
+// MedianTimeDeploymentEnder is a ClockConsensusDeploymentEnder that uses the
+// median time past of a target block to determine if a deployment has ended.
+type MedianTimeDeploymentEnder struct {
+	blockClock BlockClock
+
+	endTime time.Time
+}
+
+// NewMedianTimeDeploymentEnder returns a new instance of the
+// MedianTimeDeploymentEnder anchored around the passed endTime.
+func NewMedianTimeDeploymentEnder(endTime time.Time) *MedianTimeDeploymentEnder {
+	return &MedianTimeDeploymentEnder{
+		endTime: endTime,
+	}
+}
+
+// HasEnded returns true if the deployment has ended.
+func (m *MedianTimeDeploymentEnder) HasEnded(blkHeader *wire.BlockHeader) (bool, error) {
+	switch {
+	// If we haven't yet been synchronized with a block clock, then we can't tell
+	// the time, so we'll we haven't yet been synchronized with a block
+	// clock, then w can't tell the time, so we'll fail.
+	case m.blockClock == nil:
+		return false, ErrNoBlockClock
+
+	// If the time is "zero", then the deployment never ends.
+	case m.endTime.IsZero():
+		return false, nil
+	}
+
+	medianTime, err := m.blockClock.PastMedianTime(blkHeader)
+	if err != nil {
+		return false, err
+	}
+
+	// We check both after and equal here as after will fail for equivalent
+	// times, and we want to be inclusive.
+	return medianTime.After(m.endTime) || medianTime.Equal(m.endTime), nil
+}
+
+// MedianTimeDeploymentEnder returns the raw end time of the deployment.
+func (m *MedianTimeDeploymentEnder) EndTime() time.Time {
+	return m.endTime
+}
+
+// SynchronizeClock synchronizes the target ConsensusDeploymentEnder with the
+// current up-to date BlockClock.
+func (m *MedianTimeDeploymentEnder) SynchronizeClock(clock BlockClock) {
+	m.blockClock = clock
+}
+
+// A compile-time assertion to ensure MedianTimeDeploymentEnder implements the
+// ClockConsensusDeploymentStarter interface.
+var _ ClockConsensusDeploymentEnder = (*MedianTimeDeploymentEnder)(nil)

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -8,7 +8,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"errors"
-	"math"
 	"math/big"
 	"strings"
 	"time"
@@ -95,13 +94,13 @@ type ConsensusDeployment struct {
 	// this particular soft-fork deployment refers to.
 	BitNumber uint8
 
-	// StartTime is the median block time after which voting on the
-	// deployment starts.
-	StartTime uint64
+	// DeploymentStarter is used to determine if the given
+	// ConsensusDeployment has started or not.
+	DeploymentStarter ConsensusDeploymentStarter
 
-	// ExpireTime is the median block time after which the attempted
-	// deployment expires.
-	ExpireTime uint64
+	// DeploymentEnder is used to determine if the given
+	// ConsensusDeployment has ended or not.
+	DeploymentEnder ConsensusDeploymentEnder
 }
 
 // Constants that define the deployment offset in the deployments field of the
@@ -320,19 +319,31 @@ var MainNetParams = Params{
 	MinerConfirmationWindow:       2016, //
 	Deployments: [DefinedDeployments]ConsensusDeployment{
 		DeploymentTestDummy: {
-			BitNumber:  28,
-			StartTime:  1199145601, // January 1, 2008 UTC
-			ExpireTime: 1230767999, // December 31, 2008 UTC
+			BitNumber: 28,
+			DeploymentStarter: NewMedianTimeDeploymentStarter(
+				time.Unix(11991456010, 0), // January 1, 2008 UTC
+			),
+			DeploymentEnder: NewMedianTimeDeploymentEnder(
+				time.Unix(1230767999, 0), // December 31, 2008 UTC
+			),
 		},
 		DeploymentCSV: {
-			BitNumber:  0,
-			StartTime:  1462060800, // May 1st, 2016
-			ExpireTime: 1493596800, // May 1st, 2017
+			BitNumber: 0,
+			DeploymentStarter: NewMedianTimeDeploymentStarter(
+				time.Unix(1462060800, 0), // May 1st, 2016
+			),
+			DeploymentEnder: NewMedianTimeDeploymentEnder(
+				time.Unix(1493596800, 0), // May 1st, 2017
+			),
 		},
 		DeploymentSegwit: {
-			BitNumber:  1,
-			StartTime:  1479168000, // November 15, 2016 UTC
-			ExpireTime: 1510704000, // November 15, 2017 UTC.
+			BitNumber: 1,
+			DeploymentStarter: NewMedianTimeDeploymentStarter(
+				time.Unix(1479168000, 0), // November 15, 2016 UTC
+			),
+			DeploymentEnder: NewMedianTimeDeploymentEnder(
+				time.Unix(1510704000, 0), // November 15, 2017 UTC.
+			),
 		},
 	},
 
@@ -396,19 +407,31 @@ var RegressionNetParams = Params{
 	MinerConfirmationWindow:       144,
 	Deployments: [DefinedDeployments]ConsensusDeployment{
 		DeploymentTestDummy: {
-			BitNumber:  28,
-			StartTime:  0,             // Always available for vote
-			ExpireTime: math.MaxInt64, // Never expires
+			BitNumber: 28,
+			DeploymentStarter: NewMedianTimeDeploymentStarter(
+				time.Time{}, // Always available for vote
+			),
+			DeploymentEnder: NewMedianTimeDeploymentEnder(
+				time.Time{}, // Never expires
+			),
 		},
 		DeploymentCSV: {
-			BitNumber:  0,
-			StartTime:  0,             // Always available for vote
-			ExpireTime: math.MaxInt64, // Never expires
+			BitNumber: 0,
+			DeploymentStarter: NewMedianTimeDeploymentStarter(
+				time.Time{}, // Always available for vote
+			),
+			DeploymentEnder: NewMedianTimeDeploymentEnder(
+				time.Time{}, // Never expires
+			),
 		},
 		DeploymentSegwit: {
-			BitNumber:  1,
-			StartTime:  0,             // Always available for vote
-			ExpireTime: math.MaxInt64, // Never expires.
+			BitNumber: 1,
+			DeploymentStarter: NewMedianTimeDeploymentStarter(
+				time.Time{}, // Always available for vote
+			),
+			DeploymentEnder: NewMedianTimeDeploymentEnder(
+				time.Time{}, // Never expires.
+			),
 		},
 	},
 
@@ -490,19 +513,31 @@ var TestNet3Params = Params{
 	MinerConfirmationWindow:       2016,
 	Deployments: [DefinedDeployments]ConsensusDeployment{
 		DeploymentTestDummy: {
-			BitNumber:  28,
-			StartTime:  1199145601, // January 1, 2008 UTC
-			ExpireTime: 1230767999, // December 31, 2008 UTC
+			BitNumber: 28,
+			DeploymentStarter: NewMedianTimeDeploymentStarter(
+				time.Unix(1199145601, 0), // January 1, 2008 UTC
+			),
+			DeploymentEnder: NewMedianTimeDeploymentEnder(
+				time.Unix(1230767999, 0), // December 31, 2008 UTC
+			),
 		},
 		DeploymentCSV: {
-			BitNumber:  0,
-			StartTime:  1456790400, // March 1st, 2016
-			ExpireTime: 1493596800, // May 1st, 2017
+			BitNumber: 0,
+			DeploymentStarter: NewMedianTimeDeploymentStarter(
+				time.Unix(1456790400, 0), // March 1st, 2016
+			),
+			DeploymentEnder: NewMedianTimeDeploymentEnder(
+				time.Unix(1493596800, 0), // May 1st, 2017
+			),
 		},
 		DeploymentSegwit: {
-			BitNumber:  1,
-			StartTime:  1462060800, // May 1, 2016 UTC
-			ExpireTime: 1493596800, // May 1, 2017 UTC.
+			BitNumber: 1,
+			DeploymentStarter: NewMedianTimeDeploymentStarter(
+				time.Unix(1462060800, 0), // May 1, 2016 UTC
+			),
+			DeploymentEnder: NewMedianTimeDeploymentEnder(
+				time.Unix(1493596800, 0), // May 1, 2017 UTC.
+			),
 		},
 	},
 
@@ -570,19 +605,31 @@ var SimNetParams = Params{
 	MinerConfirmationWindow:       100,
 	Deployments: [DefinedDeployments]ConsensusDeployment{
 		DeploymentTestDummy: {
-			BitNumber:  28,
-			StartTime:  0,             // Always available for vote
-			ExpireTime: math.MaxInt64, // Never expires
+			BitNumber: 28,
+			DeploymentStarter: NewMedianTimeDeploymentStarter(
+				time.Time{}, // Always available for vote
+			),
+			DeploymentEnder: NewMedianTimeDeploymentEnder(
+				time.Time{}, // Never expires
+			),
 		},
 		DeploymentCSV: {
-			BitNumber:  0,
-			StartTime:  0,             // Always available for vote
-			ExpireTime: math.MaxInt64, // Never expires
+			BitNumber: 0,
+			DeploymentStarter: NewMedianTimeDeploymentStarter(
+				time.Time{}, // Always available for vote
+			),
+			DeploymentEnder: NewMedianTimeDeploymentEnder(
+				time.Time{}, // Never expires
+			),
 		},
 		DeploymentSegwit: {
-			BitNumber:  1,
-			StartTime:  0,             // Always available for vote
-			ExpireTime: math.MaxInt64, // Never expires.
+			BitNumber: 1,
+			DeploymentStarter: NewMedianTimeDeploymentStarter(
+				time.Time{}, // Always available for vote
+			),
+			DeploymentEnder: NewMedianTimeDeploymentEnder(
+				time.Time{}, // Never expires.
+			),
 		},
 	},
 
@@ -665,24 +712,40 @@ func CustomSignetParams(challenge []byte, dnsSeeds []DNSSeed) Params {
 		MinerConfirmationWindow:       2016,
 		Deployments: [DefinedDeployments]ConsensusDeployment{
 			DeploymentTestDummy: {
-				BitNumber:  28,
-				StartTime:  1199145601, // January 1, 2008 UTC
-				ExpireTime: 1230767999, // December 31, 2008 UTC
+				BitNumber: 28,
+				DeploymentStarter: NewMedianTimeDeploymentStarter(
+					time.Unix(1199145601, 0), // January 1, 2008 UTC
+				),
+				DeploymentEnder: NewMedianTimeDeploymentEnder(
+					time.Unix(1230767999, 0), // December 31, 2008 UTC
+				),
 			},
 			DeploymentCSV: {
-				BitNumber:  29,
-				StartTime:  0,             // Always available for vote
-				ExpireTime: math.MaxInt64, // Never expires
+				BitNumber: 29,
+				DeploymentStarter: NewMedianTimeDeploymentStarter(
+					time.Time{}, // Always available for vote
+				),
+				DeploymentEnder: NewMedianTimeDeploymentEnder(
+					time.Time{}, // Never expires
+				),
 			},
 			DeploymentSegwit: {
-				BitNumber:  29,
-				StartTime:  0,             // Always available for vote
-				ExpireTime: math.MaxInt64, // Never expires.
+				BitNumber: 29,
+				DeploymentStarter: NewMedianTimeDeploymentStarter(
+					time.Time{}, // Always available for vote
+				),
+				DeploymentEnder: NewMedianTimeDeploymentEnder(
+					time.Time{}, // Never expires
+				),
 			},
 			DeploymentTaproot: {
-				BitNumber:  29,
-				StartTime:  0,             // Always available for vote
-				ExpireTime: math.MaxInt64, // Never expires.
+				BitNumber: 29,
+				DeploymentStarter: NewMedianTimeDeploymentStarter(
+					time.Time{}, // Always available for vote
+				),
+				DeploymentEnder: NewMedianTimeDeploymentEnder(
+					time.Time{}, // Never expires
+				),
 			},
 		},
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1297,10 +1297,11 @@ func handleGetBlockChainInfo(s *rpcServer, cmd interface{}, closeChan <-chan str
 			endTime = ender.EndTime().Unix()
 		}
 		chainInfo.SoftForks.Bip9SoftForks[forkName] = &btcjson.Bip9SoftForkDescription{
-			Status:     strings.ToLower(statusString),
-			Bit:        deploymentDetails.BitNumber,
-			StartTime2: startTime,
-			Timeout:    endTime,
+			Status:              strings.ToLower(statusString),
+			Bit:                 deploymentDetails.BitNumber,
+			StartTime2:          startTime,
+			Timeout:             endTime,
+			MinActivationHeight: int32(deploymentDetails.MinActivationHeight),
 		}
 	}
 

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1250,14 +1250,14 @@ func handleGetBlockChainInfo(s *rpcServer, cmd interface{}, closeChan <-chan str
 		case chaincfg.DeploymentTestDummy:
 			forkName = "dummy"
 
+		case chaincfg.DeploymentTestDummyMinActivation:
+			forkName = "dummy-min-activation"
+
 		case chaincfg.DeploymentCSV:
 			forkName = "csv"
 
 		case chaincfg.DeploymentSegwit:
 			forkName = "segwit"
-
-		case chaincfg.DeploymentTaproot:
-			forkName = "taproot"
 
 		default:
 			return nil, &btcjson.RPCError{

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -31,6 +31,7 @@ import (
 	"github.com/btcsuite/btcd/blockchain/indexers"
 	"github.com/btcsuite/btcd/btcec"
 	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/database"
@@ -40,7 +41,6 @@ import (
 	"github.com/btcsuite/btcd/peer"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/websocket"
 )
 
@@ -1289,11 +1289,18 @@ func handleGetBlockChainInfo(s *rpcServer, cmd interface{}, closeChan <-chan str
 
 		// Finally, populate the soft-fork description with all the
 		// information gathered above.
+		var startTime, endTime int64
+		if starter, ok := deploymentDetails.DeploymentStarter.(*chaincfg.MedianTimeDeploymentStarter); ok {
+			startTime = starter.StartTime().Unix()
+		}
+		if ender, ok := deploymentDetails.DeploymentEnder.(*chaincfg.MedianTimeDeploymentEnder); ok {
+			endTime = ender.EndTime().Unix()
+		}
 		chainInfo.SoftForks.Bip9SoftForks[forkName] = &btcjson.Bip9SoftForkDescription{
 			Status:     strings.ToLower(statusString),
 			Bit:        deploymentDetails.BitNumber,
-			StartTime2: int64(deploymentDetails.StartTime),
-			Timeout:    int64(deploymentDetails.ExpireTime),
+			StartTime2: startTime,
+			Timeout:    endTime,
 		}
 	}
 


### PR DESCRIPTION
In this PR, we further abstract our Version Bits implementation to be able to support _both_ BIP 9 time based timeouts, as well as BIP 8 block based timeouts. In order to bridge the two mechanisms, we introduces a series of new light interfaces that allow us to abstract away from when exactly a soft fork deployment "starts" and "ends". This PR doesn't yet add any new BIP 8 compatible deployments, as it's mean to be a pure refactoring that doesn't introduce any new behavior. It's also the case that BIP 8 has some extra Version Bits states that need to be added to our Version Bits implementation. 

The only thing missing from this PR is a few additional tests to confirm that no change in behavior has occurred. Reviewers should examine the change to how we define deployments that are "always started" and "never ended", as well as the usage of `time` methods to determine if a deployment has started or ended. 