### PR TITLE
SignRawTransactionWithKey

### DIFF
--- a/btcjson/walletsvrcmds.go
+++ b/btcjson/walletsvrcmds.go
@@ -760,6 +760,28 @@ func NewSignRawTransactionWithWalletCmd(hexEncodedTx string, inputs *[]RawTxWitn
 	}
 }
 
+// SignRawTransactionWithKeyCmd defines the signrawtransactionwithkey JSON-RPC command.
+type SignRawTransactionWithKeyCmd struct {
+	RawTx       string
+	PrivKeys    *[]string
+	Inputs      *[]RawTxWitnessInput
+	SigHashType *string `jsonrpcdefault:"\"ALL\""`
+}
+
+// NewSignRawTransactionWithKeyCmd returns a new instance which can be used to issue a
+// signrawtransactionwithkey JSON-RPC command.
+//
+// The parameters which are pointers indicate they are optional.  Passing nil
+// for optional parameters will use the default value.
+func NewSignRawTransactionWithKeyCmd(hexEncodedTx string, privKeys []string, inputs *[]RawTxWitnessInput, sigHashType *string) *SignRawTransactionWithKeyCmd {
+	return &SignRawTransactionWithKeyCmd{
+		RawTx:       hexEncodedTx,
+		PrivKeys:    &privKeys,
+		Inputs:      inputs,
+		SigHashType: sigHashType,
+	}
+}
+
 // WalletLockCmd defines the walletlock JSON-RPC command.
 type WalletLockCmd struct{}
 
