### PR TITLE
build: retract bogus tags from btcd fork

### DIFF
--- a/btcec/go.sum
+++ b/btcec/go.sum
@@ -1,6 +1,6 @@
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
-github.com/btcsuite/btcd/btcec/v2 v2.0.0/go.mod h1:vu+77Lro3alBlmsmlDnkZtgGiNo6OBwMHSb1XTGDwGo=
-github.com/btcsuite/btcd/btcutil v1.0.0/go.mod h1:Uoxwv0pqYWhD//tfTiipkxNfdhG9UrLwaeswfjfdF0A=
+github.com/btcsuite/btcd/btcec/v2 v2.1.0/go.mod h1:2VzYrv4Gm4apmbVVsSq5bqf1Ec8v56E48Vt0Y/umPgA=
+github.com/btcsuite/btcd/btcutil v1.1.0/go.mod h1:5OapHB7A2hBBWLm48mmw4MOHNJCcUBTwmWH/0Jn8VHE=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=
 github.com/btcsuite/goleveldb v1.0.0/go.mod h1:QiK9vBlgftBg6rWQIj6wFzbPfRjiykIEhBH4obrXJ/I=

--- a/btcutil/go.sum
+++ b/btcutil/go.sum
@@ -1,6 +1,6 @@
 github.com/aead/siphash v1.0.1 h1:FwHfE/T45KPKYuuSAKyyvE+oPWcaQ+CUmFW0bPlM+kg=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
-github.com/btcsuite/btcd/btcutil v1.0.0/go.mod h1:Uoxwv0pqYWhD//tfTiipkxNfdhG9UrLwaeswfjfdF0A=
+github.com/btcsuite/btcd/btcutil v1.1.0/go.mod h1:5OapHB7A2hBBWLm48mmw4MOHNJCcUBTwmWH/0Jn8VHE=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=

--- a/btcutil/psbt/go.mod
+++ b/btcutil/psbt/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c
 	github.com/btcsuite/btcd/btcec/v2 v2.1.0
-	github.com/btcsuite/btcd/btcutil v1.0.0
+	github.com/btcsuite/btcd/btcutil v1.1.0
 	github.com/davecgh/go-spew v1.1.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/btcsuite/btcd
 
 require (
 	github.com/btcsuite/btcd/btcec/v2 v2.1.0
-	github.com/btcsuite/btcd/btcutil v1.0.0
+	github.com/btcsuite/btcd/btcutil v1.1.0
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd
 	github.com/btcsuite/goleveldb v1.0.0
@@ -25,5 +25,37 @@ require (
 replace github.com/btcsuite/btcd/btcutil => ./btcutil
 
 replace github.com/btcsuite/btcd/btcec/v2 => ./btcec
+
+// The retract statements below fixes an accidental push of the tags of a btcd
+// fork.
+retract (
+	v0.18.1
+	v0.18.0
+	v0.17.1
+	v0.17.0
+	v0.16.5
+	v0.16.4
+	v0.16.3
+	v0.16.2
+	v0.16.1
+	v0.16.0
+
+	v0.15.2
+	v0.15.1
+	v0.15.0
+
+	v0.14.7
+	v0.14.6
+	v0.14.6
+	v0.14.5
+	v0.14.4
+	v0.14.3
+	v0.14.2
+	v0.14.1
+
+	v0.14.0
+	v0.13.0-beta2
+	v0.13.0-beta
+)
 
 go 1.17


### PR DESCRIPTION
Fixes https://github.com/btcsuite/btcd/issues/1791.