### PR TITLE
harden daemon on OpenBSD

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/logrotate v1.0.0
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	golang.org/x/sys v0.0.0-20200814200057-3d37ad5750ed
 )
 
 require (

--- a/ossec/ossec.go
+++ b/ossec/ossec.go
@@ -1,0 +1,15 @@
+//go:build !openbsd
+
+package ossec
+
+func Unveil(path string, perms string) error {
+	return nil
+}
+
+func Pledge(promises, execpromises string) error {
+	return nil
+}
+
+func PledgePromises(promises string) error {
+	return nil
+}

--- a/ossec/ossec_openbsd.go
+++ b/ossec/ossec_openbsd.go
@@ -1,0 +1,17 @@
+package ossec
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+func Unveil(path string, perms string) error {
+	return unix.Unveil(path, perms)
+}
+
+func Pledge(promises, execpromises string) error {
+	return unix.Pledge(promises, execpromises)
+}
+
+func PledgePromises(promises string) error {
+	return unix.PledgePromises(promises)
+}


### PR DESCRIPTION
I've created a patch to harden the daemon on OpenBSD by using [pledge(2)](http://man.openbsd.org/pledge) and [unveil(2)](http://man.openbsd.org/unveil). This way the program gets killed if any syscall is called other than the basic networking or file system ones, preventing further exploitation of a system once a program is compromised. Furthermore, the view of the file system is restricted to only access the files and directories the daemon needs.