### PR TITLE
Switch irc to libera.chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ $ ./btcd
 
 ## IRC
 
-- irc.freenode.net
+- irc.libera.chat
 - channel #btcd
-- [webchat](https://webchat.freenode.net/?channels=btcd)
+- [webchat](https://web.libera.chat/gamja/?channels=btcd)
 
 ## Issue Tracker
 

--- a/docs/contact.md
+++ b/docs/contact.md
@@ -2,7 +2,7 @@
 
 ## IRC
 
-* [irc.freenode.net](irc://irc.freenode.net), channel `#btcd`
+* [irc.libera.chat](irc://irc.libera.chat), channel `#btcd`
 
 ## Mailing Lists
 


### PR DESCRIPTION
We haven't exactly decided to make the move yet, but I want this PR ready.  We have a new channel already and it does not look like freenode is a viable solution any more based on what has happened with many other channels.