### PR TITLE
Add wire.Outpoint parser from string

### DIFF
--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -6,9 +6,11 @@ package wire
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 )
@@ -213,6 +215,29 @@ func NewOutPoint(hash *chainhash.Hash, index uint32) *OutPoint {
 		Hash:  *hash,
 		Index: index,
 	}
+}
+
+// NewOutPointFromString returns a new bitcoin transaction outpoint parsed from
+// the provided string, which should be in the format "hash:index".
+func NewOutPointFromString(outpoint string) (*OutPoint, error) {
+	parts := strings.Split(outpoint, ":")
+	if len(parts) != 2 {
+		return nil, errors.New("outpoint should be of the form txid:index")
+	}
+	hash, err := chainhash.NewHashFromStr(parts[0])
+	if err != nil {
+		return nil, err
+	}
+
+	outputIndex, err := strconv.ParseUint(parts[1], 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("invalid output index: %v", err)
+	}
+
+	return &OutPoint{
+		Hash:  *hash,
+		Index: uint32(outputIndex),
+	}, nil
 }
 
 // String returns the OutPoint in the human-readable form "hash:index".


### PR DESCRIPTION
- Adds `NewOutPointFromString` function in `wire` package.
- Adds unit tests for `NewOutPointFromString`