### PR TITLE
rpcclient: fix missing return

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -842,6 +842,7 @@ func (c *Client) handleSendPostMessage(jReq *jsonRequest,
 				"method: %s, id: %d, last error=%v",
 				jReq.method, jReq.id, lastErr),
 		}
+		return
 	}
 
 	// Read the raw bytes and close the response.


### PR DESCRIPTION
The fix of the retry logic (https://github.com/btcsuite/btcd/pull/1856) missed the return when the http response was nil. This PR fixes this issue.