### PR TITLE
chaincfg: fix deployment bit numbers

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -670,17 +670,17 @@ func CustomSignetParams(challenge []byte, dnsSeeds []DNSSeed) Params {
 				ExpireTime: 1230767999, // December 31, 2008 UTC
 			},
 			DeploymentCSV: {
-				BitNumber:  0,
+				BitNumber:  29,
 				StartTime:  0,             // Always available for vote
 				ExpireTime: math.MaxInt64, // Never expires
 			},
 			DeploymentSegwit: {
-				BitNumber:  1,
+				BitNumber:  29,
 				StartTime:  0,             // Always available for vote
 				ExpireTime: math.MaxInt64, // Never expires.
 			},
 			DeploymentTaproot: {
-				BitNumber:  2,
+				BitNumber:  29,
 				StartTime:  0,             // Always available for vote
 				ExpireTime: math.MaxInt64, // Never expires.
 			},


### PR DESCRIPTION
On signet all previous soft forks and also taproot are always activated,
meaning the version is always 0x20000000 for all blocks. To make sure
they activate properly in `btcd` we therefore need to use the correct
bit to mask the version.
This means that on any custom signet there would need to be 2016 blocks
mined before SegWit or Taproot can be used.

cc @wpaulino, @Roasbeef.