### PR TITLE
btcec/schnorr/musig2: add new musig2 implementation based on musig2 draft BIP

### DIFF
--- a/btcec/go.mod
+++ b/btcec/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
+	golang.org/x/exp v0.0.0-20220426173459-3bcf042a4bf5
 )
 
 require github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect

--- a/btcec/go.mod
+++ b/btcec/go.mod
@@ -3,7 +3,7 @@ module github.com/btcsuite/btcd/btcec/v2
 go 1.17
 
 require (
-	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0
+	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
 )

--- a/btcec/go.sum
+++ b/btcec/go.sum
@@ -1,5 +1,5 @@
-github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0 h1:MSskdM4/xJYcFzy0altH/C/xHopifpWzHUi1JeVI34Q=
-github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
+github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
+github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=

--- a/btcec/go.sum
+++ b/btcec/go.sum
@@ -6,3 +6,5 @@ github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
+golang.org/x/exp v0.0.0-20220426173459-3bcf042a4bf5 h1:rxKZ2gOnYxjfmakvUUqh9Gyb6KXfrj7JWTxORTYqb0E=
+golang.org/x/exp v0.0.0-20220426173459-3bcf042a4bf5/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=

--- a/btcec/schnorr/musig2/bench_test.go
+++ b/btcec/schnorr/musig2/bench_test.go
@@ -301,11 +301,16 @@ func BenchmarkAggregateKeys(b *testing.B) {
 			name := fmt.Sprintf("num_signers=%v/sort_keys=%v",
 				numSigners, sortKeys)
 
+			uniqueKeyIndex := secondUniqueKeyIndex(signerKeys)
+
 			b.Run(name, func(b *testing.B) {
 				b.ResetTimer()
 				b.ReportAllocs()
 
-				aggKey := AggregateKeys(signerKeys, sortKeys)
+				aggKey := AggregateKeys(
+					signerKeys, sortKeys,
+					WithUniqueKeyIndex(uniqueKeyIndex),
+				)
 
 				testKey = aggKey
 			})

--- a/btcec/schnorr/musig2/bench_test.go
+++ b/btcec/schnorr/musig2/bench_test.go
@@ -301,7 +301,7 @@ func BenchmarkAggregateKeys(b *testing.B) {
 				b.ResetTimer()
 				b.ReportAllocs()
 
-				aggKey := AggregateKeys(
+				aggKey, _, _, _ := AggregateKeys(
 					signerKeys, sortKeys,
 					WithUniqueKeyIndex(uniqueKeyIndex),
 				)

--- a/btcec/schnorr/musig2/bench_test.go
+++ b/btcec/schnorr/musig2/bench_test.go
@@ -1,0 +1,314 @@
+// Copyright 2013-2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package musig2
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+var (
+	testPrivBytes = hexToModNScalar("9e0699c91ca1e3b7e3c9ba71eb71c89890872be97576010fe593fbf3fd57e66d")
+
+	testMsg = hexToBytes("c301ba9de5d6053caad9f5eb46523f007702add2c62fa39de03146a36b8026b7")
+)
+
+func hexToBytes(s string) []byte {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic("invalid hex in source file: " + s)
+	}
+	return b
+}
+
+func hexToModNScalar(s string) *btcec.ModNScalar {
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		panic("invalid hex in source file: " + s)
+	}
+	var scalar btcec.ModNScalar
+	if overflow := scalar.SetByteSlice(b); overflow {
+		panic("hex in source file overflows mod N scalar: " + s)
+	}
+	return &scalar
+}
+
+func genSigner(t *testing.B) signer {
+	privKey, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatalf("unable to gen priv key: %v", err)
+	}
+
+	pubKey, err := schnorr.ParsePubKey(
+		schnorr.SerializePubKey(privKey.PubKey()),
+	)
+	if err != nil {
+		t.Fatalf("unable to gen key: %v", err)
+	}
+
+	nonces, err := GenNonces()
+	if err != nil {
+		t.Fatalf("unable to gen nonces: %v", err)
+	}
+
+	return signer{
+		privKey: privKey,
+		pubKey:  pubKey,
+		nonces:  nonces,
+	}
+}
+
+var (
+	testSig *PartialSignature
+	testErr error
+)
+
+// BenchmarkPartialSign benchmarks how long it takes to generate a partial
+// signature factoring in if the keys are sorted and also if we're in fast sign
+// mode.
+func BenchmarkPartialSign(b *testing.B) {
+	privKey := secp256k1.NewPrivateKey(testPrivBytes)
+
+	for _, numSigners := range []int{10, 100} {
+		for _, fastSign := range []bool{true, false} {
+			for _, sortKeys := range []bool{true, false} {
+				name := fmt.Sprintf("num_signers=%v/fast_sign=%v/sort=%v",
+					numSigners, fastSign, sortKeys)
+
+				nonces, err := GenNonces()
+				if err != nil {
+					b.Fatalf("unable to generate nonces: %v", err)
+				}
+
+				signers := make(signerSet, numSigners)
+				for i := 0; i < numSigners; i++ {
+					signers[i] = genSigner(b)
+				}
+
+				combinedNonce, err := AggregateNonces(signers.pubNonces())
+				if err != nil {
+					b.Fatalf("unable to generate combined nonce: %v", err)
+				}
+
+				var sig *PartialSignature
+
+				var msg [32]byte
+				copy(msg[:], testMsg[:])
+
+				keys := signers.keys()
+
+				b.Run(name, func(b *testing.B) {
+					var signOpts []SignOption
+					if fastSign {
+						signOpts = append(signOpts, WithFastSign())
+					}
+					if sortKeys {
+						signOpts = append(signOpts, WithSortedKeys())
+					}
+
+					b.ResetTimer()
+					b.ReportAllocs()
+
+					for i := 0; i < b.N; i++ {
+						sig, err = Sign(
+							nonces.SecNonce, privKey, combinedNonce,
+							keys, msg, signOpts...,
+						)
+					}
+
+					testSig = sig
+					testErr = err
+				})
+			}
+		}
+	}
+}
+
+// TODO(roasbeef): add impact of sorting ^
+
+var sigOk bool
+
+// BenchmarkPartialVerify benchmarks how long it takes to verify a partial
+// signature.
+func BenchmarkPartialVerify(b *testing.B) {
+	privKey := secp256k1.NewPrivateKey(testPrivBytes)
+
+	for _, numSigners := range []int{10, 100} {
+		for _, sortKeys := range []bool{true, false} {
+			name := fmt.Sprintf("sort_keys=%v/num_signers=%v",
+				sortKeys, numSigners)
+
+			nonces, err := GenNonces()
+			if err != nil {
+				b.Fatalf("unable to generate nonces: %v", err)
+			}
+
+			signers := make(signerSet, numSigners)
+			for i := 0; i < numSigners; i++ {
+				signers[i] = genSigner(b)
+			}
+
+			combinedNonce, err := AggregateNonces(
+				signers.pubNonces(),
+			)
+			if err != nil {
+				b.Fatalf("unable to generate combined "+
+					"nonce: %v", err)
+			}
+
+			var sig *PartialSignature
+
+			var msg [32]byte
+			copy(msg[:], testMsg[:])
+
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			sig, err = Sign(
+				nonces.SecNonce, privKey, combinedNonce,
+				signers.keys(), msg, WithFastSign(),
+			)
+
+			keys := signers.keys()
+			pubKey := privKey.PubKey()
+
+			b.Run(name, func(b *testing.B) {
+				var signOpts []SignOption
+				if sortKeys {
+					signOpts = append(
+						signOpts, WithSortedKeys(),
+					)
+				}
+
+				b.ResetTimer()
+				b.ReportAllocs()
+
+				var ok bool
+				for i := 0; i < b.N; i++ {
+					ok = sig.Verify(
+						nonces.PubNonce, combinedNonce,
+						keys, pubKey, msg,
+					)
+				}
+				sigOk = ok
+			})
+
+		}
+	}
+}
+
+var finalSchnorrSig *schnorr.Signature
+
+// BenchmarkCombineSigs benchmarks how long it takes to combine a set amount of
+// signatures.
+func BenchmarkCombineSigs(b *testing.B) {
+
+	for _, numSigners := range []int{10, 100} {
+		signers := make(signerSet, numSigners)
+		for i := 0; i < numSigners; i++ {
+			signers[i] = genSigner(b)
+		}
+
+		combinedNonce, err := AggregateNonces(signers.pubNonces())
+		if err != nil {
+			b.Fatalf("unable to generate combined nonce: %v", err)
+		}
+
+		var msg [32]byte
+		copy(msg[:], testMsg[:])
+
+		var finalNonce *btcec.PublicKey
+		for i := range signers {
+			signer := signers[i]
+			partialSig, err := Sign(
+				signer.nonces.SecNonce, signer.privKey,
+				combinedNonce, signers.keys(), msg,
+			)
+			if err != nil {
+				b.Fatalf("unable to generate partial sig: %v",
+					err)
+			}
+
+			signers[i].partialSig = partialSig
+
+			if finalNonce == nil {
+				finalNonce = partialSig.R
+			}
+		}
+
+		sigs := signers.partialSigs()
+
+		name := fmt.Sprintf("num_signers=%v", numSigners)
+		b.Run(name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			finalSig := CombineSigs(finalNonce, sigs)
+
+			finalSchnorrSig = finalSig
+		})
+	}
+}
+
+var testNonce [PubNonceSize]byte
+
+// BenchmarkAggregateNonces benchmarks how long it takes to combine nonces.
+func BenchmarkAggregateNonces(b *testing.B) {
+	for _, numSigners := range []int{10, 100} {
+		signers := make(signerSet, numSigners)
+		for i := 0; i < numSigners; i++ {
+			signers[i] = genSigner(b)
+		}
+
+		nonces := signers.pubNonces()
+
+		name := fmt.Sprintf("num_signers=%v", numSigners)
+		b.Run(name, func(b *testing.B) {
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			pubNonce, err := AggregateNonces(nonces)
+			if err != nil {
+				b.Fatalf("unable to generate nonces: %v", err)
+			}
+
+			testNonce = pubNonce
+		})
+	}
+}
+
+var testKey *btcec.PublicKey
+
+// BenchmarkAggregateKeys benchmarks how long it takes to aggregate public
+// keys.
+func BenchmarkAggregateKeys(b *testing.B) {
+	for _, numSigners := range []int{10, 100} {
+		for _, sortKeys := range []bool{true, false} {
+			signers := make(signerSet, numSigners)
+			for i := 0; i < numSigners; i++ {
+				signers[i] = genSigner(b)
+			}
+
+			signerKeys := signers.keys()
+
+			name := fmt.Sprintf("num_signers=%v/sort_keys=%v",
+				numSigners, sortKeys)
+
+			b.Run(name, func(b *testing.B) {
+				b.ResetTimer()
+				b.ReportAllocs()
+
+				aggKey := AggregateKeys(signerKeys, sortKeys)
+
+				testKey = aggKey
+			})
+		}
+	}
+}

