### PR TITLE
rpcclient: add getnewaddresstype and revert breaking change

### DIFF
--- a/btcjson/walletsvrcmds_test.go
+++ b/btcjson/walletsvrcmds_test.go
@@ -388,7 +388,21 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 		},
 		{
-			name: "getnewaddress optional",
+			name: "getnewaddress optional acct",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("getnewaddress", "acct")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewGetNewAddressCmd(btcjson.String("acct"), nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getnewaddress","params":["acct"],"id":1}`,
+			unmarshalled: &btcjson.GetNewAddressCmd{
+				Account:     btcjson.String("acct"),
+				AddressType: nil,
+			},
+		},
+		{
+			name: "getnewaddress optional acct and type",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("getnewaddress", "acct", "legacy")
 			},
@@ -416,7 +430,21 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 		},
 		{
-			name: "getrawchangeaddress optional",
+			name: "getrawchangeaddress optional acct",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("getrawchangeaddress", "acct")
+			},
+			staticCmd: func() interface{} {
+				return btcjson.NewGetRawChangeAddressCmd(btcjson.String("acct"), nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"getrawchangeaddress","params":["acct"],"id":1}`,
+			unmarshalled: &btcjson.GetRawChangeAddressCmd{
+				Account:     btcjson.String("acct"),
+				AddressType: nil,
+			},
+		},
+		{
+			name: "getrawchangeaddress optional acct and type",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("getrawchangeaddress", "acct", "legacy")
 			},

--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -9,10 +9,10 @@ import (
 	"strconv"
 
 	"github.com/btcsuite/btcd/btcjson"
+	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/btcsuite/btcd/btcutil"
 )
 
 // *****************************
@@ -1089,8 +1089,8 @@ func (r FutureGetNewAddressResult) Receive() (btcutil.Address, error) {
 // returned instance.
 //
 // See GetNewAddress for the blocking version and more details.
-func (c *Client) GetNewAddressAsync(account, addrType string) FutureGetNewAddressResult {
-	cmd := btcjson.NewGetNewAddressCmd(&account, &addrType)
+func (c *Client) GetNewAddressAsync(account string) FutureGetNewAddressResult {
+	cmd := btcjson.NewGetNewAddressCmd(&account, nil)
 	result := FutureGetNewAddressResult{
 		network:         c.chainParams,
 		responseChannel: c.SendCmd(cmd),
@@ -1100,8 +1100,28 @@ func (c *Client) GetNewAddressAsync(account, addrType string) FutureGetNewAddres
 
 // GetNewAddress returns a new address, and decodes based on the client's
 // chain params.
-func (c *Client) GetNewAddress(account, addrType string) (btcutil.Address, error) {
-	return c.GetNewAddressAsync(account, addrType).Receive()
+func (c *Client) GetNewAddress(account string) (btcutil.Address, error) {
+	return c.GetNewAddressAsync(account).Receive()
+}
+
+// GetNewAddressTypeAsync returns an instance of a type that can be used to get
+// the result of the RPC at some future time by invoking the Receive function on
+// the returned instance.
+//
+// See GetNewAddressType for the blocking version and more details.
+func (c *Client) GetNewAddressTypeAsync(account, addrType string) FutureGetNewAddressResult {
+	cmd := btcjson.NewGetNewAddressCmd(&account, &addrType)
+	result := FutureGetNewAddressResult{
+		network:         c.chainParams,
+		responseChannel: c.SendCmd(cmd),
+	}
+	return result
+}
+
+// GetNewAddressType returns a new address, and decodes based on the client's
+// chain params.
+func (c *Client) GetNewAddressType(account, addrType string) (btcutil.Address, error) {
+	return c.GetNewAddressTypeAsync(account, addrType).Receive()
 }
 
 // FutureGetRawChangeAddressResult is a future promise to deliver the result of
@@ -1135,8 +1155,8 @@ func (r FutureGetRawChangeAddressResult) Receive() (btcutil.Address, error) {
 // function on the returned instance.
 //
 // See GetRawChangeAddress for the blocking version and more details.
-func (c *Client) GetRawChangeAddressAsync(account, addrType string) FutureGetRawChangeAddressResult {
-	cmd := btcjson.NewGetRawChangeAddressCmd(&account, &addrType)
+func (c *Client) GetRawChangeAddressAsync(account string) FutureGetRawChangeAddressResult {
+	cmd := btcjson.NewGetRawChangeAddressCmd(&account, nil)
 	result := FutureGetRawChangeAddressResult{
 		network:         c.chainParams,
 		responseChannel: c.SendCmd(cmd),
@@ -1147,8 +1167,29 @@ func (c *Client) GetRawChangeAddressAsync(account, addrType string) FutureGetRaw
 // GetRawChangeAddress returns a new address for receiving change that will be
 // associated with the provided account.  Note that this is only for raw
 // transactions and NOT for normal use.
-func (c *Client) GetRawChangeAddress(account, addrType string) (btcutil.Address, error) {
-	return c.GetRawChangeAddressAsync(account, addrType).Receive()
+func (c *Client) GetRawChangeAddress(account string) (btcutil.Address, error) {
+	return c.GetRawChangeAddressAsync(account).Receive()
+}
+
+// GetRawChangeAddressTypeAsync returns an instance of a type that can be used
+// to get the result of the RPC at some future time by invoking the Receive
+// function on the returned instance.
+//
+// See GetRawChangeAddressType for the blocking version and more details.
+func (c *Client) GetRawChangeAddressTypeAsync(account, addrType string) FutureGetRawChangeAddressResult {
+	cmd := btcjson.NewGetRawChangeAddressCmd(&account, &addrType)
+	result := FutureGetRawChangeAddressResult{
+		network:         c.chainParams,
+		responseChannel: c.SendCmd(cmd),
+	}
+	return result
+}
+
+// GetRawChangeAddressType returns a new address for receiving change that will
+// be associated with the provided account.  Note that this is only for raw
+// transactions and NOT for normal use.
+func (c *Client) GetRawChangeAddressType(account, addrType string) (btcutil.Address, error) {
+	return c.GetRawChangeAddressTypeAsync(account, addrType).Receive()
 }
 
 // FutureAddWitnessAddressResult is a future promise to deliver the result of


### PR DESCRIPTION
Since the address type was [added to the btcjson and rpcclient packages](https://github.com/btcsuite/btcd/commit/061aef98af1321d2cad437afcb7dcbd562a5b3b6), but the [corresponding btcwallet PR](https://github.com/btcsuite/btcwallet/pull/783) is not yet merged, it made it clear that the rpcclient would ideally be able to work with older btcwallet versions.  That is not straightforward with the recently modified `rpcclient.Client` methods.  See https://github.com/btcsuite/btcd/issues/1843.  This change seeks to make the rpcclient's `GetNewAddress` method compatible with both old and new btcwallet apps.

This reverts the previous breaking change to the `GetNewAddress` and `GetRawChangeAddress` `rpcclient.Client` methods, and adds the methods `GetNewAddressType` and `GetRawChangeAddressType` for requesting an address of a certain type.  This change allows the rpcclient package to continue to work with versions of the btcwallet app that do not recognize the address type parameter.

An alternate change that does not add new methods but lets the type param be omitted is here: https://github.com/btcsuite/btcd/issues/1843#issuecomment-1098044861 That keeps the current API with the breaking change however.