### PR TITLE
GOGC and GOMAXPROCS configuration items added and defaults set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ coverage.txt
 btcec/coverage.txt
 btcutil/coverage.txt
 btcutil/psbt/coverage.txt
+/.idea/.gitignore
+/.idea/btcd.iml
+/.idea/modules.xml
+/.idea/vcs.xml

--- a/sample-btcd.conf
+++ b/sample-btcd.conf
@@ -343,3 +343,13 @@
 ; be disabled if this option is not specified.  The profile information can be
 ; accessed at http://localhost:<profileport>/debug/pprof once running.
 ; profile=6061
+
+; This sets the value of GOGC - by default set to 300, which increases memory
+; utilization slightly but dramatically improves performance.
+; gogc = 300
+
+; GOMAXPROCS value is by default set to the same as the number of CPU threads,
+; however, goroutines are much lighter than threads and the default value will
+; be set to 3 times the CPU threads from runtime.NumCPU(). Thus 24 would be a
+; typical value.
+; gomaxprocs = 24


### PR DESCRIPTION
I think GOGC can be set via environment variable, the runtime checks for it, maybe, but for certain it is better done directly in the app.

Increasing GOMAXPROCS above the number of CPU threads can produce substantial improvements in initial block download and validation.

These both default to prior defaults if unset but provide a way for deployments to dramatically improve IBD and speed of updating the DB when new blocks arrive. Not important improvements but produce a ~50% time to initial sync at the cost of around double memory use.

IBD is a definite weak point for btcd versus bitcoind. There is minimal cost efficiency between a 4gb vs 2gb memory availability nowadays, so this brings btcd closer to parity of performance.