### PR TITLE
btcec: remove import of chainhash

### DIFF
--- a/btcec/ecdsa/example_test.go
+++ b/btcec/ecdsa/example_test.go
@@ -5,13 +5,19 @@
 package ecdsa_test
 
 import (
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
-	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
+
+func doubleHash(b []byte) []byte {
+	first := sha256.Sum256(b)
+	second := sha256.Sum256(first[:])
+	return second[:]
+}
 
 // This example demonstrates signing a message with a secp256k1 private key that
 // is first parsed form raw bytes and serializing the generated signature.
@@ -27,7 +33,7 @@ func Example_signMessage() {
 
 	// Sign a message using the private key.
 	message := "test message"
-	messageHash := chainhash.DoubleHashB([]byte(message))
+	messageHash := doubleHash([]byte(message))
 	signature := ecdsa.Sign(privKey, messageHash)
 
 	// Serialize and display the signature.
@@ -76,7 +82,7 @@ func Example_verifySignature() {
 
 	// Verify the signature for the message using the public key.
 	message := "test message"
-	messageHash := chainhash.DoubleHashB([]byte(message))
+	messageHash := doubleHash([]byte(message))
 	verified := signature.Verify(messageHash, pubKey)
 	fmt.Println("Signature Verified?", verified)
 

--- a/btcec/field_test.go
+++ b/btcec/field_test.go
@@ -6,9 +6,8 @@
 package btcec
 
 import (
-	"math/rand"
-
 	"encoding/hex"
+	"math/rand"
 	"testing"
 )
 

--- a/btcec/go.mod
+++ b/btcec/go.mod
@@ -3,7 +3,6 @@ module github.com/btcsuite/btcd/btcec/v2
 go 1.17
 
 require (
-	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
 )

--- a/btcec/go.sum
+++ b/btcec/go.sum
@@ -1,5 +1,3 @@
-github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0 h1:MSskdM4/xJYcFzy0altH/C/xHopifpWzHUi1JeVI34Q=
-github.com/btcsuite/btcd/chaincfg/chainhash v1.0.0/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK09Y2A4Xv7EE0=


### PR DESCRIPTION
One option to quickly resolve https://github.com/btcsuite/btcd/issues/1839

This duplicates some code, but requires no import path changes, only a new btcec/v2 tag.  For a proper solution, a chainhash/v2 module is still required (e.g. https://github.com/btcsuite/btcd/commit/39b119350096dee8c34d3aaa426c17105795caa9 plus a [large cascade of deps](https://github.com/btcsuite/btcd/compare/master...chappjc:chainhashv2?expand=1) like btcutil/v2 and all the way up)  since it's not just btcec that will introduce this ambiguous import.

```
The chainhash import is challenging for consumers of the latest tagged
btcd module (v0.22.0-beta) because that module revision has its own
chainhash package.  This creates an ambiguous import when trying
to import both the older btcd module and btcec/v2 which requires the
standalone module version of chainhash.

This is the brute solution.  An alternative would be to create a
chaincfg/chainhash/v2 module and have btcec/v2 require that instead.
```