### PR TITLE
mempool: introduce GetDustThreshold to export dust limit calculation

### DIFF
--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -172,17 +172,10 @@ func checkPkScriptStandard(pkScript []byte, scriptClass txscript.ScriptClass) er
 	return nil
 }
 
-// IsDust returns whether or not the passed transaction output amount is
-// considered dust or not based on the passed minimum transaction relay fee.
-// Dust is defined in terms of the minimum transaction relay fee.  In
-// particular, if the cost to the network to spend coins is more than 1/3 of the
-// minimum transaction relay fee, it is considered dust.
-func IsDust(txOut *wire.TxOut, minRelayTxFee btcutil.Amount) bool {
-	// Unspendable outputs are considered dust.
-	if txscript.IsUnspendable(txOut.PkScript) {
-		return true
-	}
-
+// GetDustThreshold calculates the dust limit for a *wire.TxOut by taking the
+// size of a typical spending transaction and multiplying it by 3 to account
+// for the minimum dust relay fee of 3000sat/kvb.
+func GetDustThreshold(txOut *wire.TxOut) int64 {
 	// The total serialized size consists of the output and the associated
 	// input script to redeem it.  Since there is no input script
 	// to redeem it yet, use the minimum size of a typical input script.
@@ -253,6 +246,20 @@ func IsDust(txOut *wire.TxOut, minRelayTxFee btcutil.Amount) bool {
 		totalSize += 107
 	}
 
+	return 3 * int64(totalSize)
+}
+
+// IsDust returns whether or not the passed transaction output amount is
+// considered dust or not based on the passed minimum transaction relay fee.
+// Dust is defined in terms of the minimum transaction relay fee.  In
+// particular, if the cost to the network to spend coins is more than 1/3 of the
+// minimum transaction relay fee, it is considered dust.
+func IsDust(txOut *wire.TxOut, minRelayTxFee btcutil.Amount) bool {
+	// Unspendable outputs are considered dust.
+	if txscript.IsUnspendable(txOut.PkScript) {
+		return true
+	}
+
 	// The output is considered dust if the cost to the network to spend the
 	// coins is more than 1/3 of the minimum free transaction relay fee.
 	// minFreeTxRelayFee is in Satoshi/KB, so multiply by 1000 to
@@ -265,7 +272,7 @@ func IsDust(txOut *wire.TxOut, minRelayTxFee btcutil.Amount) bool {
 	//
 	// The following is equivalent to (value/totalSize) * (1/3) * 1000
 	// without needing to do floating point math.
-	return txOut.Value*1000/(3*int64(totalSize)) < int64(minRelayTxFee)
+	return txOut.Value*1000/GetDustThreshold(txOut) < int64(minRelayTxFee)
 }
 
 // checkTransactionStandard performs a series of checks on a transaction to


### PR DESCRIPTION
This commit modifies no behavior and would allow other projects to retrieve the dust limit for a particular output type before the amount of the output is known (so `IsDust` wouldn't be possible). This is particularly useful in the Lightning Network for channel negotiation.  I did not include a unit test but I did locally check the following dust limits at the current 3000sat/kvb dust relay feerate:
- p2pkh: 546
- p2sh: 540
- p2wsh: 330
- p2wpkh: 294
- p2tr: 330