### PR TITLE
txscript: add taproot script type

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/btcsuite/btcd
 
 require (
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
-	github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce
+	github.com/btcsuite/btcutil v1.0.3-0.20210929233259-9cdf59f60c51
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd
 	github.com/btcsuite/goleveldb v1.0.0
 	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufo
 github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:+5NJ2+qvTyV9exUAL/rxXi3DcLg2Ts+ymUAY5y4NvMg=
 github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce h1:YtWJF7RHm2pYCvA5t0RPmAaLUhREsKuKd+SLhxFbFeQ=
 github.com/btcsuite/btcutil v1.0.3-0.20201208143702-a53e38424cce/go.mod h1:0DVlHczLPewLcPGEIeUEzfOJhqGPQ0mJJRDBtD307+o=
+github.com/btcsuite/btcutil v1.0.3-0.20210929233259-9cdf59f60c51 h1:6XGSs4BMDRlNR9k+tpr1g2S6ZfQhKQl/Xr276yAEfP0=
+github.com/btcsuite/btcutil v1.0.3-0.20210929233259-9cdf59f60c51/go.mod h1:0DVlHczLPewLcPGEIeUEzfOJhqGPQ0mJJRDBtD307+o=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd h1:R/opQEbFEy9JGkIguV40SvRY1uliPX8ifOvi6ICsFCw=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v0.0.0-20160330041536-7834afc9e8cd/go.mod h1:F+uVaaLLH7j4eDXPRvw78tMflu7Ie2bzYOH4Y8rRKBY=

--- a/txscript/pkscript.go
+++ b/txscript/pkscript.go
@@ -239,26 +239,11 @@ func computeNonWitnessPkScript(sigScript []byte) (PkScript, error) {
 
 // computeWitnessPkScript computes the script of an output by looking at the
 // spending input's witness.
-// IMPORTANT: With the addition of taproot, we can no longer say for certain
-// what kind of script the witness is in most cases. The only case in which we
-// can say for sure is when the witness data has an annex as the last push. In
-// that case, we can identify the script type, but we lack the ability to
-// reconstruct the script itself.
+// IMPORTANT: With the addition of taproot, we can not say for certain
+// what kind of script the witness is.
 func computeWitnessPkScript(witness wire.TxWitness) (PkScript, error) {
 	var pkScript PkScript
-	switch {
-	// If the last push starts with the annex flag, this is a taproot spend.
-	// We can set the script class, but we can't say what the pubkey script
-	// looks like with just the witness data.
-	case isAnnexedWitness(witness):
-		pkScript.class = WitnessV1TaprootTy
-
-	// For any other witnesses, we can't say for certain what type it is or what
-	// the pubkey script will be.
-	default:
-		pkScript.class = WitnessUnknownTy
-	}
-
+	pkScript.class = WitnessUnknownTy
 	return pkScript, nil
 }
 

--- a/txscript/pkscript_test.go
+++ b/txscript/pkscript_test.go
@@ -334,7 +334,7 @@ func TestComputePkScript(t *testing.T) {
 			pkScript:  nil,
 		},
 		{
-			name:      "P2WSH witness",
+			name:      "witness unknown",
 			sigScript: nil,
 			witness: [][]byte{
 				{},
@@ -348,20 +348,14 @@ func TestComputePkScript(t *testing.T) {
 					0x42, 0x59, 0x90, 0xac, 0xac,
 				},
 			},
-			class: WitnessV0ScriptHashTy,
-			pkScript: []byte{
-				// OP_0
-				0x00,
-				// OP_DATA_32
-				0x20,
-				// <32-byte script hash>
-				0x01, 0xd5, 0xd9, 0x2e, 0xff, 0xa6, 0xff, 0xba,
-				0x3e, 0xfa, 0x37, 0x9f, 0x98, 0x30, 0xd0, 0xf7,
-				0x56, 0x18, 0xb1, 0x33, 0x93, 0x82, 0x71, 0x52,
-				0xd2, 0x6e, 0x43, 0x09, 0x00, 0x0e, 0x88, 0xb1,
-			},
+			// We can't say for sure what kind of pubkey script this is. Before
+			// taproot, it would have been p2sh
+			class: WitnessUnknownTy,
 		},
 		{
+			// Before taproot, we could tell this script type based on its
+			// structure. But now this particular structure matches rules for
+			// both witness_v0_keyhash and witness_v1_taproot.
 			name:      "P2WPKH witness",
 			sigScript: nil,
 			witness: [][]byte{
@@ -378,17 +372,7 @@ func TestComputePkScript(t *testing.T) {
 					0x59, 0x90, 0xac,
 				},
 			},
-			class: WitnessV0PubKeyHashTy,
-			pkScript: []byte{
-				// OP_0
-				0x00,
-				// OP_DATA_20
-				0x14,
-				// <20-byte pubkey hash>
-				0x1d, 0x7c, 0xd6, 0xc7, 0x5c, 0x2e, 0x86, 0xf4,
-				0xcb, 0xf9, 0x8e, 0xae, 0xd2, 0x21, 0xb3, 0x0b,
-				0xd9, 0xa0, 0xb9, 0x28,
-			},
+			class: WitnessUnknownTy,
 		},
 		// Invalid v0 P2WPKH - same as above but missing a byte on the
 		// public key.
@@ -429,12 +413,12 @@ func TestComputePkScript(t *testing.T) {
 			}
 
 			if pkScript.Class() != test.class {
-				t.Fatalf("expected pkScript of type %v, got %v",
-					test.class, pkScript.Class())
+				t.Fatalf("%s: expected pkScript of type %v, got %v",
+					test.name, test.class, pkScript.Class())
 			}
 			if !bytes.Equal(pkScript.Script(), test.pkScript) {
-				t.Fatalf("expected pkScript=%x, got pkScript=%x",
-					test.pkScript, pkScript.Script())
+				t.Fatalf("%s: expected pkScript=%x, got pkScript=%x",
+					test.name, test.pkScript, pkScript.Script())
 			}
 		})
 	}

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -651,7 +651,7 @@ func countSigOpsV0(script []byte, precise bool) int {
 			// covering 1 through 16 pubkeys, which means this will count any
 			// more than that value (e.g. 17, 18 19) as the maximum number of
 			// allowed pubkeys. This is, unfortunately, now part of
-			// the Bitcion consensus rules, due to historical
+			// the Bitcoin consensus rules, due to historical
 			// reasons. This could be made more correct with a new
 			// script version, however, ideally all multisignaure
 			// operations in new script versions should move to
@@ -799,6 +799,9 @@ func getWitnessSigOps(pkScript []byte, witness wire.TxWitness) int {
 			witnessScript := witness[len(witness)-1]
 			return countSigOpsV0(witnessScript, true)
 		}
+	case 1:
+		// https://github.com/bitcoin/bitcoin/blob/368831371d97a642beb54b5c4eb6eb0fedaa16b4/src/script/interpreter.cpp#L2090
+		return 0
 	}
 
 	return 0

