### PR TITLE
btcd: don't override explicitly set GOGC

### DIFF
--- a/btcd.go
+++ b/btcd.go
@@ -297,11 +297,14 @@ func loadBlockDB() (database.DB, error) {
 }
 
 func main() {
-	// Block and transaction processing can cause bursty allocations.  This
-	// limits the garbage collector from excessively overallocating during
-	// bursts.  This value was arrived at with the help of profiling live
-	// usage.
-	debug.SetGCPercent(10)
+	// If GOGC is not explicitly set, override GC percent.
+	if os.Getenv("GOGC") == "" {
+		// Block and transaction processing can cause bursty allocations.  This
+		// limits the garbage collector from excessively overallocating during
+		// bursts.  This value was arrived at with the help of profiling live
+		// usage.
+		debug.SetGCPercent(10)
+	}
 
 	// Up some limits.
 	if err := limits.SetLimits(); err != nil {


### PR DESCRIPTION
If GOGC env var is explicitly set, use it. Otherwise, set GC to 10% (default).