### PR TITLE
rpcclient+rpcserver+integration: GetNetworkHashPS3 must be float64

### DIFF
--- a/rpcclient/mining.go
+++ b/rpcclient/mining.go
@@ -255,14 +255,14 @@ type FutureGetNetworkHashPS chan *Response
 // Receive waits for the Response promised by the future and returns the
 // estimated network hashes per second for the block heights provided by the
 // parameters.
-func (r FutureGetNetworkHashPS) Receive() (int64, error) {
+func (r FutureGetNetworkHashPS) Receive() (float64, error) {
 	res, err := ReceiveFuture(r)
 	if err != nil {
 		return -1, err
 	}
 
-	// Unmarshal result as an int64.
-	var result int64
+	// Unmarshal result as an float64.
+	var result float64
 	err = json.Unmarshal(res, &result)
 	if err != nil {
 		return 0, err
@@ -286,7 +286,7 @@ func (c *Client) GetNetworkHashPSAsync() FutureGetNetworkHashPS {
 //
 // See GetNetworkHashPS2 to override the number of blocks to use and
 // GetNetworkHashPS3 to override the height at which to calculate the estimate.
-func (c *Client) GetNetworkHashPS() (int64, error) {
+func (c *Client) GetNetworkHashPS() (float64, error) {
 	return c.GetNetworkHashPSAsync().Receive()
 }
 
@@ -307,7 +307,7 @@ func (c *Client) GetNetworkHashPS2Async(blocks int) FutureGetNetworkHashPS {
 //
 // See GetNetworkHashPS to use defaults and GetNetworkHashPS3 to override the
 // height at which to calculate the estimate.
-func (c *Client) GetNetworkHashPS2(blocks int) (int64, error) {
+func (c *Client) GetNetworkHashPS2(blocks int) (float64, error) {
 	return c.GetNetworkHashPS2Async(blocks).Receive()
 }
 
@@ -327,7 +327,7 @@ func (c *Client) GetNetworkHashPS3Async(blocks, height int) FutureGetNetworkHash
 // of blocks since the last difficulty change will be used.
 //
 // See GetNetworkHashPS and GetNetworkHashPS2 to use defaults.
-func (c *Client) GetNetworkHashPS3(blocks, height int) (int64, error) {
+func (c *Client) GetNetworkHashPS3(blocks, height int) (float64, error) {
 	return c.GetNetworkHashPS3Async(blocks, height).Receive()
 }
 

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -740,7 +740,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getmempoolinfo":         {(*btcjson.GetMempoolInfoResult)(nil)},
 	"getmininginfo":          {(*btcjson.GetMiningInfoResult)(nil)},
 	"getnettotals":           {(*btcjson.GetNetTotalsResult)(nil)},
-	"getnetworkhashps":       {(*int64)(nil)},
+	"getnetworkhashps":       {(*float64)(nil)},
 	"getnodeaddresses":       {(*[]btcjson.GetNodeAddressesResult)(nil)},
 	"getpeerinfo":            {(*[]btcjson.GetPeerInfoResult)(nil)},
 	"getrawmempool":          {(*[]string)(nil), (*btcjson.GetRawMempoolVerboseResult)(nil)},


### PR DESCRIPTION
## Description
Fixes [rpcclient issue](https://github.com/btcsuite/btcd/issues/1747) caused by using the rpcclient with bitcoind and expecting an int64, but bitcoind is [returning a float64](https://github.com/bitcoin/bitcoin/pull/7480/files).

## Changes
- Change getnetworkhashps and handlers return type from an int64 to a float64 to be aligned with bitcoin core and to also avoid the overflow

## Testing
- Extended rpcserver integration tests to test client methods `GetNetworkHashPS`, `GetNetworkHashPS2`, and `GetNetworkHashPS3`