### PR TITLE
connmgr: Fix stale comment in TestRemovePendingConnection

### DIFF
--- a/connmgr/connmanager_test.go
+++ b/connmgr/connmanager_test.go
@@ -464,7 +464,7 @@ func TestRemovePendingConnection(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 
 	// Now examine the status of the connection request, it should read a
-	// status of failed.
+	// status of ConnCanceled.
 	if cr.State() != ConnCanceled {
 		t.Fatalf("request wasn't canceled, status is: %v", cr.State())
 	}


### PR DESCRIPTION
- Fixes #1748

Changes the comment to 
```go
// Now examine the status of the connection request, it should read a 
// status of ConnCanceled.
```
This should resolve the confusion.