### PR TITLE
btcjson: add addresstype arg to getnewaddress

### DIFF
--- a/btcjson/jsonrpcerr.go
+++ b/btcjson/jsonrpcerr.go
@@ -117,6 +117,9 @@ const (
 	// example, key not found, etc.
 	ErrRPCWallet RPCErrorCode = -4
 
+	// ErrRPCWalletInvalidAddressType indicates an invalid address type.
+	ErrRPCWalletInvalidAddressType RPCErrorCode = -5
+
 	// ErrRPCWalletInsufficientFunds indicates that there are not enough
 	// funds in wallet or account.
 	ErrRPCWalletInsufficientFunds RPCErrorCode = -6

--- a/btcjson/walletsvrcmds.go
+++ b/btcjson/walletsvrcmds.go
@@ -242,7 +242,8 @@ func NewGetBalancesCmd() *GetBalancesCmd {
 
 // GetNewAddressCmd defines the getnewaddress JSON-RPC command.
 type GetNewAddressCmd struct {
-	Account *string
+	Account     *string
+	AddressType *string
 }
 
 // NewGetNewAddressCmd returns a new instance which can be used to issue a
@@ -250,9 +251,10 @@ type GetNewAddressCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewGetNewAddressCmd(account *string) *GetNewAddressCmd {
+func NewGetNewAddressCmd(account, addrType *string) *GetNewAddressCmd {
 	return &GetNewAddressCmd{
-		Account: account,
+		Account:     account,
+		AddressType: addrType,
 	}
 }
 

--- a/btcjson/walletsvrcmds.go
+++ b/btcjson/walletsvrcmds.go
@@ -260,7 +260,8 @@ func NewGetNewAddressCmd(account, addrType *string) *GetNewAddressCmd {
 
 // GetRawChangeAddressCmd defines the getrawchangeaddress JSON-RPC command.
 type GetRawChangeAddressCmd struct {
-	Account *string
+	Account     *string
+	AddressType *string
 }
 
 // NewGetRawChangeAddressCmd returns a new instance which can be used to issue a
@@ -268,9 +269,10 @@ type GetRawChangeAddressCmd struct {
 //
 // The parameters which are pointers indicate they are optional.  Passing nil
 // for optional parameters will use the default value.
-func NewGetRawChangeAddressCmd(account *string) *GetRawChangeAddressCmd {
+func NewGetRawChangeAddressCmd(account, addrType *string) *GetRawChangeAddressCmd {
 	return &GetRawChangeAddressCmd{
-		Account: account,
+		Account:     account,
+		AddressType: addrType,
 	}
 }
 

--- a/btcjson/walletsvrcmds_test.go
+++ b/btcjson/walletsvrcmds_test.go
@@ -407,24 +407,26 @@ func TestWalletSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getrawchangeaddress")
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetRawChangeAddressCmd(nil)
+				return btcjson.NewGetRawChangeAddressCmd(nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getrawchangeaddress","params":[],"id":1}`,
 			unmarshalled: &btcjson.GetRawChangeAddressCmd{
-				Account: nil,
+				Account:     nil,
+				AddressType: nil,
 			},
 		},
 		{
 			name: "getrawchangeaddress optional",
 			newCmd: func() (interface{}, error) {
-				return btcjson.NewCmd("getrawchangeaddress", "acct")
+				return btcjson.NewCmd("getrawchangeaddress", "acct", "legacy")
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetRawChangeAddressCmd(btcjson.String("acct"))
+				return btcjson.NewGetRawChangeAddressCmd(btcjson.String("acct"), btcjson.String("legacy"))
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"getrawchangeaddress","params":["acct"],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"getrawchangeaddress","params":["acct","legacy"],"id":1}`,
 			unmarshalled: &btcjson.GetRawChangeAddressCmd{
-				Account: btcjson.String("acct"),
+				Account:     btcjson.String("acct"),
+				AddressType: btcjson.String("legacy"),
 			},
 		},
 		{

--- a/btcjson/walletsvrcmds_test.go
+++ b/btcjson/walletsvrcmds_test.go
@@ -379,24 +379,26 @@ func TestWalletSvrCmds(t *testing.T) {
 				return btcjson.NewCmd("getnewaddress")
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetNewAddressCmd(nil)
+				return btcjson.NewGetNewAddressCmd(nil, nil)
 			},
 			marshalled: `{"jsonrpc":"1.0","method":"getnewaddress","params":[],"id":1}`,
 			unmarshalled: &btcjson.GetNewAddressCmd{
-				Account: nil,
+				Account:     nil,
+				AddressType: nil,
 			},
 		},
 		{
 			name: "getnewaddress optional",
 			newCmd: func() (interface{}, error) {
-				return btcjson.NewCmd("getnewaddress", "acct")
+				return btcjson.NewCmd("getnewaddress", "acct", "legacy")
 			},
 			staticCmd: func() interface{} {
-				return btcjson.NewGetNewAddressCmd(btcjson.String("acct"))
+				return btcjson.NewGetNewAddressCmd(btcjson.String("acct"), btcjson.String("legacy"))
 			},
-			marshalled: `{"jsonrpc":"1.0","method":"getnewaddress","params":["acct"],"id":1}`,
+			marshalled: `{"jsonrpc":"1.0","method":"getnewaddress","params":["acct","legacy"],"id":1}`,
 			unmarshalled: &btcjson.GetNewAddressCmd{
-				Account: btcjson.String("acct"),
+				Account:     btcjson.String("acct"),
+				AddressType: btcjson.String("legacy"),
 			},
 		},
 		{

--- a/mempool/mempool_test.go
+++ b/mempool/mempool_test.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcd/btcutil"
 )
 
 // fakeChain is used by the pool harness to provide generated test utxos and
@@ -560,7 +560,7 @@ func TestOrphanReject(t *testing.T) {
 
 		// Ensure no transactions were reported as accepted.
 		if len(acceptedTxns) != 0 {
-			t.Fatal("ProcessTransaction: reported %d accepted "+
+			t.Fatalf("ProcessTransaction: reported %d accepted "+
 				"transactions from failed orphan attempt",
 				len(acceptedTxns))
 		}

--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -1135,8 +1135,8 @@ func (r FutureGetRawChangeAddressResult) Receive() (btcutil.Address, error) {
 // function on the returned instance.
 //
 // See GetRawChangeAddress for the blocking version and more details.
-func (c *Client) GetRawChangeAddressAsync(account string) FutureGetRawChangeAddressResult {
-	cmd := btcjson.NewGetRawChangeAddressCmd(&account)
+func (c *Client) GetRawChangeAddressAsync(account, addrType string) FutureGetRawChangeAddressResult {
+	cmd := btcjson.NewGetRawChangeAddressCmd(&account, &addrType)
 	result := FutureGetRawChangeAddressResult{
 		network:         c.chainParams,
 		responseChannel: c.SendCmd(cmd),
@@ -1147,8 +1147,8 @@ func (c *Client) GetRawChangeAddressAsync(account string) FutureGetRawChangeAddr
 // GetRawChangeAddress returns a new address for receiving change that will be
 // associated with the provided account.  Note that this is only for raw
 // transactions and NOT for normal use.
-func (c *Client) GetRawChangeAddress(account string) (btcutil.Address, error) {
-	return c.GetRawChangeAddressAsync(account).Receive()
+func (c *Client) GetRawChangeAddress(account, addrType string) (btcutil.Address, error) {
+	return c.GetRawChangeAddressAsync(account, addrType).Receive()
 }
 
 // FutureAddWitnessAddressResult is a future promise to deliver the result of

--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -1089,8 +1089,8 @@ func (r FutureGetNewAddressResult) Receive() (btcutil.Address, error) {
 // returned instance.
 //
 // See GetNewAddress for the blocking version and more details.
-func (c *Client) GetNewAddressAsync(account string) FutureGetNewAddressResult {
-	cmd := btcjson.NewGetNewAddressCmd(&account)
+func (c *Client) GetNewAddressAsync(account, addrType string) FutureGetNewAddressResult {
+	cmd := btcjson.NewGetNewAddressCmd(&account, &addrType)
 	result := FutureGetNewAddressResult{
 		network:         c.chainParams,
 		responseChannel: c.SendCmd(cmd),
@@ -1100,8 +1100,8 @@ func (c *Client) GetNewAddressAsync(account string) FutureGetNewAddressResult {
 
 // GetNewAddress returns a new address, and decodes based on the client's
 // chain params.
-func (c *Client) GetNewAddress(account string) (btcutil.Address, error) {
-	return c.GetNewAddressAsync(account).Receive()
+func (c *Client) GetNewAddress(account, addrType string) (btcutil.Address, error) {
+	return c.GetNewAddressAsync(account, addrType).Receive()
 }
 
 // FutureGetRawChangeAddressResult is a future promise to deliver the result of


### PR DESCRIPTION
This adds a `AddressType` field to the `btcjson.GetNewAddressCmd` type to facilitate requesting different address types from btcwallet.
Required for https://github.com/btcsuite/btcwallet/pull/783
Partially resolves https://github.com/btcsuite/btcd/issues/1703