### PR TITLE
build: update to btcec v2.1.0

### DIFF
--- a/btcutil/go.mod
+++ b/btcutil/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/aead/siphash v1.0.1
 	github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c
-	github.com/btcsuite/btcd/btcec/v2 v2.0.0
+	github.com/btcsuite/btcd/btcec/v2 v2.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
 	github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23

--- a/btcutil/psbt/go.mod
+++ b/btcutil/psbt/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c
-	github.com/btcsuite/btcd/btcec/v2 v2.0.0
+	github.com/btcsuite/btcd/btcec/v2 v2.1.0
 	github.com/btcsuite/btcd/btcutil v1.0.0
 	github.com/davecgh/go-spew v1.1.1
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/btcsuite/btcd
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.0.0
+	github.com/btcsuite/btcd/btcec/v2 v2.1.0
 	github.com/btcsuite/btcd/btcutil v1.0.0
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd


### PR DESCRIPTION
This was the version tagged that created the new `ecdsa` and `schnorr`
packages. Updating these pinned version lets importers properly use
these packages and build. Things build as is since we use replace
directive to point to the latest version _in the repo_ when we build.