### PR TITLE
mining: return witness_script instead of raw witness_commitment in GBT

### DIFF
--- a/mining/mining.go
+++ b/mining/mining.go
@@ -863,7 +863,7 @@ mempoolLoop:
 }
 
 // AddWitnessCommitment adds the witness commitment as an OP_RETURN outpout
-// within the coinbase tx.  The raw commitment is returned.
+// within the coinbase tx.  The witness script is returned.
 func AddWitnessCommitment(coinbaseTx *btcutil.Tx,
 	blockTxns []*btcutil.Tx) []byte {
 
@@ -902,7 +902,7 @@ func AddWitnessCommitment(coinbaseTx *btcutil.Tx,
 	coinbaseTx.MsgTx().TxOut = append(coinbaseTx.MsgTx().TxOut,
 		commitmentOutput)
 
-	return witnessCommitment
+	return witnessScript
 }
 
 // UpdateBlockTime updates the timestamp in the header of the passed block to


### PR DESCRIPTION
The `"default_witness_commit"` in the `getblocktemplate` response uses the witness_script instead of raw commitment.