### PR TITLE
build: bump version to v0.23.2

### DIFF
--- a/version.go
+++ b/version.go
@@ -18,7 +18,7 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 23
-	appPatch uint = 1
+	appPatch uint = 2
 
 	// appPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.


### PR DESCRIPTION
This includes the recent fix to the wire witness wire parsing bug.