### PR TITLE
chaincfg: Use FQDN for DNS seed domain names

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -258,12 +258,12 @@ var MainNetParams = Params{
 	Net:         wire.MainNet,
 	DefaultPort: "8333",
 	DNSSeeds: []DNSSeed{
-		{"seed.bitcoin.sipa.be", true},
-		{"dnsseed.bluematt.me", true},
-		{"dnsseed.bitcoin.dashjr.org", false},
-		{"seed.bitcoinstats.com", true},
-		{"seed.bitnodes.io", false},
-		{"seed.bitcoin.jonasschnelli.ch", true},
+		{"seed.bitcoin.sipa.be.", true},
+		{"dnsseed.bluematt.me.", true},
+		{"dnsseed.bitcoin.dashjr.org.", false},
+		{"seed.bitcoinstats.com.", true},
+		{"seed.bitnodes.io.", false},
+		{"seed.bitcoin.jonasschnelli.ch.", true},
 	},
 
 	// Chain parameters
@@ -441,10 +441,10 @@ var TestNet3Params = Params{
 	Net:         wire.TestNet3,
 	DefaultPort: "18333",
 	DNSSeeds: []DNSSeed{
-		{"testnet-seed.bitcoin.jonasschnelli.ch", true},
-		{"testnet-seed.bitcoin.schildbach.de", false},
-		{"seed.tbtc.petertodd.org", true},
-		{"testnet-seed.bluematt.me", false},
+		{"testnet-seed.bitcoin.jonasschnelli.ch.", true},
+		{"testnet-seed.bitcoin.schildbach.de.", false},
+		{"seed.tbtc.petertodd.org.", true},
+		{"testnet-seed.bluematt.me.", false},
 	},
 
 	// Chain parameters


### PR DESCRIPTION
Small PR to use FQDN (full stop at the end) to avoid ambiguity.

See: 
https://github.com/bitcoin/bitcoin/issues/23193
https://github.com/bitcoin/bitcoin/pull/23268