### PR TITLE
chaincfg: use lower custom activation threshold for regtest+simnet

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -493,7 +493,7 @@ var RegressionNetParams = Params{
 			DeploymentEnder: NewMedianTimeDeploymentEnder(
 				time.Time{}, // Never expires.
 			),
-			CustomActivationThreshold: 1512, // 75%
+			CustomActivationThreshold: 108, // Only needs 75% hash rate.
 		},
 	},
 
@@ -733,7 +733,7 @@ var SimNetParams = Params{
 			DeploymentEnder: NewMedianTimeDeploymentEnder(
 				time.Time{}, // Never expires.
 			),
-			CustomActivationThreshold: 1815, // 90%
+			CustomActivationThreshold: 75, // Only needs 75% hash rate.
 		},
 	},
 


### PR DESCRIPTION
The existing values were copied over from the testnet deployment, which
uses a much larger miner confirmation window. As a result, the main
taproot deployment would require thousands of blocks to properly
activate in development environments.