--- a/btcec/schnorr/musig2/bench_test.go
+++ b/btcec/schnorr/musig2/bench_test.go
@@ -306,7 +306,7 @@ func BenchmarkAggregateKeys(b *testing.B) {
 					WithUniqueKeyIndex(uniqueKeyIndex),
 				)
 
-				testKey = aggKey
+				testKey = aggKey.FinalKey
 			})
 		}
 	}

--- a/btcec/schnorr/musig2/context.go
+++ b/btcec/schnorr/musig2/context.go
@@ -1,0 +1,305 @@
+// Copyright (c) 2013-2022 The btcsuite developers
+
+package musig2
+
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+)
+
+var (
+	// ErrSignerNotInKeySet is returned when a the private key for a signer
+	// isn't included in the set of signing public keys.
+	ErrSignerNotInKeySet = fmt.Errorf("signing key is not found in key" +
+		" set")
+
+	// ErrAlredyHaveAllNonces is called when RegisterPubNonce is called too
+	// many times for a given signing session.
+	ErrAlredyHaveAllNonces = fmt.Errorf("already have all nonces")
+
+	// ErrAlredyHaveAllSigs is called when CombineSig is called too many
+	// times for a given signing session.
+	ErrAlredyHaveAllSigs = fmt.Errorf("already have all sigs")
+
+	// ErrSigningContextReuse is returned if a user attempts to sign using
+	// the same signing context more than once.
+	ErrSigningContextReuse = fmt.Errorf("nonce already used")
+
+	// ErrFinalSigInvalid is returned when the combined signature turns out
+	// to be invalid.
+	ErrFinalSigInvalid = fmt.Errorf("final signature is invalid")
+
+	// ErrCombinedNonceUnavailable is returned when a caller attempts to
+	// sign a partial signature, without first having collected all the
+	// required combined nonces.
+	ErrCombinedNonceUnavailable = fmt.Errorf("missing combined nonce")
+)
+
+// Context is a managed signing context for musig2. It takes care of things
+// like securely generating secret nonces, aggregating keys and nonces, etc.
+type Context struct {
+	// signingKey is the key we'll use for signing.
+	signingKey *btcec.PrivateKey
+
+	// pubKey is our even-y coordinate public  key.
+	pubKey *btcec.PublicKey
+
+	// keySet is the set of all signers.
+	keySet []*btcec.PublicKey
+
+	// combinedKey is the aggregated public key.
+	combinedKey *btcec.PublicKey
+
+	// uniqueKeyIndex is the index of the second unique key in the keySet.
+	// This is used to speed up signing and verification computations.
+	uniqueKeyIndex int
+
+	// keysHash is the hash of all the keys as defined in musig2.
+	keysHash []byte
+
+	// shouldSort keeps track of if the public keys should be sorted before
+	// any operations.
+	shouldSort bool
+}
+
+// NewContext creates a new signing context with the passed singing key and set
+// of public keys for each of the other signers.
+//
+// NOTE: This struct should be used over the raw Sign API whenever possible.
+func NewContext(signingKey *btcec.PrivateKey,
+	signers []*btcec.PublicKey, shouldSort bool) (*Context, error) {
+
+	// As a sanity check, make sure the signing key is actually amongst the sit
+	// of signers.
+	//
+	// TODO(roasbeef): instead have pass all the _other_ signers?
+	pubKey, err := schnorr.ParsePubKey(
+		schnorr.SerializePubKey(signingKey.PubKey()),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var keyFound bool
+	for _, key := range signers {
+		if key.IsEqual(pubKey) {
+			keyFound = true
+			break
+		}
+	}
+	if !keyFound {
+		return nil, ErrSignerNotInKeySet
+	}
+
+	// Now that we know that we're actually a signer, we'll generate the
+	// key hash finger print and second unique key index so we can speed up
+	// signing later.
+	keysHash := keyHashFingerprint(signers, shouldSort)
+	uniqueKeyIndex := secondUniqueKeyIndex(signers, shouldSort)
+
+	// Next, we'll use this information to compute the aggregated public
+	// key that'll be used for signing in practice.
+	combinedKey := AggregateKeys(
+		signers, shouldSort, WithKeysHash(keysHash),
+		WithUniqueKeyIndex(uniqueKeyIndex),
+	)
+
+	return &Context{
+		signingKey:     signingKey,
+		pubKey:         pubKey,
+		keySet:         signers,
+		combinedKey:    combinedKey,
+		uniqueKeyIndex: uniqueKeyIndex,
+		keysHash:       keysHash,
+		shouldSort:     shouldSort,
+	}, nil
+}
+
+// CombinedKey returns the combined public key that will be used to generate
+// multi-signatures  against.
+func (c *Context) CombinedKey() btcec.PublicKey {
+	return *c.combinedKey
+}
+
+// PubKey returns the public key of the signer of this session.
+func (c *Context) PubKey() btcec.PublicKey {
+	return *c.pubKey
+}
+
+// SigningKeys returns the set of keys used for signing.
+func (c *Context) SigningKeys() []*btcec.PublicKey {
+	keys := make([]*btcec.PublicKey, len(c.keySet))
+	copy(keys, c.keySet)
+
+	return keys
+}
+
+// Session represents a musig2 signing session. A new instance should be
+// created each time a multi-signature is needed. The session struct handles
+// nonces management, incremental partial sig vitrifaction, as well as final
+// signature combination. Errors are returned when unsafe behavior such as
+// nonce re-use is attempted.
+//
+// NOTE: This struct should be used over the raw Sign API whenever possible.
+type Session struct {
+	ctx *Context
+
+	localNonces *Nonces
+
+	pubNonces [][PubNonceSize]byte
+
+	combinedNonce *[PubNonceSize]byte
+
+	msg [32]byte
+
+	ourSig *PartialSignature
+	sigs   []*PartialSignature
+
+	finalSig *schnorr.Signature
+}
+
+// NewSession creates a new musig2 signing session.
+func (c *Context) NewSession() (*Session, error) {
+	localNonces, err := GenNonces()
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Session{
+		ctx:         c,
+		localNonces: localNonces,
+		pubNonces:   make([][PubNonceSize]byte, 0, len(c.keySet)),
+		sigs:        make([]*PartialSignature, 0, len(c.keySet)),
+	}
+
+	s.pubNonces = append(s.pubNonces, localNonces.PubNonce)
+
+	return s, nil
+}
+
+// PublicNonce returns the public nonce for a signer. This should be sent to
+// other parties before signing begins, so they can compute the aggregated
+// public nonce.
+func (s *Session) PublicNonce() [PubNonceSize]byte {
+	return s.localNonces.PubNonce
+}
+
+// NumRegisteredNonces returns the total number of nonces that have been
+// regsitered so far.
+func (s *Session) NumRegisteredNonces() int {
+	return len(s.pubNonces)
+}
+
+// RegisterPubNonce should be called for each public nonce from the set of
+// signers. This method returns true once all the public nonces have been
+// accounted for.
+func (s *Session) RegisterPubNonce(nonce [PubNonceSize]byte) (bool, error) {
+	// If we already have all the nonces, then this method was called too many
+	// times.
+	haveAllNonces := len(s.pubNonces) == len(s.ctx.keySet)
+	if haveAllNonces {
+		return false, nil
+	}
+
+	// Add this nonce and check again if we already have tall the nonces we
+	// need.
+	s.pubNonces = append(s.pubNonces, nonce)
+	haveAllNonces = len(s.pubNonces) == len(s.ctx.keySet)
+
+	// If we have all the nonces, then we can go ahead and combine them
+	// now.
+	if haveAllNonces {
+		combinedNonce, err := AggregateNonces(s.pubNonces)
+		if err != nil {
+			return false, err
+		}
+
+		s.combinedNonce = &combinedNonce
+	}
+
+	return haveAllNonces, nil
+}
+
+// Sign generates a partial signature for the target message, using the target
+// context. If this method is called more than once per context, then an error
+// is returned, as that means a nonce was re-used.
+func (s *Session) Sign(msg [32]byte,
+	signOpts ...SignOption) (*PartialSignature, error) {
+
+	s.msg = msg
+
+	switch {
+	// If no local nonce is present, then this means we already signed, so
+	// we'll return an error to prevent nonce re-use.
+	case s.localNonces == nil:
+		return nil, ErrSigningContextReuse
+
+	// We also need to make sure we have the combined nonce, otherwise this
+	// funciton was called too early.
+	case s.combinedNonce == nil:
+		return nil, ErrCombinedNonceUnavailable
+	}
+
+	partialSig, err := Sign(
+		s.localNonces.SecNonce, s.ctx.signingKey, *s.combinedNonce,
+		s.ctx.keySet, msg, signOpts...,
+	)
+
+	// Now that we've generated our signature, we'll make sure to blank out
+	// our signing nonce.
+	s.localNonces = nil
+
+	if err != nil {
+		return nil, err
+	}
+
+	s.ourSig = partialSig
+	s.sigs = append(s.sigs, partialSig)
+
+	return partialSig, nil
+}
+
+// CombineSigs buffers a partial signature received from a signing party. The
+// method returns true once all the signatures are available, and can be
+// combined into the final signature.
+func (s *Session) CombineSig(sig *PartialSignature) (bool, error) {
+	// First check if we already have all the signatures we need. We
+	// already accumulated our own signature when we generated the sig.
+	haveAllSigs := len(s.sigs) == len(s.ctx.keySet)
+	if haveAllSigs {
+		return false, ErrAlredyHaveAllSigs
+	}
+
+	// TODO(roasbeef): incremental check for invalid sig, or just detect at
+	// the very end?
+
+	// Accumulate this sig, and check again if we have all the sigs we
+	// need.
+	s.sigs = append(s.sigs, sig)
+	haveAllSigs = len(s.sigs) == len(s.ctx.keySet)
+
+	// If we have all the signatures, then we can combine them all into the
+	// final signature.
+	if haveAllSigs {
+		finalSig := CombineSigs(s.ourSig.R, s.sigs)
+
+		// We'll also verify the signature at this point to ensure it's
+		// valid.
+		//
+		// TODO(roasbef): allow skipping?
+		if !finalSig.Verify(s.msg[:], s.ctx.combinedKey) {
+			return false, ErrFinalSigInvalid
+		}
+
+		s.finalSig = finalSig
+	}
+
+	return haveAllSigs, nil
+}
+
+// FinalSig returns the final combined multi-signature, if present.
+func (s *Session) FinalSig() *schnorr.Signature {
+	return s.finalSig
+}

--- a/btcec/schnorr/musig2/context.go
+++ b/btcec/schnorr/musig2/context.go
@@ -481,7 +481,13 @@ func (c *Context) NewSession(options ...SessionOption) (*Session, error) {
 	// specified nonce, or generate a fresh set.
 	var err error
 	if localNonces == nil {
-		localNonces, err = GenNonces()
+		// At this point we need to generate a fresh nonce. We'll pass
+		// in some auxiliary information to strengthen the nonce
+		// generated.
+		localNonces, err = GenNonces(
+			WithNonceSecretKeyAux(c.signingKey),
+			WithNonceCombinedKeyAux(c.combinedKey.FinalKey),
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/btcec/schnorr/musig2/keys.go
+++ b/btcec/schnorr/musig2/keys.go
@@ -118,7 +118,11 @@ func aggregationCoefficient(keySet []*btcec.PublicKey,
 
 // secondUniqueKeyIndex returns the index of the second unique key. If all keys
 // are the same, then a value of -1 is returned.
-func secondUniqueKeyIndex(keySet []*btcec.PublicKey) int {
+func secondUniqueKeyIndex(keySet []*btcec.PublicKey, sort bool) int {
+	if sort {
+		keySet = sortKeys(keySet)
+	}
+
 	// Find the first key that isn't the same as the very first key (second
 	// unique key).
 	for i := range keySet {
@@ -197,7 +201,7 @@ func AggregateKeys(keys []*btcec.PublicKey, sort bool,
 	// A caller may also specify the unique key index themselves so we
 	// don't need to re-compute it.
 	if opts.uniqueKeyIndex == nil {
-		idx := secondUniqueKeyIndex(keys)
+		idx := secondUniqueKeyIndex(keys, sort)
 		opts.uniqueKeyIndex = &idx
 	}
 

--- a/btcec/schnorr/musig2/keys.go
+++ b/btcec/schnorr/musig2/keys.go
@@ -1,0 +1,166 @@
+// Copyright 2013-2022 The btcsuite developers
+
+package musig2
+
+import (
+	"bytes"
+	"sort"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+var (
+	// KeyAggTagList is the tagged hash tag used to compute the hash of the
+	// list of sorted public keys.
+	KeyAggTagList = []byte("KeyAgg list")
+
+	// KeyAggTagCoeff is the tagged hash tag used to compute the key
+	// aggregation coefficient for each key.
+	KeyAggTagCoeff = []byte("KeyAgg coefficient")
+)
+
+// sortableKeys defines a type of slice of public keys that implements the sort
+// interface for BIP 340 keys.
+type sortableKeys []*btcec.PublicKey
+
+// Less reports whether the element with index i must sort before the element
+// with index j.
+func (s sortableKeys) Less(i, j int) bool {
+	keyIBytes := schnorr.SerializePubKey(s[i])
+	keyJBytes := schnorr.SerializePubKey(s[j])
+
+	return bytes.Compare(keyIBytes, keyJBytes) == -1
+}
+
+// Swap swaps the elements with indexes i and j.
+func (s sortableKeys) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+// Len is the number of elements in the collection.
+func (s sortableKeys) Len() int {
+	return len(s)
+}
+
+// sortKeys takes a set of schnorr public keys and returns a new slice that is
+// a copy of the keys sorted in lexicographical order bytes on the x-only
+// pubkey serialization.
+func sortKeys(keys []*btcec.PublicKey) []*btcec.PublicKey {
+	keySet := sortableKeys(keys)
+	if sort.IsSorted(keySet) {
+		return keys
+	}
+
+	sort.Sort(keySet)
+	return keySet
+}
+
+// keyHashFingerprint computes the tagged hash of the series of (sorted) public
+// keys passed as input. This is used to compute the aggregation coefficient
+// for each key. The final computation is:
+//   * H(tag=KeyAgg list, pk1 || pk2..)
+func keyHashFingerprint(keys []*btcec.PublicKey, sort bool) []byte {
+	var keyBytes bytes.Buffer
+
+	if sort {
+		keys = sortKeys(keys)
+	}
+
+	for _, key := range keys {
+		keyBytes.Write(schnorr.SerializePubKey(key))
+	}
+
+	h := chainhash.TaggedHash(KeyAggTagList, keyBytes.Bytes())
+	return h[:]
+}
+
+// isSecondKey returns true if the passed public key is the second key in the
+// (sorted) keySet passed.
+func isSecondKey(keySet []*btcec.PublicKey, targetKey *btcec.PublicKey) bool {
+	// For this comparison, we want to compare the raw serialized version
+	// instead of the full pubkey, as it's possible we're dealing with a
+	// pubkey that _actually_ has an odd y coordinate.
+	equalBytes := func(a, b *btcec.PublicKey) bool {
+		return bytes.Equal(
+			schnorr.SerializePubKey(a),
+			schnorr.SerializePubKey(b),
+		)
+	}
+
+	for i := range keySet {
+		if !equalBytes(keySet[i], keySet[0]) {
+			return equalBytes(keySet[i], targetKey)
+		}
+	}
+
+	return false
+}
+
+// aggregationCoefficient computes the key aggregation coefficient for the
+// specified target key. The coefficient is computed as:
+//  * H(tag=KeyAgg coefficient, keyHashFingerprint(pks) || pk)
+func aggregationCoefficient(keySet []*btcec.PublicKey,
+	targetKey *btcec.PublicKey, sort bool) *btcec.ModNScalar {
+
+	var mu btcec.ModNScalar
+
+	// If this is the second key, then this coefficient is just one.
+	//
+	// TODO(roasbeef): use intermediate cache to keep track of the second
+	// key, can just store an index, otherwise this is O(n^2)
+	if isSecondKey(keySet, targetKey) {
+		return mu.SetInt(1)
+	}
+
+	// Otherwise, we'll compute the full finger print hash for this given
+	// key and then use that to compute the coefficient tagged hash:
+	//  * H(tag=KeyAgg coefficient, keyHashFingerprint(pks, pk) || pk)
+	var coefficientBytes bytes.Buffer
+	coefficientBytes.Write(keyHashFingerprint(keySet, sort))
+	coefficientBytes.Write(schnorr.SerializePubKey(targetKey))
+
+	muHash := chainhash.TaggedHash(KeyAggTagCoeff, coefficientBytes.Bytes())
+
+	mu.SetByteSlice(muHash[:])
+
+	return &mu
+}
+
+// TODO(roasbeef): make proper IsEven func
+
+// AggregateKeys takes a list of possibly unsorted keys and returns a single
+// aggregated key as specified by the musig2 key aggregation algorithm.
+func AggregateKeys(keys []*btcec.PublicKey, sort bool) *btcec.PublicKey {
+	// Sort the set of public key so we know we're working with them in
+	// sorted order for all the routines below.
+	if sort {
+		keys = sortKeys(keys)
+	}
+
+	// For each key, we'll compute the intermediate blinded key: a_i*P_i,
+	// where a_i is the aggregation coefficient for that key, and P_i is
+	// the key itself, then accumulate that (addition) into the main final
+	// key: P = P_1 + P_2 ... P_N.
+	var finalKeyJ btcec.JacobianPoint
+	for _, key := range keys {
+		// Port the key over to Jacobian coordinates as we need it in
+		// this format for the routines below.
+		var keyJ btcec.JacobianPoint
+		key.AsJacobian(&keyJ)
+
+		// Compute the aggregation coefficient for the key, then
+		// multiply it by the key itself: P_i' = a_i*P_i.
+		var tweakedKeyJ btcec.JacobianPoint
+		a := aggregationCoefficient(keys, key, sort)
+		btcec.ScalarMultNonConst(a, &keyJ, &tweakedKeyJ)
+
+		// Finally accumulate this into the final key in an incremental
+		// fashion.
+		btcec.AddNonConst(&finalKeyJ, &tweakedKeyJ, &finalKeyJ)
+	}
+
+	finalKeyJ.ToAffine()
+	return btcec.NewPublicKey(&finalKeyJ.X, &finalKeyJ.Y)
+}

--- a/btcec/schnorr/musig2/musig2_test.go
+++ b/btcec/schnorr/musig2/musig2_test.go
@@ -324,6 +324,8 @@ func testMultiPartySign(t *testing.T, taprootTweak []byte,
 
 	var ctxOpts []ContextOption
 	switch {
+	case len(taprootTweak) == 0:
+		ctxOpts = append(ctxOpts, WithBip86TweakCtx())
 	case taprootTweak != nil:
 		ctxOpts = append(ctxOpts, WithTaprootTweakCtx(taprootTweak))
 	case len(tweaks) != 0:
@@ -468,5 +470,11 @@ func TestMuSigMultiParty(t *testing.T) {
 		t.Parallel()
 
 		testMultiPartySign(t, testTweak[:])
+	})
+
+	t.Run("taproot_bip_86", func(t *testing.T) {
+		t.Parallel()
+
+		testMultiPartySign(t, []byte{})
 	})
 }

--- a/btcec/schnorr/musig2/musig2_test.go
+++ b/btcec/schnorr/musig2/musig2_test.go
@@ -1,0 +1,252 @@
+// Copyright 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package musig2
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+)
+
+// TestMuSig2SgnTestVectors tests that this implementation of musig2 matches
+// the secp256k1-zkp test vectors.
+func TestMuSig2SignTestVectors(t *testing.T) {
+	t.Parallel()
+}
+
+var (
+	key1Bytes, _ = hex.DecodeString("F9308A019258C31049344F85F89D5229B53" +
+		"1C845836F99B08601F113BCE036F9")
+	key2Bytes, _ = hex.DecodeString("DFF1D77F2A671C5F36183726DB2341BE58F" +
+		"EAE1DA2DECED843240F7B502BA659")
+	key3Bytes, _ = hex.DecodeString("3590A94E768F8E1815C2F24B4D80A8E3149" +
+		"316C3518CE7B7AD338368D038CA66")
+
+	testKeys = [][]byte{key1Bytes, key2Bytes, key3Bytes}
+
+	keyCombo1, _ = hex.DecodeString("E5830140512195D74C8307E39637CBE5FB730EBEAB80EC514CF88A877CEEEE0B")
+	keyCombo2, _ = hex.DecodeString("D70CD69A2647F7390973DF48CBFA2CCC407B8B2D60B08C5F1641185C7998A290")
+	keyCombo3, _ = hex.DecodeString("81A8B093912C9E481408D09776CEFB48AEB8B65481B6BAAFB3C5810106717BEB")
+	keyCombo4, _ = hex.DecodeString("2EB18851887E7BDC5E830E89B19DDBC28078F1FA88AAD0AD01CA06FE4F80210B")
+)
+
+// TestMuSig2KeyAggTestVectors tests that this implementation of musig2 key
+// aggregation lines up with the secp256k1-zkp test vectors.
+func TestMuSig2KeyAggTestVectors(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		keyOrder    []int
+		expectedKey []byte
+	}{
+		// Keys in backwards lexicographical order.
+		{
+			keyOrder:    []int{0, 1, 2},
+			expectedKey: keyCombo1,
+		},
+
+		// Keys in sorted order.
+		{
+			keyOrder:    []int{2, 1, 0},
+			expectedKey: keyCombo2,
+		},
+
+		// Only the first key.
+		{
+			keyOrder:    []int{0, 0, 0},
+			expectedKey: keyCombo3,
+		},
+
+		// Duplicate the first key and second keys.
+		{
+			keyOrder:    []int{0, 0, 1, 1},
+			expectedKey: keyCombo4,
+		},
+	}
+	for i, testCase := range testCases {
+		testName := fmt.Sprintf("%v", testCase.keyOrder)
+		t.Run(testName, func(t *testing.T) {
+			var keys []*btcec.PublicKey
+			for _, keyIndex := range testCase.keyOrder {
+				keyBytes := testKeys[keyIndex]
+				pub, err := schnorr.ParsePubKey(keyBytes)
+				if err != nil {
+					t.Fatalf("unable to parse pubkeys: %v", err)
+				}
+
+				keys = append(keys, pub)
+			}
+
+			combinedKey := AggregateKeys(keys, false)
+			combinedKeyBytes := schnorr.SerializePubKey(combinedKey)
+			if !bytes.Equal(combinedKeyBytes, testCase.expectedKey) {
+				t.Fatalf("case: #%v, invalid aggregation: "+
+					"expected %x, got %x", i, testCase.expectedKey,
+					combinedKeyBytes)
+			}
+		})
+	}
+}
+
+func mustParseHex(str string) []byte {
+	b, err := hex.DecodeString(str)
+	if err != nil {
+		panic(fmt.Errorf("unable to parse hex: %v", err))
+	}
+
+	return b
+}
+
+func parseKey(xHex string) *btcec.PublicKey {
+	xB, err := hex.DecodeString(xHex)
+	if err != nil {
+		panic(err)
+	}
+
+	var x, y btcec.FieldVal
+	x.SetByteSlice(xB)
+	if !btcec.DecompressY(&x, false, &y) {
+		panic("x not on curve")
+	}
+	y.Normalize()
+
+	return btcec.NewPublicKey(&x, &y)
+}
+
+var (
+	signSetPrivKey, _ = btcec.PrivKeyFromBytes(
+		mustParseHex("7FB9E0E687ADA1EEBF7ECFE2F21E73EBDB51A7D450948DFE8D76D7F2D1007671"),
+	)
+	signSetPubKey, _ = schnorr.ParsePubKey(schnorr.SerializePubKey(signSetPrivKey.PubKey()))
+
+	signTestMsg = mustParseHex("F95466D086770E689964664219266FE5ED215C92AE20BAB5C9D79ADDDDF3C0CF")
+
+	signSetKey2, _ = schnorr.ParsePubKey(
+		mustParseHex("F9308A019258C31049344F85F89D5229B531C845836F99B086" +
+			"01F113BCE036F9"),
+	)
+	signSetKey3, _ = schnorr.ParsePubKey(
+		mustParseHex("DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843" +
+			"240F7B502BA659"),
+	)
+
+	signSetKeys = []*btcec.PublicKey{signSetPubKey, signSetKey2, signSetKey3}
+)
+
+// TestMuSig2SigningTestVectors tests that the musig2 implementation produces
+// the same set of signatures.
+func TestMuSig2SigningTestVectors(t *testing.T) {
+	t.Parallel()
+
+	var aggregatedNonce [PubNonceSize]byte
+	copy(
+		aggregatedNonce[:],
+		mustParseHex("028465FCF0BBDBCF443AABCCE533D42B4B5A10966AC09A49655E8C42DAAB8FCD61"),
+	)
+	copy(
+		aggregatedNonce[33:],
+		mustParseHex("037496A3CC86926D452CAFCFD55D25972CA1675D549310DE296BFF42F72EEEA8C9"),
+	)
+
+	var secNonce [SecNonceSize]byte
+	copy(secNonce[:], mustParseHex("508B81A611F100A6B2B6B29656590898AF488BCF2E1F55CF22E5CFB84421FE61"))
+	copy(secNonce[32:], mustParseHex("FA27FD49B1D50085B481285E1CA205D55C82CC1B31FF5CD54A489829355901F7"))
+
+	testCases := []struct {
+		keyOrder           []int
+		expectedPartialSig []byte
+	}{
+		{
+			keyOrder:           []int{0, 1, 2},
+			expectedPartialSig: mustParseHex("68537CC5234E505BD14061F8DA9E90C220A181855FD8BDB7F127BB12403B4D3B"),
+		},
+		{
+			keyOrder:           []int{1, 0, 2},
+			expectedPartialSig: mustParseHex("2DF67BFFF18E3DE797E13C6475C963048138DAEC5CB20A357CECA7C8424295EA"),
+		},
+
+		{
+			keyOrder:           []int{1, 2, 0},
+			expectedPartialSig: mustParseHex("0D5B651E6DE34A29A12DE7A8B4183B4AE6A7F7FBE15CDCAFA4A3D1BCAABC7517"),
+		},
+	}
+
+	var msg [32]byte
+	copy(msg[:], signTestMsg)
+
+	for _, testCase := range testCases {
+		testName := fmt.Sprintf("%v", testCase.keyOrder)
+		t.Run(testName, func(t *testing.T) {
+			keySet := make([]*btcec.PublicKey, 0, len(testCase.keyOrder))
+			for _, keyIndex := range testCase.keyOrder {
+				keySet = append(keySet, signSetKeys[keyIndex])
+			}
+
+			partialSig, err := Sign(
+				secNonce, signSetPrivKey, aggregatedNonce, keySet, msg,
+			)
+			if err != nil {
+				t.Fatalf("unable to generate partial sig: %v", err)
+			}
+
+			var partialSigBytes [32]byte
+			partialSig.S.PutBytesUnchecked(partialSigBytes[:])
+
+			if !bytes.Equal(partialSigBytes[:], testCase.expectedPartialSig) {
+				t.Fatalf("sigs don't match: expected %x, got %x",
+					testCase.expectedPartialSig, partialSigBytes,
+				)
+			}
+		})
+	}
+}
+
+type signer struct {
+	privKey *btcec.PrivateKey
+	pubKey  *btcec.PublicKey
+
+	nonces *Nonces
+
+	partialSig *PartialSignature
+}
+
+type signerSet []signer
+
+func (s signerSet) keys() []*btcec.PublicKey {
+	keys := make([]*btcec.PublicKey, len(s))
+	for i := 0; i < len(s); i++ {
+		keys[i] = s[i].pubKey
+	}
+
+	return keys
+}
+
+func (s signerSet) partialSigs() []*PartialSignature {
+	sigs := make([]*PartialSignature, len(s))
+	for i := 0; i < len(s); i++ {
+		sigs[i] = s[i].partialSig
+	}
+
+	return sigs
+}
+
+func (s signerSet) pubNonces() [][PubNonceSize]byte {
+	nonces := make([][PubNonceSize]byte, len(s))
+	for i := 0; i < len(s); i++ {
+		nonces[i] = s[i].nonces.PubNonce
+	}
+
+	return nonces
+}
+
+func (s signerSet) combinedKey() *btcec.PublicKey {
+	return AggregateKeys(s.keys(), false)
+}

--- a/btcec/schnorr/musig2/musig2_test.go
+++ b/btcec/schnorr/musig2/musig2_test.go
@@ -85,7 +85,10 @@ func TestMuSig2KeyAggTestVectors(t *testing.T) {
 				keys = append(keys, pub)
 			}
 
-			combinedKey := AggregateKeys(keys, false)
+			uniqueKeyIndex := secondUniqueKeyIndex(keys)
+			combinedKey := AggregateKeys(
+				keys, false, WithUniqueKeyIndex(uniqueKeyIndex),
+			)
 			combinedKeyBytes := schnorr.SerializePubKey(combinedKey)
 			if !bytes.Equal(combinedKeyBytes, testCase.expectedKey) {
 				t.Fatalf("case: #%v, invalid aggregation: "+
@@ -248,7 +251,10 @@ func (s signerSet) pubNonces() [][PubNonceSize]byte {
 }
 
 func (s signerSet) combinedKey() *btcec.PublicKey {
-	return AggregateKeys(s.keys(), false)
+	uniqueKeyIndex := secondUniqueKeyIndex(s.keys())
+	return AggregateKeys(
+		s.keys(), false, WithUniqueKeyIndex(uniqueKeyIndex),
+	)
 }
 
 // TestMuSigMultiParty tests that for a given set of 100 signers, we're able to

--- a/btcec/schnorr/musig2/musig2_test.go
+++ b/btcec/schnorr/musig2/musig2_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -392,20 +393,25 @@ func testMultiPartySign(t *testing.T, taprootTweak []byte,
 		ctxOpts = append(ctxOpts, WithTweakedContext(tweaks...))
 	}
 
+	ctxOpts = append(ctxOpts, WithKnownSigners(signSet))
+
 	// Now that we have all the signers, we'll make a new context, then
 	// generate a new session for each of them(which handles nonce
 	// generation).
 	signers := make([]*Session, numSigners)
 	for i, signerKey := range signerKeys {
 		signCtx, err := NewContext(
-			signerKey, signSet, false, ctxOpts...,
+			signerKey, false, ctxOpts...,
 		)
 		if err != nil {
 			t.Fatalf("unable to generate context: %v", err)
 		}
 
 		if combinedKey == nil {
-			combinedKey = signCtx.CombinedKey()
+			combinedKey, err = signCtx.CombinedKey()
+			if err != nil {
+				t.Fatalf("combined key not available: %v", err)
+			}
 		}
 
 		session, err := signCtx.NewSession()
@@ -537,4 +543,181 @@ func TestMuSigMultiParty(t *testing.T) {
 
 		testMultiPartySign(t, []byte{})
 	})
+}
+
+// TestMuSigEarlyNonce tests that for protocols where nonces need to be
+// exchagned before all signers are known, the context API works as expected.
+func TestMuSigEarlyNonce(t *testing.T) {
+	t.Parallel()
+
+	privKey1, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatalf("unable to gen priv key: %v", err)
+	}
+	privKey2, err := btcec.NewPrivateKey()
+	if err != nil {
+		t.Fatalf("unable to gen priv key: %v", err)
+	}
+
+	// If we try to make a context, with just the private key and sorting
+	// value, we should get an error.
+	_, err = NewContext(privKey1, true)
+	if !errors.Is(err, ErrSignersNotSpecified) {
+		t.Fatalf("unexpected ctx error: %v", err)
+	}
+
+	numSigners := 2
+
+	ctx1, err := NewContext(
+		privKey1, true, WithNumSigners(numSigners), WithEarlyNonceGen(),
+	)
+	if err != nil {
+		t.Fatalf("unable to make ctx: %v", err)
+	}
+	pubKey1 := ctx1.PubKey()
+
+	ctx2, err := NewContext(
+		privKey2, true, WithNumSigners(numSigners), WithEarlyNonceGen(),
+	)
+	if err != nil {
+		t.Fatalf("unable to make ctx: %v", err)
+	}
+	pubKey2 := ctx2.PubKey()
+
+	// At this point, the combined key shouldn't be available for both
+	// signers, since we only know of the sole signers.
+	if _, err := ctx1.CombinedKey(); !errors.Is(err, ErrNotEnoughSigners) {
+		t.Fatalf("unepxected error: %v", err)
+	}
+	if _, err := ctx2.CombinedKey(); !errors.Is(err, ErrNotEnoughSigners) {
+		t.Fatalf("unepxected error: %v", err)
+	}
+
+	// The early nonces _should_ be available at this point.
+	nonce1, err := ctx1.EarlySessionNonce()
+	if err != nil {
+		t.Fatalf("session nonce not available: %v", err)
+	}
+	nonce2, err := ctx2.EarlySessionNonce()
+	if err != nil {
+		t.Fatalf("session nonce not available: %v", err)
+	}
+
+	// The number of registered signers should still be 1 for both parties.
+	if ctx1.NumRegisteredSigners() != 1 {
+		t.Fatalf("expected 1 signer, instead have: %v",
+			ctx1.NumRegisteredSigners())
+	}
+	if ctx2.NumRegisteredSigners() != 1 {
+		t.Fatalf("expected 1 signer, instead have: %v",
+			ctx2.NumRegisteredSigners())
+	}
+
+	// If we try to make a session, we should get an error since we dn't
+	// have all the signers yet.
+	if _, err := ctx1.NewSession(); !errors.Is(err, ErrNotEnoughSigners) {
+		t.Fatalf("unexpected session key error: %v", err)
+	}
+
+	// The combined key should also be unavailable as well.
+	if _, err := ctx1.CombinedKey(); !errors.Is(err, ErrNotEnoughSigners) {
+		t.Fatalf("unexpected combined key error: %v", err)
+	}
+
+	// We'll now register the other signer for both parties.
+	done, err := ctx1.RegisterSigner(&pubKey2)
+	if err != nil {
+		t.Fatalf("unable to register signer: %v", err)
+	}
+	if !done {
+		t.Fatalf("signer 1 doesn't have all keys")
+	}
+	done, err = ctx2.RegisterSigner(&pubKey1)
+	if err != nil {
+		t.Fatalf("unable to register signer: %v", err)
+	}
+	if !done {
+		t.Fatalf("signer 2 doesn't have all keys")
+	}
+
+	// If we try to register the signer again, we should get an error.
+	_, err = ctx2.RegisterSigner(&pubKey1)
+	if !errors.Is(err, ErrAlreadyHaveAllSigners) {
+		t.Fatalf("should not be able to register too many signers")
+	}
+
+	// We should be able to create the session at this point.
+	session1, err := ctx1.NewSession()
+	if err != nil {
+		t.Fatalf("unable to create new session: %v", err)
+	}
+	session2, err := ctx2.NewSession()
+	if err != nil {
+		t.Fatalf("unable to create new session: %v", err)
+	}
+
+	msg := sha256.Sum256([]byte("let's get taprooty, LN style"))
+
+	// If we try to sign before we have the combined nonce, we shoudl get
+	// an error.
+	_, err = session1.Sign(msg)
+	if !errors.Is(err, ErrCombinedNonceUnavailable) {
+		t.Fatalf("unable to gen sig: %v", err)
+	}
+
+	// Now we can exchange nonces to continue with the rest of the signing
+	// process as normal.
+	done, err = session1.RegisterPubNonce(nonce2.PubNonce)
+	if err != nil {
+		t.Fatalf("unable to register nonce: %v", err)
+	}
+	if !done {
+		t.Fatalf("signer 1 doesn't have all nonces")
+	}
+	done, err = session2.RegisterPubNonce(nonce1.PubNonce)
+	if err != nil {
+		t.Fatalf("unable to register nonce: %v", err)
+	}
+	if !done {
+		t.Fatalf("signer 2 doesn't have all nonces")
+	}
+
+	// Registering the nonce again should error out.
+	_, err = session2.RegisterPubNonce(nonce1.PubNonce)
+	if !errors.Is(err, ErrAlredyHaveAllNonces) {
+		t.Fatalf("shouldn't be able to register nonces twice")
+	}
+
+	// Sign the message and combine the two partial sigs into one.
+	_, err = session1.Sign(msg)
+	if err != nil {
+		t.Fatalf("unable to gen sig: %v", err)
+	}
+	sig2, err := session2.Sign(msg)
+	if err != nil {
+		t.Fatalf("unable to gen sig: %v", err)
+	}
+	done, err = session1.CombineSig(sig2)
+	if err != nil {
+		t.Fatalf("unable to combine sig: %v", err)
+	}
+	if !done {
+		t.Fatalf("all sigs should be known now: %v", err)
+	}
+
+	// If we try to combine another sig, then we should get an error.
+	_, err = session1.CombineSig(sig2)
+	if !errors.Is(err, ErrAlredyHaveAllSigs) {
+		t.Fatalf("shouldn't be able to combine again")
+	}
+
+	// Finally, verify that the final signature is valid.
+	combinedKey, err := ctx1.CombinedKey()
+	if err != nil {
+		t.Fatalf("unexpected combined key error: %v", err)
+	}
+	finalSig := session1.FinalSig()
+	if !finalSig.Verify(msg[:], combinedKey) {
+		t.Fatalf("final sig is invalid!")
+	}
 }

--- a/btcec/schnorr/musig2/nonces.go
+++ b/btcec/schnorr/musig2/nonces.go
@@ -117,7 +117,7 @@ func GenNonces(options ...NonceGenOption) (*Nonces, error) {
 	// Next, we'll generate R_1 = k_1*G and R_2 = k_2*G. Along the way we
 	// need to map our nonce values into mod n scalars so we can work with
 	// the btcec API.
-	nonces.PubNonce = secNonceToPubNonce(nonces.SecNonce)
+	nonces.PubNonce = secNonceToPubNonce(&nonces.SecNonce)
 
 	return &nonces, nil
 }

--- a/btcec/schnorr/musig2/nonces.go
+++ b/btcec/schnorr/musig2/nonces.go
@@ -1,7 +1,4 @@
-// Copyright 2013-2016 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
-// Use of this source code is governed by an ISC
-// license that can be found in the LICENSE file.
+// Copyright 2013-2022 The btcsuite developers
 
 package musig2
 
@@ -22,6 +19,10 @@ const (
 	SecNonceSize = 64
 )
 
+// zeroSecNonce is a secret nonce that's all zeroes. This is used to check that
+// we're not attempting to re-use a nonce, and also protect callers from it.
+var zeroSecNonce [SecNonceSize]byte
+
 // Nonces holds the public and secret nonces required for musig2.
 //
 // TODO(roasbeef): methods on this to help w/ parsing, etc?
@@ -37,7 +38,7 @@ type Nonces struct {
 
 // secNonceToPubNonce takes our two secrete nonces, and produces their two
 // corresponding EC points, serialized in compressed format.
-func secNonceToPubNonce(secNonce *[SecNonceSize]byte) [PubNonceSize]byte {
+func secNonceToPubNonce(secNonce [SecNonceSize]byte) [PubNonceSize]byte {
 	var k1Mod, k2Mod btcec.ModNScalar
 	k1Mod.SetByteSlice(secNonce[:btcec.PrivKeyBytesLen])
 	k2Mod.SetByteSlice(secNonce[btcec.PrivKeyBytesLen:])
@@ -117,7 +118,7 @@ func GenNonces(options ...NonceGenOption) (*Nonces, error) {
 	// Next, we'll generate R_1 = k_1*G and R_2 = k_2*G. Along the way we
 	// need to map our nonce values into mod n scalars so we can work with
 	// the btcec API.
-	nonces.PubNonce = secNonceToPubNonce(&nonces.SecNonce)
+	nonces.PubNonce = secNonceToPubNonce(nonces.SecNonce)
 
 	return &nonces, nil
 }

--- a/btcec/schnorr/musig2/nonces.go
+++ b/btcec/schnorr/musig2/nonces.go
@@ -1,0 +1,208 @@
+// Copyright 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package musig2
+
+import (
+	"crypto/rand"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+)
+
+const (
+	// PubNonceSize is the size of the public nonces. Each public nonce is
+	// serialized the full compressed encoding, which uses 32 bytes for each
+	// nonce.
+	PubNonceSize = 66
+
+	// SecNonceSize is the size of the secret nonces for musig2. The secret
+	// nonces are the corresponding private keys to the public nonce points.
+	SecNonceSize = 64
+)
+
+// Nonces holds the public and secret nonces required for musig2.
+//
+// TODO(roasbeef): methods on this to help w/ parsing, etc?
+type Nonces struct {
+	// PubNonce holds the two 33-byte compressed encoded points that serve
+	// as the public set of nonces.
+	PubNonce [PubNonceSize]byte
+
+	// SecNonce holds the two 32-byte scalar values that are the private
+	// keys to the two public nonces.
+	SecNonce [SecNonceSize]byte
+}
+
+// secNonceToPubNonce takes our two secrete nonces, and produces their two
+// corresponding EC points, serialized in compressed format.
+func secNonceToPubNonce(secNonce *[SecNonceSize]byte) [PubNonceSize]byte {
+	var k1Mod, k2Mod btcec.ModNScalar
+	k1Mod.SetByteSlice(secNonce[:btcec.PrivKeyBytesLen])
+	k2Mod.SetByteSlice(secNonce[btcec.PrivKeyBytesLen:])
+
+	var r1, r2 btcec.JacobianPoint
+	btcec.ScalarBaseMultNonConst(&k1Mod, &r1)
+	btcec.ScalarBaseMultNonConst(&k2Mod, &r2)
+
+	// Next, we'll convert the key in jacobian format to a normal public
+	// key expressed in affine coordinates.
+	r1.ToAffine()
+	r2.ToAffine()
+	r1Pub := btcec.NewPublicKey(&r1.X, &r1.Y)
+	r2Pub := btcec.NewPublicKey(&r2.X, &r2.Y)
+
+	var pubNonce [PubNonceSize]byte
+
+	// The public nonces are serialized as: R1 || R2, where both keys are
+	// serialized in compressed format.
+	copy(pubNonce[:], r1Pub.SerializeCompressed())
+	copy(
+		pubNonce[btcec.PubKeyBytesLenCompressed:],
+		r2Pub.SerializeCompressed(),
+	)
+
+	return pubNonce
+}
+
+// NonceGenOption is a function option that allows callers to modify how nonce
+// generation happens.
+type NonceGenOption func(*nonceGenOpts)
+
+// nonceGenOpts is the set of options that control how nonce generation happens.
+type nonceGenOpts struct {
+	randReader func(b []byte) (int, error)
+}
+
+// defaultNonceGenOpts returns the default set of nonce generation options.
+func defaultNonceGenOpts() *nonceGenOpts {
+	return &nonceGenOpts{
+		// By default, we always use the crypto/rand reader, but the
+		// caller is able to specify their own generation, which can be
+		// useful for deterministic tests.
+		randReader: rand.Read,
+	}
+}
+
+// GenNonces generates the secret nonces, as well as the public nonces which
+// correspond to an EC point generated using the secret nonce as a private key.
+func GenNonces(options ...NonceGenOption) (*Nonces, error) {
+	opts := defaultNonceGenOpts()
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	// Generate two 32-byte random values that'll be the private keys to
+	// the public nonces.
+	var k1, k2 [32]byte
+	if _, err := opts.randReader(k1[:]); err != nil {
+		return nil, err
+	}
+	if _, err := opts.randReader(k2[:]); err != nil {
+		return nil, err
+	}
+
+	var nonces Nonces
+
+	var k1Mod, k2Mod btcec.ModNScalar
+	k1Mod.SetBytes(&k1)
+	k2Mod.SetBytes(&k2)
+
+	// The secret nonces are serialized as the concatenation of the two 32
+	// byte secret nonce values.
+	k1Mod.PutBytesUnchecked(nonces.SecNonce[:])
+	k2Mod.PutBytesUnchecked(nonces.SecNonce[btcec.PrivKeyBytesLen:])
+
+	// Next, we'll generate R_1 = k_1*G and R_2 = k_2*G. Along the way we
+	// need to map our nonce values into mod n scalars so we can work with
+	// the btcec API.
+	nonces.PubNonce = secNonceToPubNonce(nonces.SecNonce)
+
+	return &nonces, nil
+}
+
+// AggregateNonces aggregates the set of a pair of public nonces for each party
+// into a single aggregated nonces to be used for multi-signing.
+func AggregateNonces(pubNonces [][PubNonceSize]byte) ([PubNonceSize]byte, error) {
+	// combineNonces is a helper function that aggregates (adds) up a
+	// series of nonces encoded in compressed format. It uses a slicing
+	// function to extra 33 bytes at a time from the packed 2x public
+	// nonces.
+	type nonceSlicer func([PubNonceSize]byte) []byte
+	combineNonces := func(slicer nonceSlicer) (*btcec.PublicKey, error) {
+		// Convert the set of nonces into jacobian coordinates we can
+		// use to accumulate them all into each other.
+		pubNonceJs := make([]*btcec.JacobianPoint, len(pubNonces))
+		for i, pubNonceBytes := range pubNonces {
+			// Using the slicer, extract just the bytes we need to
+			// decode.
+			var nonceJ btcec.JacobianPoint
+			pubNonce, err := btcec.ParsePubKey(
+				slicer(pubNonceBytes),
+			)
+			if err != nil {
+				return nil, err
+			}
+
+			pubNonce.AsJacobian(&nonceJ)
+			pubNonceJs[i] = &nonceJ
+		}
+
+		// Now that we have the set of complete nonces, we'll aggregate
+		// them: R = R_i + R_i+1 + ... + R_i+n.
+		var aggregateNonce btcec.JacobianPoint
+		for _, pubNonceJ := range pubNonceJs {
+			btcec.AddNonConst(
+				&aggregateNonce, pubNonceJ, &aggregateNonce,
+			)
+		}
+
+		// Now that we've aggregated all the points, we need to check
+		// if this point is the point at infinity, if so, then we'll
+		// just return the generator. At a later step, the malicious
+		// party will be detected.
+		if aggregateNonce == infinityPoint {
+			// TODO(roasbeef): better way to get the generator w/
+			// the new API? -- via old curve params instead?
+			var generator btcec.JacobianPoint
+			one := new(btcec.ModNScalar).SetInt(1)
+			btcec.ScalarBaseMultNonConst(one, &generator)
+
+			generator.ToAffine()
+			return btcec.NewPublicKey(
+				&generator.X, &generator.Y,
+			), nil
+		}
+
+		aggregateNonce.ToAffine()
+		return btcec.NewPublicKey(
+			&aggregateNonce.X, &aggregateNonce.Y,
+		), nil
+	}
+
+	// The final nonce public nonce is actually two nonces, one that
+	// aggregate the first nonce of all the parties, and the other that
+	// aggregates the second nonce of all the parties.
+	var finalNonce [PubNonceSize]byte
+	combinedNonce1, err := combineNonces(func(n [PubNonceSize]byte) []byte {
+		return n[:btcec.PubKeyBytesLenCompressed]
+	})
+	if err != nil {
+		return finalNonce, err
+	}
+	combinedNonce2, err := combineNonces(func(n [PubNonceSize]byte) []byte {
+		return n[btcec.PubKeyBytesLenCompressed:]
+	})
+	if err != nil {
+		return finalNonce, err
+	}
+
+	copy(finalNonce[:], combinedNonce1.SerializeCompressed())
+	copy(
+		finalNonce[btcec.PubKeyBytesLenCompressed:],
+		combinedNonce2.SerializeCompressed(),
+	)
+
+	return finalNonce, nil
+}

--- a/btcec/schnorr/musig2/nonces.go
+++ b/btcec/schnorr/musig2/nonces.go
@@ -185,7 +185,7 @@ func uint8Writer(w io.Writer, b []byte) error {
 	return binary.Write(w, byteOrder, uint8(len(b)))
 }
 
-// uint8Writer is an implementation of lengthWriter that writes the length of
+// uint32Writer is an implementation of lengthWriter that writes the length of
 // the byte slice using 4 bytes.
 func uint32Writer(w io.Writer, b []byte) error {
 	return binary.Write(w, byteOrder, uint32(len(b)))

--- a/btcec/schnorr/musig2/sign.go
+++ b/btcec/schnorr/musig2/sign.go
@@ -1,0 +1,423 @@
+// Copyright 2013-2016 The btcsuite developers
+// Copyright (c) 2015-2021 The Decred developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package musig2
+
+import (
+	"bytes"
+	"fmt"
+
+	secp "github.com/decred/dcrd/dcrec/secp256k1/v4"
+
+	"github.com/btcsuite/btcd/btcec/v2"
+	"github.com/btcsuite/btcd/btcec/v2/schnorr"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+var (
+	// NonceBlindTag is that tag used to construct the value b, which
+	// blinds the second public nonce of each party.
+	NonceBlindTag = []byte("MuSig/noncecoef")
+
+	// ChallengeHashTag is the tag used to construct the challenge hash
+	ChallengeHashTag = []byte("BIP0340/challenge")
+
+	// ErrNoncePointAtInfinity is returned if during signing, the fully
+	// combined public nonce is the point at infinity.
+	ErrNoncePointAtInfinity = fmt.Errorf("signing nonce is the infinity " +
+		"point")
+
+	// ErrPrivKeyZero is returned when the private key for signing is
+	// actually zero.
+	ErrPrivKeyZero = fmt.Errorf("priv key is zero")
+
+	// ErrPartialSigInvalid is returned when a partial is found to be
+	// invalid.
+	ErrPartialSigInvalid = fmt.Errorf("partial signature is invalid")
+
+	// ErrSecretNonceZero is returned when a secret nonce is passed in a
+	// zero.
+	ErrSecretNonceZero = fmt.Errorf("secret nonce is blank")
+)
+
+// infinityPoint is the jacobian representation of the point at infinity.
+var infinityPoint btcec.JacobianPoint
+
+// PartialSignature reprints a partial (s-only) musig2 multi-signature. This
+// isn't a valid schnorr signature by itself, as it needs to be aggregated
+// along with the other partial signatures to be completed.
+type PartialSignature struct {
+	S *btcec.ModNScalar
+
+	R *btcec.PublicKey
+}
+
+// NewPartialSignature returns a new instances of the partial sig struct.
+func NewPartialSignature(s *btcec.ModNScalar,
+	r *btcec.PublicKey) PartialSignature {
+
+	return PartialSignature{
+		S: s,
+		R: r,
+	}
+}
+
+// SignOption is a functional option argument that allows callers to modify the
+// way we generate musig2 schnorr signatures.
+type SignOption func(*signOptions)
+
+// signOptions houses the set of functional options that can be used to modify
+// the method used to generate the musig2 partial signature.
+type signOptions struct {
+	// fastSign determines if we'll skip the check at the end of the
+	// routine where we attempt to verify the produced signature.
+	fastSign bool
+
+	// sortKeys determines if the set of keys should be sorted before doing
+	// key aggregation.
+	sortKeys bool
+}
+
+// defaultSignOptions returns the default set of signing operations.
+func defaultSignOptions() *signOptions {
+	return &signOptions{}
+}
+
+// WithFastSign forces signing to skip the extra verification step at the end.
+// Performance sensitive applications may opt to use this option to speed up
+// the signing operation.
+func WithFastSign() SignOption {
+	return func(o *signOptions) {
+		o.fastSign = true
+	}
+}
+
+// WithSortedKeys determines if the set of signing public keys are to be sorted
+// or not before doing key aggregation.
+func WithSortedKeys() SignOption {
+	return func(o *signOptions) {
+		o.sortKeys = true
+	}
+}
+
+// Sign generates a musig2 partial signature given the passed key set, secret
+// nonce, public nonce, and private keys. This method returns an error if the
+// generated nonces are either too large, or end up mapping to the point at
+// infinity.
+func Sign(secNonce [SecNonceSize]byte, privKey *btcec.PrivateKey,
+	combinedNonce [PubNonceSize]byte, pubKeys []*btcec.PublicKey,
+	msg [32]byte, signOpts ...SignOption) (*PartialSignature, error) {
+
+	// First, parse the set of optional signing options.
+	opts := defaultSignOptions()
+	for _, option := range signOpts {
+		option(opts)
+	}
+
+	// Next, we'll parse the public nonces into R1 and R2.
+	r1, err := btcec.ParsePubKey(
+		combinedNonce[:btcec.PubKeyBytesLenCompressed],
+	)
+	if err != nil {
+		return nil, err
+	}
+	r2, err := btcec.ParsePubKey(
+		combinedNonce[btcec.PubKeyBytesLenCompressed:],
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Next we'll construct the aggregated public key based on the set of
+	// signers.
+	combinedKey := AggregateKeys(pubKeys, opts.sortKeys)
+
+	// Next we'll compute the value b, that blinds our second public
+	// nonce:
+	//  * b = h(tag=NonceBlindTag, combinedNonce || combinedKey || m).
+	var (
+		nonceMsgBuf  bytes.Buffer
+		nonceBlinder btcec.ModNScalar
+	)
+	nonceMsgBuf.Write(combinedNonce[:])
+	nonceMsgBuf.Write(schnorr.SerializePubKey(combinedKey))
+	nonceMsgBuf.Write(msg[:])
+	nonceBlindHash := chainhash.TaggedHash(
+		NonceBlindTag, nonceMsgBuf.Bytes(),
+	)
+	nonceBlinder.SetByteSlice(nonceBlindHash[:])
+
+	var nonce, r1J, r2J btcec.JacobianPoint
+	r1.AsJacobian(&r1J)
+	r2.AsJacobian(&r2J)
+
+	// With our nonce blinding value, we'll now combine both the public
+	// nonces, using the blinding factor to tweak the second nonce:
+	//  * R = R_1 + b*R_2
+	btcec.ScalarMultNonConst(&nonceBlinder, &r2J, &r2J)
+	btcec.AddNonConst(&r1J, &r2J, &nonce)
+
+	// If the combined nonce it eh point at infinity, then we'll bail out.
+	if nonce == infinityPoint {
+		return nil, ErrNoncePointAtInfinity
+	}
+
+	// Next we'll parse out our two secret nonces, which we'll be using in
+	// the core signing process below.
+	var k1, k2 btcec.ModNScalar
+	k1.SetByteSlice(secNonce[:btcec.PrivKeyBytesLen])
+	k2.SetByteSlice(secNonce[btcec.PrivKeyBytesLen:])
+
+	if k1.IsZero() || k2.IsZero() {
+		return nil, ErrSecretNonceZero
+	}
+
+	nonce.ToAffine()
+
+	nonceKey := btcec.NewPublicKey(&nonce.X, &nonce.Y)
+
+	// If the nonce R has an odd y coordinate, then we'll negate both our
+	// secret nonces.
+	if nonce.Y.IsOdd() {
+		k1.Negate()
+		k2.Negate()
+	}
+
+	privKeyScalar := privKey.Key
+	if privKeyScalar.IsZero() {
+		return nil, ErrPrivKeyZero
+	}
+
+	// If the y coordinate of the public key is odd xor the y coordinate of
+	// the combined public key is odd, then we'll negate the private key.
+	pubKey := privKey.PubKey()
+	pubKeyYIsOdd := func() bool {
+		pubKeyBytes := pubKey.SerializeCompressed()
+		return pubKeyBytes[0] == secp.PubKeyFormatCompressedOdd
+	}()
+	combinedKeyYIsOdd := func() bool {
+		combinedKeyBytes := combinedKey.SerializeCompressed()
+		return combinedKeyBytes[0] == secp.PubKeyFormatCompressedOdd
+	}()
+	if pubKeyYIsOdd != combinedKeyYIsOdd {
+		privKeyScalar.Negate()
+	}
+
+	// Next we'll create the challenge hash that commits to the combined
+	// nonce, combined public key and also the message: * e =
+	// H(tag=ChallengeHashTag, R || Q || m) mod n
+	var challengeMsg bytes.Buffer
+	challengeMsg.Write(schnorr.SerializePubKey(nonceKey))
+	challengeMsg.Write(schnorr.SerializePubKey(combinedKey))
+	challengeMsg.Write(msg[:])
+	challengeBytes := chainhash.TaggedHash(
+		ChallengeHashTag, challengeMsg.Bytes(),
+	)
+	var e btcec.ModNScalar
+	e.SetByteSlice(challengeBytes[:])
+
+	// Next, we'll compute mu, our aggregation coefficient for the key that
+	// we're signing with.
+	mu := aggregationCoefficient(pubKeys, pubKey, opts.sortKeys)
+
+	// With mu constructed, we can finally generate our partial signature
+	// as: s = (k1_1 + b*k_2 + e*mu*d) mod n.
+	s := new(btcec.ModNScalar)
+	s.Add(&k1).Add(k2.Mul(&nonceBlinder)).Add(e.Mul(mu).Mul(&privKeyScalar))
+
+	sig := NewPartialSignature(s, nonceKey)
+
+	// If we're not in fast sign mode, then we'll also validate our partial
+	// signature.
+	if !opts.fastSign {
+		pubNonce := secNonceToPubNonce(&secNonce)
+		sigValid := sig.Verify(
+			pubNonce, combinedNonce, pubKeys, pubKey, msg,
+			signOpts...,
+		)
+		if !sigValid {
+			return nil, fmt.Errorf("sig is invalid!")
+		}
+	}
+
+	return &sig, nil
+}
+
+// Verify implements partial signature verification given the public nonce for
+// the signer, aggregate nonce, signer set and finally the message being
+// signed.
+func (p *PartialSignature) Verify(pubNonce [PubNonceSize]byte,
+	combinedNonce [PubNonceSize]byte, keySet []*btcec.PublicKey,
+	signingKey *btcec.PublicKey, msg [32]byte, signOpts ...SignOption) bool {
+
+	pubKey := schnorr.SerializePubKey(signingKey)
+	return verifyPartialSig(
+		p, pubNonce, combinedNonce, keySet, pubKey, msg, signOpts...,
+	) == nil
+}
+
+// verifyPartialSig attempts to verify a partial schnorr signature given the
+// necessary parameters. This is the internal version of Verify that returns
+// detailed errors.  signed.
+func verifyPartialSig(partialSig *PartialSignature, pubNonce [PubNonceSize]byte,
+	combinedNonce [PubNonceSize]byte, keySet []*btcec.PublicKey,
+	pubKey []byte, msg [32]byte, signOpts ...SignOption) error {
+
+	opts := defaultSignOptions()
+	for _, option := range signOpts {
+		option(opts)
+	}
+
+	// First we'll map the internal partial signature back into something
+	// we can manipulate.
+	s := partialSig.S
+
+	// Next we'll parse out the two public nonces into something we can
+	// use.
+	//
+	// TODO(roasbeef): consolidate, new method
+	r1, err := btcec.ParsePubKey(
+		combinedNonce[:btcec.PubKeyBytesLenCompressed],
+	)
+	if err != nil {
+		return err
+	}
+	r2, err := btcec.ParsePubKey(
+		combinedNonce[btcec.PubKeyBytesLenCompressed:],
+	)
+	if err != nil {
+		return err
+	}
+
+	// Next we'll construct the aggregated public key based on the set of
+	// signers.
+	combinedKey := AggregateKeys(keySet, opts.sortKeys)
+
+	// Next we'll compute the value b, that blinds our second public
+	// nonce:
+	//  * b = h(tag=NonceBlindTag, combinedNonce || combinedKey || m).
+	var (
+		nonceMsgBuf  bytes.Buffer
+		nonceBlinder btcec.ModNScalar
+	)
+	nonceMsgBuf.Write(combinedNonce[:])
+	nonceMsgBuf.Write(schnorr.SerializePubKey(combinedKey))
+	nonceMsgBuf.Write(msg[:])
+	nonceBlindHash := chainhash.TaggedHash(NonceBlindTag, nonceMsgBuf.Bytes())
+	nonceBlinder.SetByteSlice(nonceBlindHash[:])
+
+	var nonce, r1J, r2J btcec.JacobianPoint
+	r1.AsJacobian(&r1J)
+	r2.AsJacobian(&r2J)
+
+	// With our nonce blinding value, we'll now combine both the public
+	// nonces, using the blinding factor to tweak the second nonce:
+	//  * R = R_1 + b*R_2
+	btcec.ScalarMultNonConst(&nonceBlinder, &r2J, &r2J)
+	btcec.AddNonConst(&r1J, &r2J, &nonce)
+
+	// Next, we'll parse out the set of public nonces this signer used to
+	// generate the signature.
+	pubNonce1, err := btcec.ParsePubKey(
+		pubNonce[:btcec.PubKeyBytesLenCompressed],
+	)
+	if err != nil {
+		return err
+	}
+	pubNonce2, err := btcec.ParsePubKey(
+		pubNonce[btcec.PubKeyBytesLenCompressed:],
+	)
+	if err != nil {
+		return err
+	}
+
+	// We'll perform a similar aggregation and blinding operator as we did
+	// above for the combined nonces: R' = R_1' + b*R_2'.
+	var pubNonceJ, pubNonce1J, pubNonce2J btcec.JacobianPoint
+	pubNonce1.AsJacobian(&pubNonce1J)
+	pubNonce2.AsJacobian(&pubNonce2J)
+	btcec.ScalarMultNonConst(&nonceBlinder, &pubNonce2J, &pubNonce2J)
+	btcec.AddNonConst(&pubNonce1J, &pubNonce2J, &pubNonceJ)
+
+	nonce.ToAffine()
+
+	// If the combined nonce used in the challenge hash has an odd y
+	// coordinate, then we'll negate our final public nonce.
+	//
+	// TODO(roasbeef): make into func
+	if nonce.Y.IsOdd() {
+		pubNonceJ.ToAffine()
+		pubNonceJ.Y.Negate(1)
+		pubNonceJ.Y.Normalize()
+	}
+
+	// Next we'll create the challenge hash that commits to the combined
+	// nonce, combined public key and also the message:
+	//  * e = H(tag=ChallengeHashTag, R || Q || m) mod n
+	var challengeMsg bytes.Buffer
+	challengeMsg.Write(schnorr.SerializePubKey(btcec.NewPublicKey(
+		&nonce.X, &nonce.Y,
+	)))
+	challengeMsg.Write(schnorr.SerializePubKey(combinedKey))
+	challengeMsg.Write(msg[:])
+	challengeBytes := chainhash.TaggedHash(
+		ChallengeHashTag, challengeMsg.Bytes(),
+	)
+	var e btcec.ModNScalar
+	e.SetByteSlice(challengeBytes[:])
+
+	signingKey, err := schnorr.ParsePubKey(pubKey)
+	if err != nil {
+		return err
+	}
+
+	// Next, we'll compute mu, our aggregation coefficient for the key that
+	// we're signing with.
+	mu := aggregationCoefficient(keySet, signingKey, opts.sortKeys)
+
+	// If the combined key has an odd y coordinate, then we'll negate the
+	// signer key.
+	var signKeyJ btcec.JacobianPoint
+	signingKey.AsJacobian(&signKeyJ)
+	combinedKeyBytes := combinedKey.SerializeCompressed()
+	if combinedKeyBytes[0] == secp.PubKeyFormatCompressedOdd {
+		signKeyJ.ToAffine()
+		signKeyJ.Y.Negate(1)
+		signKeyJ.Y.Normalize()
+	}
+
+	// In the final set, we'll check that: s*G == R' + e*mu*P.
+	var sG, rP btcec.JacobianPoint
+	btcec.ScalarBaseMultNonConst(s, &sG)
+	btcec.ScalarMultNonConst(e.Mul(mu), &signKeyJ, &rP)
+	btcec.AddNonConst(&rP, &pubNonceJ, &rP)
+
+	sG.ToAffine()
+	rP.ToAffine()
+
+	if sG != rP {
+		return ErrPartialSigInvalid
+	}
+
+	return nil
+}
+
+// CombineSigs combines the set of public keys given the final aggregated
+// nonce, and the series of partial signatures for each nonce.
+func CombineSigs(combinedNonce *btcec.PublicKey,
+	partialSigs []*PartialSignature) *schnorr.Signature {
+
+	var combinedSig btcec.ModNScalar
+	for _, partialSig := range partialSigs {
+		combinedSig.Add(partialSig.S)
+	}
+
+	// TODO(roasbeef): less verbose way to get the x coord...
+	var nonceJ btcec.JacobianPoint
+	combinedNonce.AsJacobian(&nonceJ)
+	nonceJ.ToAffine()
+
+	return schnorr.NewSignature(&nonceJ.X, &combinedSig)
+}

--- a/btcec/schnorr/signature.go
+++ b/btcec/schnorr/signature.go
@@ -1,7 +1,4 @@
-// Copyright (c) 2013-2017 The btcsuite developers
-// Copyright (c) 2015-2021 The Decred developers
-// Use of this source code is governed by an ISC
-// license that can be found in the LICENSE file.
+// Copyright (c) 2013-2022 The btcsuite developers
 
 package schnorr
 


### PR DESCRIPTION
In this commit, we add a fully featured `musig2` implementation capable of generating partial signatures, combining them, and finally ensuring that the combined signature is a valid BIP-340 schnorr signature. This implementation is based off of [this spec](https://github.com/ElementsProject/secp256k1-zkp/blob/master/doc/musig-spec.mediawiki) from the `secp256k1-zkp` repo. 

I consider much of the external API to still be a WIP, but everything is functional as is. The API will likely evolve as we start to use it upstream in `lnd`, `pool`, `loop`, etc, etc. 

Before this PR is ready for merging, I want to further optimize it (adding benchmarks along the way), as during signing and nonce generation a lot of values end up being computed multiple times, when instead they can be computed once and memoized from there. I think it would also be useful to export a nicer version of the bookkeeping struct created in the final test for multi party signing. 

TODOs
- [x] add benchmarks 
- [x] optimize logic by memoizing common routines (blinding factor, combined keys, etc)
- [x] create better multi-party signing API (context to hold all the keys, etc), similar to what's added in the final test
- [x] add support for BIP 341 taproot tweak output key derivation
- [x] add explicit support for BIP 86 output key derivation
- [x] extend context API to allow nonce generation before all keys are known (needed for certain contexts like LN funding)
- [x] properly cache intermediate computations to avoid redoing it all several times in the process