### PR TITLE
rpcclient: fix documentation typo

### DIFF
--- a/rpcclient/net.go
+++ b/rpcclient/net.go
@@ -90,7 +90,7 @@ func (c *Client) NodeAsync(command btcjson.NodeSubCmd, host string,
 // connect or diconnect a non-persistent one.
 //
 // The connectSubCmd should be set either "perm" or "temp", depending on
-// whether we are targetting a persistent or non-persistent peer. Passing nil
+// whether we are targeting a persistent or non-persistent peer. Passing nil
 // will cause the default value to be used, which currently is "temp".
 func (c *Client) Node(command btcjson.NodeSubCmd, host string,
 	connectSubCmd *string) error {


### PR DESCRIPTION
Just noticed this while checking that the godoc didn't need any changes for #1706.