### PR TITLE
txscript: add `SigHashTypeForScript` helper func

### DIFF
--- a/txscript/sighash.go
+++ b/txscript/sighash.go
@@ -626,3 +626,20 @@ func CalcTapscriptSignaturehash(sigHashes *TxSigHashes, hType SigHashType,
 		sigHashes, hType, tx, idx, prevOutFetcher, opts...,
 	)
 }
+
+// SigHashTypeForScript returns the sighash flag for the given UTXO's pkScript.
+func SigHashTypeForScript(script []byte) (SigHashType, error) {
+	switch {
+	case IsPayToTaproot(script):
+		return SigHashDefault, nil
+
+	case IsPayToPubKey(script) || IsPayToPubKeyHash(script) ||
+		IsPayToScriptHash(script) || IsPayToWitnessPubKeyHash(script) ||
+		IsPayToWitnessScriptHash(script):
+
+		return SigHashAll, nil
+
+	default:
+		return 0, fmt.Errorf("unknown script type")
+	}
+}


### PR DESCRIPTION
Helper function that tries to identify the type of a script and returns the appropriate `SigHashType`.
