### PR TITLE
Add ScriptPubKeyResult address field (rpc client & server)

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -431,7 +431,8 @@ type ScriptPubKeyResult struct {
 	Hex       string   `json:"hex,omitempty"`
 	ReqSigs   int32    `json:"reqSigs,omitempty"`
 	Type      string   `json:"type"`
-	Addresses []string `json:"addresses,omitempty"`
+	Address   *string  `json:"address,omitempty"`
+	Addresses []string `json:"addresses,omitempty"` // Deprecated: removed in Bitcoin Core
 }
 
 // GetTxOutResult models the data from the gettxout command.

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -732,6 +732,9 @@ func createVoutList(mtx *wire.MsgTx, chainParams *chaincfg.Params, filterAddrMap
 		var vout btcjson.Vout
 		vout.N = uint32(i)
 		vout.Value = btcutil.Amount(v.Value).ToBTC()
+		if len(encodedAddrs) > 0 {
+			vout.ScriptPubKey.Address = &encodedAddrs[0]
+		}
 		vout.ScriptPubKey.Addresses = encodedAddrs
 		vout.ScriptPubKey.Asm = disbuf
 		vout.ScriptPubKey.Hex = hex.EncodeToString(v.PkScript)
@@ -2725,6 +2728,7 @@ func handleGetTxOut(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (i
 	var value int64
 	var pkScript []byte
 	var isCoinbase bool
+	var address *string
 	includeMempool := true
 	if c.IncludeMempool != nil {
 		includeMempool = *c.IncludeMempool
@@ -2797,6 +2801,9 @@ func handleGetTxOut(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (i
 	for i, addr := range addrs {
 		addresses[i] = addr.EncodeAddress()
 	}
+	if len(addresses) > 0 {
+		address = &addresses[0]
+	}
 
 	txOutReply := &btcjson.GetTxOutResult{
 		BestBlock:     bestBlockHash,
@@ -2807,10 +2814,12 @@ func handleGetTxOut(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (i
 			Hex:       hex.EncodeToString(pkScript),
 			ReqSigs:   int32(reqSigs),
 			Type:      scriptClass.String(),
+			Address:   address,
 			Addresses: addresses,
 		},
 		Coinbase: isCoinbase,
 	}
+
 	return txOutReply, nil
 }
 

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -86,7 +86,8 @@ var helpDescsEnUS = map[string]string{
 	"scriptpubkeyresult-hex":       "Hex-encoded bytes of the script",
 	"scriptpubkeyresult-reqSigs":   "The number of required signatures",
 	"scriptpubkeyresult-type":      "The type of the script (e.g. 'pubkeyhash')",
-	"scriptpubkeyresult-addresses": "The bitcoin addresses associated with this script",
+	"scriptpubkeyresult-address":   "The bitcoin address associated with this script",
+	"scriptpubkeyresult-addresses": "(DEPRECATED) The bitcoin addresses associated with this script",
 
 	// Vout help.
 	"vout-value":        "The amount in BTC",


### PR DESCRIPTION
Add `address` field to `ScriptPubKeyResult`. Deprecate `addresses` field.

This conforms to the corresponding change in Bitcoin Core:

- https://bitcoincore.org/en/doc/22.0.0/rpc/rawtransactions/getrawtransaction/
- https://bitcoincore.org/en/doc/22.0.0/rpc/rawtransactions/decoderawtransaction/
- https://bitcoincore.org/en/doc/22.0.0/rpc/blockchain/gettxout/

In Bitcoin Core a configuration flag is required to keep serving `addresses`. This PR serves both for the time being. The reason to require a configuration change is likely to incentivise adoption of the new field. I don't see that being as necessary for `btcd`.