### PR TITLE
build: switch to using Go 1.18 for CI in go.mod

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ env:
   # go needs absolute directories, using the $HOME variable doesn't work here.
   GOCACHE: /home/runner/work/go/pkg/build
   GOPATH: /home/runner/work/go
-  GO_VERSION: 1.17.5
+  GO_VERSION: "1.18.x"
 
 jobs:
   build:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,7 @@ details on how to install on the supported operating systems.
 
 ## Requirements
 
-[Go](http://golang.org) 1.16 or newer.
+[Go](http://golang.org) 1.18 or newer.
 
 ## GPG Verification Key
 

--- a/go.mod
+++ b/go.mod
@@ -62,4 +62,4 @@ retract (
 	v0.13.0-beta
 )
 
-go 1.17
+go 1.18


### PR DESCRIPTION
In this commit, we switch to using Go 1.18 everywhere. This is a
deviation from our typical "last 2 versions" rule. Switching now gives
us access to the new type params feature immediately, versus near the
end of this year. With this change we'd also be able to start using the
new std lib fuzzing features as well.