@@ -1131,6 +1153,7 @@ func init() {
 	MustRegisterCmd("signmessage", (*SignMessageCmd)(nil), flags)
 	MustRegisterCmd("signrawtransaction", (*SignRawTransactionCmd)(nil), flags)
 	MustRegisterCmd("signrawtransactionwithwallet", (*SignRawTransactionWithWalletCmd)(nil), flags)
+	MustRegisterCmd("signrawtransactionwithkey", (*SignRawTransactionWithKeyCmd)(nil), flags)
 	MustRegisterCmd("unloadwallet", (*UnloadWalletCmd)(nil), flags)
 	MustRegisterCmd("walletlock", (*WalletLockCmd)(nil), flags)
 	MustRegisterCmd("walletpassphrase", (*WalletPassphraseCmd)(nil), flags)

--- a/btcjson/walletsvrcmds_test.go
+++ b/btcjson/walletsvrcmds_test.go
@@ -1461,6 +1461,112 @@ func TestWalletSvrCmds(t *testing.T) {
 			},
 		},
 		{
+			name: "signrawtransactionwithkey",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("signrawtransactionwithkey", "001122", `["abc"]`)
+			},
+			staticCmd: func() interface{} {
+				privKeys := []string{"abc"}
+				return btcjson.NewSignRawTransactionWithKeyCmd("001122", privKeys, nil, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"signrawtransactionwithkey","params":["001122",["abc"]],"id":1}`,
+			unmarshalled: &btcjson.SignRawTransactionWithKeyCmd{
+				RawTx:       "001122",
+				PrivKeys:    &[]string{"abc"},
+				Inputs:      nil,
+				SigHashType: btcjson.String("ALL"),
+			},
+		},
+		{
+			name: "signrawtransactionwithkey optional1",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("signrawtransactionwithkey", "001122", `["abc"]`, `[{"txid":"123","vout":1,"scriptPubKey":"00","redeemScript":"01","witnessScript":"02","amount":1.5}]`)
+			},
+			staticCmd: func() interface{} {
+				privKeys := []string{"abc"}
+				txInputs := []btcjson.RawTxWitnessInput{
+					{
+						Txid:          "123",
+						Vout:          1,
+						ScriptPubKey:  "00",
+						RedeemScript:  btcjson.String("01"),
+						WitnessScript: btcjson.String("02"),
+						Amount:        btcjson.Float64(1.5),
+					},
+				}
+
+				return btcjson.NewSignRawTransactionWithKeyCmd("001122", privKeys, &txInputs, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"signrawtransactionwithkey","params":["001122",["abc"],[{"txid":"123","vout":1,"scriptPubKey":"00","redeemScript":"01","witnessScript":"02","amount":1.5}]],"id":1}`,
+			unmarshalled: &btcjson.SignRawTransactionWithKeyCmd{
+				RawTx:    "001122",
+				PrivKeys: &[]string{"abc"},
+				Inputs: &[]btcjson.RawTxWitnessInput{
+					{
+						Txid:          "123",
+						Vout:          1,
+						ScriptPubKey:  "00",
+						RedeemScript:  btcjson.String("01"),
+						WitnessScript: btcjson.String("02"),
+						Amount:        btcjson.Float64(1.5),
+					},
+				},
+				SigHashType: btcjson.String("ALL"),
+			},
+		},
+		{
+			name: "signrawtransactionwithkey optional1 with blank fields in input",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("signrawtransactionwithkey", "001122", `["abc"]`, `[{"txid":"123","vout":1,"scriptPubKey":"00","redeemScript":"01"}]`)
+			},
+			staticCmd: func() interface{} {
+				privKeys := []string{"abc"}
+				txInputs := []btcjson.RawTxWitnessInput{
+					{
+						Txid:         "123",
+						Vout:         1,
+						ScriptPubKey: "00",
+						RedeemScript: btcjson.String("01"),
+					},
+				}
+
+				return btcjson.NewSignRawTransactionWithKeyCmd("001122", privKeys, &txInputs, nil)
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"signrawtransactionwithkey","params":["001122",["abc"],[{"txid":"123","vout":1,"scriptPubKey":"00","redeemScript":"01"}]],"id":1}`,
+			unmarshalled: &btcjson.SignRawTransactionWithKeyCmd{
+				RawTx:    "001122",
+				PrivKeys: &[]string{"abc"},
+				Inputs: &[]btcjson.RawTxWitnessInput{
+					{
+						Txid:         "123",
+						Vout:         1,
+						ScriptPubKey: "00",
+						RedeemScript: btcjson.String("01"),
+					},
+				},
+				SigHashType: btcjson.String("ALL"),
+			},
+		},
+		{
+			name: "signrawtransactionwithkey optional2",
+			newCmd: func() (interface{}, error) {
+				return btcjson.NewCmd("signrawtransactionwithkey", "001122", `["abc"]`, `[]`, "ALL")
+			},
+			staticCmd: func() interface{} {
+				privKeys := []string{"abc"}
+				txInputs := []btcjson.RawTxWitnessInput{}
+
+				return btcjson.NewSignRawTransactionWithKeyCmd("001122", privKeys, &txInputs, btcjson.String("ALL"))
+			},
+			marshalled: `{"jsonrpc":"1.0","method":"signrawtransactionwithkey","params":["001122",["abc"],[],"ALL"],"id":1}`,
+			unmarshalled: &btcjson.SignRawTransactionWithKeyCmd{
+				RawTx:       "001122",
+				PrivKeys:    &[]string{"abc"},
+				Inputs:      &[]btcjson.RawTxWitnessInput{},
+				SigHashType: btcjson.String("ALL"),
+			},
+		},
+		{
 			name: "walletlock",
 			newCmd: func() (interface{}, error) {
 				return btcjson.NewCmd("walletlock")

--- a/btcjson/walletsvrresults.go
+++ b/btcjson/walletsvrresults.go
@@ -322,6 +322,14 @@ type SignRawTransactionWithWalletResult struct {
 	Errors   []SignRawTransactionError `json:"errors,omitempty"`
 }
 
+// SignRawTransactionWithKeyResult models the data from the
+// signrawtransactionwithkey command.
+type SignRawTransactionWithKeyResult struct {
+	Hex      string                    `json:"hex"`
+	Complete bool                      `json:"complete"`
+	Errors   []SignRawTransactionError `json:"errors,omitempty"`
+}
+
 // ValidateAddressWalletResult models the data returned by the wallet server
 // validateaddress command.
 type ValidateAddressWalletResult struct {


### PR DESCRIPTION
More or less a copy of SignRawTransactionWithWallet method that implements
the signrawtransactionwithkey bitcoind RPC.