### PR TITLE
btcjson: Deprecate {DecodeScriptResult,ScriptPubKeyResult}.{addresses,reqSigs} and use address instead.

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -138,11 +138,10 @@ type CreateMultiSigResult struct {
 
 // DecodeScriptResult models the data returned from the decodescript command.
 type DecodeScriptResult struct {
-	Asm       string   `json:"asm"`
-	ReqSigs   int32    `json:"reqSigs,omitempty"`
-	Type      string   `json:"type"`
-	Addresses []string `json:"addresses,omitempty"`
-	P2sh      string   `json:"p2sh,omitempty"`
+	Asm     string `json:"asm"`
+	Type    string `json:"type"`
+	Address string `json:"address,omitempty"`
+	P2sh    string `json:"p2sh,omitempty"`
 }
 
 // GetAddedNodeInfoResultAddr models the data of the addresses portion of the
@@ -424,11 +423,10 @@ type GetRawMempoolVerboseResult struct {
 // ScriptPubKeyResult models the scriptPubKey data of a tx script.  It is
 // defined separately since it is used by multiple commands.
 type ScriptPubKeyResult struct {
-	Asm       string   `json:"asm"`
-	Hex       string   `json:"hex,omitempty"`
-	ReqSigs   int32    `json:"reqSigs,omitempty"`
-	Type      string   `json:"type"`
-	Addresses []string `json:"addresses,omitempty"`
+	Asm     string `json:"asm"`
+	Hex     string `json:"hex,omitempty"`
+	Type    string `json:"type"`
+	Address string `json:"address,omitempty"`
 }
 
 // GetTxOutResult models the data from the gettxout command.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -833,11 +833,11 @@ func handleDecodeScript(s *rpcServer, cmd interface{}, closeChan <-chan struct{}
 	// Get information about the script.
 	// Ignore the error here since an error means the script couldn't parse
 	// and there is no additinal information about it anyways.
-	scriptClass, addrs, reqSigs, _ := txscript.ExtractPkScriptAddrs(script,
+	scriptClass, addrs, _, _ := txscript.ExtractPkScriptAddrs(script,
 		s.cfg.ChainParams)
-	addresses := make([]string, len(addrs))
-	for i, addr := range addrs {
-		addresses[i] = addr.EncodeAddress()
+	var address string
+	if len(addrs) > 0 {
+		address = addrs[0].EncodeAddress()
 	}
 
 	// Convert the script itself to a pay-to-script-hash address.
@@ -849,10 +849,9 @@ func handleDecodeScript(s *rpcServer, cmd interface{}, closeChan <-chan struct{}
 
 	// Generate and return the reply.
 	reply := btcjson.DecodeScriptResult{
-		Asm:       disbuf,
-		ReqSigs:   int32(reqSigs),
-		Type:      scriptClass.String(),
-		Addresses: addresses,
+		Asm:     disbuf,
+		Type:    scriptClass.String(),
+		Address: address,
 	}
 	if scriptClass != txscript.ScriptHashTy {
 		reply.P2sh = p2sh.EncodeAddress()
@@ -2780,11 +2779,11 @@ func handleGetTxOut(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (i
 	// Get further info about the script.
 	// Ignore the error here since an error means the script couldn't parse
 	// and there is no additional information about it anyways.
-	scriptClass, addrs, reqSigs, _ := txscript.ExtractPkScriptAddrs(pkScript,
+	scriptClass, addrs, _, _ := txscript.ExtractPkScriptAddrs(pkScript,
 		s.cfg.ChainParams)
-	addresses := make([]string, len(addrs))
-	for i, addr := range addrs {
-		addresses[i] = addr.EncodeAddress()
+	var address string
+	if len(addrs) > 0 {
+		address = addrs[0].EncodeAddress()
 	}
 
 	txOutReply := &btcjson.GetTxOutResult{
@@ -2792,11 +2791,10 @@ func handleGetTxOut(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (i
 		Confirmations: int64(confirmations),
 		Value:         btcutil.Amount(value).ToBTC(),
 		ScriptPubKey: btcjson.ScriptPubKeyResult{
-			Asm:       disbuf,
-			Hex:       hex.EncodeToString(pkScript),
-			ReqSigs:   int32(reqSigs),
-			Type:      scriptClass.String(),
-			Addresses: addresses,
+			Asm:     disbuf,
+			Hex:     hex.EncodeToString(pkScript),
+			Type:    scriptClass.String(),
+			Address: address,
 		},
 		Coinbase: isCoinbase,
 	}


### PR DESCRIPTION
Fixes #1754.

Context: https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-22.0.md#new-and-updated-rpcs
