### PR TITLE
Remove circular dependency issue between `btcec/v2` and main package

### DIFF
--- a/btcec/go.mod
+++ b/btcec/go.mod
@@ -9,3 +9,8 @@ require (
 )
 
 require github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
+
+// We depend on chainhash as is, so we need to replace to use the version of
+// chainhash included in the version of btcd we're building in.
+// TODO(guggero): Remove this as soon as we have a tagged version of chainhash.
+replace github.com/btcsuite/btcd/chaincfg/chainhash => ../chaincfg/chainhash

--- a/btcec/go.mod
+++ b/btcec/go.mod
@@ -3,13 +3,9 @@ module github.com/btcsuite/btcd/btcec/v2
 go 1.17
 
 require (
-	github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c
+	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
 )
 
 require github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
-
-// We depend on chainhash as is, so we need to replace to use the version of
-// chainhash included in the version of btcd we're building in.
-replace github.com/btcsuite/btcd => ../

--- a/btcutil/go.mod
+++ b/btcutil/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aead/siphash v1.0.1
 	github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c
 	github.com/btcsuite/btcd/btcec/v2 v2.1.0
+	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
 	github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23

--- a/btcutil/go.mod
+++ b/btcutil/go.mod
@@ -16,3 +16,8 @@ require (
 replace github.com/btcsuite/btcd/btcec/v2 => ../btcec
 
 replace github.com/btcsuite/btcd => ../
+
+// We depend on chainhash as is, so we need to replace to use the version of
+// chainhash included in the version of btcd we're building in.
+// TODO(guggero): Remove this as soon as we have a tagged version of chainhash.
+replace github.com/btcsuite/btcd/chaincfg/chainhash => ../chaincfg/chainhash

--- a/btcutil/go.mod
+++ b/btcutil/go.mod
@@ -13,6 +13,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 )
 
+// TODO(guggero): Remove this as soon as we have a tagged version of btcec/v2.
 replace github.com/btcsuite/btcd/btcec/v2 => ../btcec
 
 replace github.com/btcsuite/btcd => ../

--- a/btcutil/go.mod
+++ b/btcutil/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/aead/siphash v1.0.1
 	github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c
-	github.com/btcsuite/btcd/btcec/v2 v2.1.0
+	github.com/btcsuite/btcd/btcec/v2 v2.1.1
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1

--- a/btcutil/psbt/go.mod
+++ b/btcutil/psbt/go.mod
@@ -16,6 +16,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 // indirect
 )
 
+// TODO(guggero): Remove this as soon as we have a tagged version of btcec/v2.
 replace github.com/btcsuite/btcd/btcec/v2 => ../../btcec
 
 replace github.com/btcsuite/btcd/btcutil => ../

--- a/btcutil/psbt/go.mod
+++ b/btcutil/psbt/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c
-	github.com/btcsuite/btcd/btcec/v2 v2.1.0
+	github.com/btcsuite/btcd/btcec/v2 v2.1.1
 	github.com/btcsuite/btcd/btcutil v1.1.0
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0
 	github.com/davecgh/go-spew v1.1.1

--- a/btcutil/psbt/go.mod
+++ b/btcutil/psbt/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/btcsuite/btcd v0.22.0-beta.0.20220111032746-97732e52810c
 	github.com/btcsuite/btcd/btcec/v2 v2.1.0
 	github.com/btcsuite/btcd/btcutil v1.1.0
+	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0
 	github.com/davecgh/go-spew v1.1.1
 )
 

--- a/btcutil/psbt/go.mod
+++ b/btcutil/psbt/go.mod
@@ -21,3 +21,8 @@ replace github.com/btcsuite/btcd/btcec/v2 => ../../btcec
 replace github.com/btcsuite/btcd/btcutil => ../
 
 replace github.com/btcsuite/btcd => ../..
+
+// We depend on chainhash as is, so we need to replace to use the version of
+// chainhash included in the version of btcd we're building in.
+// TODO(guggero): Remove this as soon as we have a tagged version of chainhash.
+replace github.com/btcsuite/btcd/chaincfg/chainhash => ../../chaincfg/chainhash

--- a/chaincfg/chainhash/go.mod
+++ b/chaincfg/chainhash/go.mod
@@ -1,0 +1,3 @@
+module github.com/btcsuite/btcd/chaincfg/chainhash
+
+go 1.17

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/btcsuite/btcd
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.1.0
+	github.com/btcsuite/btcd/btcec/v2 v2.1.1
 	github.com/btcsuite/btcd/btcutil v1.1.0
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,11 @@ replace github.com/btcsuite/btcd/btcutil => ./btcutil
 
 replace github.com/btcsuite/btcd/btcec/v2 => ./btcec
 
+// We depend on chainhash as is, so we need to replace to use the version of
+// chainhash included in the version of btcd we're building in.
+// TODO(guggero): Remove this as soon as we have a tagged version of chainhash.
+replace github.com/btcsuite/btcd/chaincfg/chainhash => ./chaincfg/chainhash
+
 // The retract statements below fixes an accidental push of the tags of a btcd
 // fork.
 retract (

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 
 replace github.com/btcsuite/btcd/btcutil => ./btcutil
 
+// TODO(guggero): Remove this as soon as we have a tagged version of btcec/v2.
 replace github.com/btcsuite/btcd/btcec/v2 => ./btcec
 
 // We depend on chainhash as is, so we need to replace to use the version of

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/btcsuite/btcd
 require (
 	github.com/btcsuite/btcd/btcec/v2 v2.1.0
 	github.com/btcsuite/btcd/btcutil v1.1.0
+	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd
 	github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792


### PR DESCRIPTION
Fixes https://github.com/btcsuite/btcd/issues/1822.

After merging this PR we need to push two tags: `chaincfg/chainhash/v1.0.0` and `btcec/v2/v2.1.1`.
And I _think_ the two tags cannot be on the same commit (because go mod is just mean that way), so I'd suggest adding `chaincfg/chainhash/v1.0.0` to 7cc824e9 and `btcec/v2/v2.1.1` to 4ad74cd4.

cc @Roasbeef.