### PR TITLE
Revert "reduce redundant memory allocatio - resolves btcsuite/btcd#1699"

### DIFF
--- a/connmgr/tor.go
+++ b/connmgr/tor.go
@@ -76,7 +76,7 @@ func TorLookupIP(host, proxy string) ([]net.IP, error) {
 		return nil, ErrTorUnrecognizedAuthMethod
 	}
 
-	buf = make([]byte, 6+len(host))
+	buf = make([]byte, 7+len(host))
 	buf[0] = 5      // protocol version
 	buf[1] = '\xF0' // Tor Resolve
 	buf[2] = 0      // reserved


### PR DESCRIPTION
This reverts commit 780cc0889fd2f326e4a2a9b513d8d30ff37e0cd2.

Oversight on my part, that extra byte is actually used. Without this, DNS resolution via tor proxy won't work