### PR TITLE
btcutil/base58: fix bug with range

### DIFF
--- a/btcutil/base58/base58.go
+++ b/btcutil/base58/base58.go
@@ -54,8 +54,8 @@ func Decode(b string) []byte {
 		}
 
 		total := uint64(0)
-		for _, v := range t[:n] {
-			tmp := b58[v]
+		for k := 0; k < n; k++ {
+			tmp := b58[t[k]]
 			if tmp == 255 {
 				return []byte("")
 			}

--- a/btcutil/base58/base58_test.go
+++ b/btcutil/base58/base58_test.go
@@ -43,6 +43,7 @@ var invalidStringTests = []struct {
 	{"4kl8", ""},
 	{"0OIl", ""},
 	{"!@#$%^&*()-_=+~`", ""},
+	{"\xdc", ""},
 }
 
 var hexTests = []struct {


### PR DESCRIPTION
The decoding was using a range over the string instead of iterating
over the bytes.