### PR TITLE
btcjson: Update fields in GetNetworkInfoResult

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -364,6 +364,8 @@ type GetNetworkInfoResult struct {
 	LocalRelay      bool                   `json:"localrelay"`
 	TimeOffset      int64                  `json:"timeoffset"`
 	Connections     int32                  `json:"connections"`
+	ConnectionsIn   int32                  `json:"connections_in"`
+	ConnectionsOut  int32                  `json:"connections_out"`
 	NetworkActive   bool                   `json:"networkactive"`
 	Networks        []NetworksResult       `json:"networks"`
 	RelayFee        float64                `json:"relayfee"`


### PR DESCRIPTION
Update the fields of GetNetworkInfoResult to reflect the current number of inbound and outbound peer connections.

* ConnectionsIn - The number of inbound peer connections
* ConnectionsOut - The number of outbound peer connections


ref: https://github.com/bitcoin/bitcoin/pull/19405
release note: https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.21.0.md#updated-rpcs

```
getnetworkinfo now returns two new fields, connections_in and connections_out, that provide the number of inbound and outbound peer connections. These new fields are in addition to the existing connections field, which returns the total number of peer connections. (#19405)
```