--- a/txscript/script_test.go
+++ b/txscript/script_test.go
@@ -173,6 +173,7 @@ func TestGetPreciseSigOps(t *testing.T) {
 // nested p2sh, and invalid variants are counted properly.
 func TestGetWitnessSigOpCount(t *testing.T) {
 	t.Parallel()
+	const OP_ANNEX = 0x50
 	tests := []struct {
 		name string
 
@@ -182,7 +183,7 @@ func TestGetWitnessSigOpCount(t *testing.T) {
 
 		numSigOps int
 	}{
-		// A regualr p2wkh witness program. The output being spent
+		// A regular p2wkh witness program. The output being spent
 		// should only have a single sig-op counted.
 		{
 			name: "p2wkh",
@@ -242,6 +243,36 @@ func TestGetWitnessSigOpCount(t *testing.T) {
 				mustParseShortForm("DUP HASH160 " +
 					"'17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem'" +
 					" EQUALVERIFY CHECKSIG DATA_20 0x91"),
+			},
+		},
+
+		{
+			name:      "taproot key-path spend",
+			numSigOps: 0, // DRAFT NOTE: verify these should really be zero.
+			pkScript:  hexToBytes("512058ce9d16c3384731a1727e512530620d031ee7b12f42aade70c9f976a905a74b"),
+			witness: wire.TxWitness{
+				hexToBytes("DCBA"),
+			},
+		},
+		{
+			name:      "taproot script-path spend without annex",
+			numSigOps: 0,
+			pkScript:  hexToBytes("512058ce9d16c3384731a1727e512530620d031ee7b12f42aade70c9f976a905a74b"),
+			witness: wire.TxWitness{
+				[]byte("signature"),
+				mustParseShortForm("CHECKSIG CHECKSIG"),
+				[]byte("control block"),
+			},
+		},
+		{
+			name:      "taproot script-path spend with annex",
+			numSigOps: 0,
+			pkScript:  hexToBytes("512058ce9d16c3384731a1727e512530620d031ee7b12f42aade70c9f976a905a74b"),
+			witness: wire.TxWitness{
+				[]byte("stuff"),
+				mustParseShortForm("CHECKSIG"),
+				[]byte("control block"),
+				[]byte{OP_ANNEX},
 			},
 		},
 	}

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -1007,6 +1007,15 @@ func ExtractPkScriptAddrs(pkScript []byte, chainParams *chaincfg.Params) (Script
 		return WitnessV0ScriptHashTy, addrs, 1, nil
 	}
 
+	if hash := extractWitnessV1ScriptHash(pkScript); hash != nil {
+		var addrs []btcutil.Address
+		addr, err := btcutil.NewAddressTaproot(hash, chainParams)
+		if err == nil {
+			addrs = append(addrs, addr)
+		}
+		return WitnessV1TaprootTy, addrs, 1, nil
+	}
+
 	// case WitnessV1TaprootTy:
 	// 	requiredSigs = 1
 	// 	addr, err := btcutil.NewAddressTaproot(pops[1].data,

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -1016,14 +1016,6 @@ func ExtractPkScriptAddrs(pkScript []byte, chainParams *chaincfg.Params) (Script
 		return WitnessV1TaprootTy, addrs, 1, nil
 	}
 
-	// case WitnessV1TaprootTy:
-	// 	requiredSigs = 1
-	// 	addr, err := btcutil.NewAddressTaproot(pops[1].data,
-	// 		chainParams)
-	// 	if err == nil {
-	// 		addrs = append(addrs, addr)
-	// 	}
-
 	// If none of the above passed, then the address must be non-standard.
 	return NonStandardTy, nil, 0, nil
 }

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -800,6 +800,12 @@ func payToWitnessScriptHashScript(scriptHash []byte) ([]byte, error) {
 	return NewScriptBuilder().AddOp(OP_0).AddData(scriptHash).Script()
 }
 
+// payToWitnessTaprootScript creates a new script to pay to a version 1
+// (taproot) witness program. The passed hash is expected to be valid.
+func payToWitnessTaprootScript(scriptHash []byte) ([]byte, error) {
+	return NewScriptBuilder().AddOp(OP_1).AddData(scriptHash).Script()
+}
+
 // payToPubkeyScript creates a new script to pay a transaction output to a
 // public key. It is expected that the input is a valid pubkey.
 func payToPubKeyScript(serializedPubKey []byte) ([]byte, error) {
@@ -846,6 +852,12 @@ func PayToAddrScript(addr btcutil.Address) ([]byte, error) {
 				nilAddrErrStr)
 		}
 		return payToWitnessScriptHashScript(addr.ScriptAddress())
+	case *btcutil.AddressTaproot:
+		if addr == nil {
+			return nil, scriptError(ErrUnsupportedAddress,
+				nilAddrErrStr)
+		}
+		return payToWitnessTaprootScript(addr.ScriptAddress())
 	}
 
 	str := fmt.Sprintf("unable to generate payment script for unsupported "+

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -58,6 +58,7 @@ const (
 	WitnessV0ScriptHashTy                    // Pay to witness script hash.
 	MultiSigTy                               // Multi signature.
 	NullDataTy                               // Empty data-only (provably prunable).
+	WitnessV1TaprootTy                       // Taproot output
 	WitnessUnknownTy                         // Witness unknown
 )
 
@@ -72,6 +73,7 @@ var scriptClassToName = []string{
 	WitnessV0ScriptHashTy: "witness_v0_scripthash",
 	MultiSigTy:            "multisig",
 	NullDataTy:            "nulldata",
+	WitnessV1TaprootTy:    "witness_v1_taproot",
 	WitnessUnknownTy:      "witness_unknown",
 }
 
@@ -365,10 +367,10 @@ func isWitnessPubKeyHashScript(script []byte) bool {
 	return extractWitnessPubKeyHash(script) != nil
 }
 
-// extractWitnessScriptHash extracts the witness script hash from the passed
+// extractWitnessV0ScriptHash extracts the witness script hash from the passed
 // script if it is standard pay-to-witness-script-hash script. It will return
 // nil otherwise.
-func extractWitnessScriptHash(script []byte) []byte {
+func extractWitnessV0ScriptHash(script []byte) []byte {
 	// A pay-to-witness-script-hash script is of the form:
 	//   OP_0 OP_DATA_32 <32-byte-hash>
 	if len(script) == 34 &&
@@ -381,10 +383,26 @@ func extractWitnessScriptHash(script []byte) []byte {
 	return nil
 }
 
+// extractWitnessV1ScriptHash extracts the witness script hash from the passed
+// script if it is standard pay-to-witness-script-hash script. It will return
+// nil otherwise.
+func extractWitnessV1ScriptHash(script []byte) []byte {
+	// A pay-to-witness-script-hash script is of the form:
+	//   OP_1 OP_DATA_32 <32-byte-hash>
+	if len(script) == 34 &&
+		script[0] == OP_1 &&
+		script[1] == OP_DATA_32 {
+
+		return script[2:34]
+	}
+
+	return nil
+}
+
 // isWitnessScriptHashScript returns whether or not the passed script is a
 // standard pay-to-witness-script-hash script.
 func isWitnessScriptHashScript(script []byte) bool {
-	return extractWitnessScriptHash(script) != nil
+	return extractWitnessV0ScriptHash(script) != nil
 }
 
 // extractWitnessProgramInfo returns the version and program if the passed
@@ -444,6 +462,23 @@ func isWitnessProgramScript(script []byte) bool {
 	return valid
 }
 
+// isWitnessTaprootScript returns true if the passed script is for a
+// pay-to-witness-taproot output, false otherwise.
+func isWitnessTaprootScript(script []byte) bool {
+	return extractWitnessV1ScriptHash(script) != nil
+}
+
+// isAnnexedWitness returns true if the passed witness has a final push
+// that is a witness annex.
+func isAnnexedWitness(witness [][]byte) bool {
+	const OP_ANNEX = 0x50
+	if len(witness) < 2 {
+		return false
+	}
+	lastElement := witness[len(witness)-1]
+	return len(lastElement) > 0 && lastElement[0] == OP_ANNEX
+}
+
 // isNullDataScript returns whether or not the passed script is a standard
 // null data script.
 //
@@ -485,28 +520,31 @@ func isNullDataScript(scriptVersion uint16, script []byte) bool {
 // NOTE:  All scripts that are not version 0 are currently considered non
 // standard.
 func typeOfScript(scriptVersion uint16, script []byte) ScriptClass {
-	if scriptVersion != 0 {
-		return NonStandardTy
+	switch scriptVersion {
+	case 0:
+		switch {
+		case isPubKeyScript(script):
+			return PubKeyTy
+		case isPubKeyHashScript(script):
+			return PubKeyHashTy
+		case isScriptHashScript(script):
+			return ScriptHashTy
+		case isWitnessPubKeyHashScript(script):
+			return WitnessV0PubKeyHashTy
+		case isWitnessScriptHashScript(script):
+			return WitnessV0ScriptHashTy
+		case isMultisigScript(scriptVersion, script):
+			return MultiSigTy
+		case isNullDataScript(scriptVersion, script):
+			return NullDataTy
+		}
+	case 1:
+		switch {
+		case isWitnessTaprootScript(script):
+			return WitnessV1TaprootTy
+		}
 	}
-
-	switch {
-	case isPubKeyScript(script):
-		return PubKeyTy
-	case isPubKeyHashScript(script):
-		return PubKeyHashTy
-	case isScriptHashScript(script):
-		return ScriptHashTy
-	case isWitnessPubKeyHashScript(script):
-		return WitnessV0PubKeyHashTy
-	case isWitnessScriptHashScript(script):
-		return WitnessV0ScriptHashTy
-	case isMultisigScript(scriptVersion, script):
-		return MultiSigTy
-	case isNullDataScript(scriptVersion, script):
-		return NullDataTy
-	default:
-		return NonStandardTy
-	}
+	return NonStandardTy
 }
 
 // GetScriptClass returns the class of the script passed.
@@ -558,6 +596,10 @@ func expectedInputs(script []byte, class ScriptClass) int {
 		return 1
 
 	case WitnessV0ScriptHashTy:
+		// Not including script.  That is handled by the caller.
+		return 1
+
+	case WitnessV1TaprootTy:
 		// Not including script.  That is handled by the caller.
 		return 1
 
@@ -956,7 +998,7 @@ func ExtractPkScriptAddrs(pkScript []byte, chainParams *chaincfg.Params) (Script
 		return WitnessV0PubKeyHashTy, addrs, 1, nil
 	}
 
-	if hash := extractWitnessScriptHash(pkScript); hash != nil {
+	if hash := extractWitnessV0ScriptHash(pkScript); hash != nil {
 		var addrs []btcutil.Address
 		addr, err := btcutil.NewAddressWitnessScriptHash(hash, chainParams)
 		if err == nil {
@@ -964,6 +1006,14 @@ func ExtractPkScriptAddrs(pkScript []byte, chainParams *chaincfg.Params) (Script
 		}
 		return WitnessV0ScriptHashTy, addrs, 1, nil
 	}
+
+	// case WitnessV1TaprootTy:
+	// 	requiredSigs = 1
+	// 	addr, err := btcutil.NewAddressTaproot(pops[1].data,
+	// 		chainParams)
+	// 	if err == nil {
+	// 		addrs = append(addrs, addr)
+	// 	}
 
 	// If none of the above passed, then the address must be non-standard.
 	return NonStandardTy, nil, 0, nil

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -660,6 +660,27 @@ func TestPayToAddrScript(t *testing.T) {
 			err)
 	}
 
+	p2wsh, err := btcutil.NewAddressWitnessScriptHash(hexToBytes("e981bd992a43650657"+
+		"d705ef7a30b2adc75a927ed42a4cf6b3da0f865a475fb4"), &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatalf("Unable to create p2wsh address: %v",
+			err)
+	}
+
+	p2tr, err := btcutil.NewAddressTaproot(hexToBytes("3a8e170b546c3b122ab9c175e"+
+		"ff36fb344db2684fe96497eb51b440e75232709"), &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatalf("Unable to create p2tr address: %v",
+			err)
+	}
+
+	p2wpkh, err := btcutil.NewAddressWitnessPubKeyHash(hexToBytes("748e50366adb8"+
+		"ae4b0255e406a28f99d24b73cbc"), &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatalf("Unable to create p2wpkh address: %v",
+			err)
+	}
+
 	// Errors used in the tests below defined here for convenience and to
 	// keep the horizontal test size shorter.
 	errUnsupportedAddress := scriptError(ErrUnsupportedAddress, "")
@@ -706,11 +727,34 @@ func TestPayToAddrScript(t *testing.T) {
 				"CHECKSIG",
 			nil,
 		},
+		// pay-to-witness-script-hash address on mainnet.
+		{
+			p2wsh,
+			"OP_0 DATA_32 0xe981bd992a43650657d705ef7a30b2adc75a927ed" +
+				"42a4cf6b3da0f865a475fb4",
+			nil,
+		},
+		// pay-to-taproot address on mainnet.
+		{
+			p2tr,
+			"OP_1 DATA_32 0x3a8e170b546c3b122ab9c175eff36fb344db2684" +
+				"fe96497eb51b440e75232709",
+			nil,
+		},
+		// pay-to-witness-pubkey-hash address on mainnet.
+		{
+			p2wpkh,
+			"OP_0 DATA_20 0x748e50366adb8ae4b0255e406a28f99d24b73cbc",
+			nil,
+		},
 
 		// Supported address types with nil pointers.
 		{(*btcutil.AddressPubKeyHash)(nil), "", errUnsupportedAddress},
 		{(*btcutil.AddressScriptHash)(nil), "", errUnsupportedAddress},
 		{(*btcutil.AddressPubKey)(nil), "", errUnsupportedAddress},
+		{(*btcutil.AddressWitnessPubKeyHash)(nil), "", errUnsupportedAddress},
+		{(*btcutil.AddressWitnessScriptHash)(nil), "", errUnsupportedAddress},
+		{(*btcutil.AddressTaproot)(nil), "", errUnsupportedAddress},
 
 		// Unsupported address type.
 		{&bogusAddress{}, "", errUnsupportedAddress},

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -71,6 +71,20 @@ func newAddressScriptHash(scriptHash []byte) btcutil.Address {
 	return addr
 }
 
+// newAddressTaproot returns a new btcutil.AddressTaproot from the
+// provided hash.  It panics if an error occurs.  This is only used in the tests
+// as a helper since the only way it can fail is if there is an error in the
+// test source code.
+func newAddressTaproot(scriptHash []byte) btcutil.Address {
+	addr, err := btcutil.NewAddressTaproot(scriptHash,
+		&chaincfg.MainNetParams)
+	if err != nil {
+		panic("invalid script hash in test source")
+	}
+
+	return addr
+}
+
 // TestExtractPkScriptAddrs ensures that extracting the type, addresses, and
 // number of required signatures from PkScripts works as intended.
 func TestExtractPkScriptAddrs(t *testing.T) {
@@ -311,8 +325,15 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 			reqSigs: 1,
 			class:   MultiSigTy,
 		},
-		// from real tx: 691dd277dc0e90a462a3d652a1171686de49cf19067cd33c7df0392833fb986a, vout 44
-		// invalid public keys
+		{
+			name: "v1 p2tr witness-script-hash",
+			script: hexToBytes("51201a82f7457a9ba6ab1074e9f50" +
+				"053eefc637f8b046e389b636766bdc7d1f676f8"),
+			addrs: []btcutil.Address{newAddressTaproot(
+				hexToBytes("1a82f7457a9ba6ab1074e9f50053eefc637f8b046e389b636766bdc7d1f676f8"))},
+			reqSigs: 1,
+			class:   WitnessV1TaprootTy,
+		},
 		{
 			name: "1 of 3 multisig with invalid pubkeys 2",
 			script: hexToBytes("514134633365633235396337346461636" +

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -334,6 +334,8 @@ func TestExtractPkScriptAddrs(t *testing.T) {
 			reqSigs: 1,
 			class:   WitnessV1TaprootTy,
 		},
+		// from real tx: 691dd277dc0e90a462a3d652a1171686de49cf19067cd33c7df0392833fb986a, vout 44
+		// invalid public keys
 		{
 			name: "1 of 3 multisig with invalid pubkeys 2",
 			script: hexToBytes("514134633365633235396337346461636" +


### PR DESCRIPTION
Add the `WitnessV1TaprootTy` script class and return it from `GetScriptClass` / `typeOfScript`.

Fix `ComputePkScript`, which was returning incorrect results for taproot (an probably other) scripts. `ComputePkScript` is now essentially useless for both v0 and v1 output witnesses.

Bump the **btcutil** dep to leverage new taproot address type.