### PR TITLE
Default to JSONRPC 1.0 if the rpcVersion empty

### DIFF
--- a/btcjson/jsonrpc.go
+++ b/btcjson/jsonrpc.go
@@ -157,6 +157,9 @@ func (request *Request) UnmarshalJSON(b []byte) error {
 // request.
 func NewRequest(rpcVersion RPCVersion, id interface{}, method string, params []interface{}) (*Request, error) {
 	// default to JSON-RPC 1.0 if RPC type is not specified
+	if rpcVersion == "" {
+		rpcVersion = RpcVersion1
+	}
 	if !rpcVersion.IsValid() {
 		str := fmt.Sprintf("rpcversion '%s' is invalid", rpcVersion)
 		return nil, makeError(ErrInvalidType, str)


### PR DESCRIPTION
This resolves https://github.com/btcsuite/btcd/issues/1711. The issue causes problems with downstream libraries if the `jsonrpc` parameter isn't included with an rpc request.

Oddly enough the comment on line 159 calls for defaulting to `RpcVersion1` but the code does not do it.

I just added in a quick check and default in the case of an empty version.