### PR TITLE
Update message.go

### DIFF
--- a/wire/message.go
+++ b/wire/message.go
@@ -316,7 +316,7 @@ func WriteMessageWithEncodingN(w io.Writer, msg Message, pver uint32,
 	// rather than directly to the writer since writeElements doesn't
 	// return the number of bytes written.
 	hw := bytes.NewBuffer(make([]byte, 0, MessageHeaderSize))
-	writeElements(hw, hdr.magic, command, hdr.length, hdr.checksum)
+	writeElements(hw, hdr.magic, hdr.command, hdr.length, hdr.checksum)
 
 	// Write header.
 	n, err := w.Write(hw.Bytes())


### PR DESCRIPTION
Prevent to affect the parameters of "writeElements" function if the changing use of the variable "command"