### PR TITLE
Fixed ban bug that doesn't print numTxns

### DIFF
--- a/server.go
+++ b/server.go
@@ -1440,7 +1440,7 @@ func (sp *serverPeer) OnNotFound(p *peer.Peer, msg *wire.MsgNotFound) {
 	}
 	if numTxns > 0 {
 		txStr := pickNoun(uint64(numTxns), "transaction", "transactions")
-		reason := fmt.Sprintf("%d %v not found", numBlocks, txStr)
+		reason := fmt.Sprintf("%d %v not found", numTxns, txStr)
 		if sp.addBanScore(0, 10*numTxns, reason) {
 			return
 		}


### PR DESCRIPTION
This is a typo fix. There is an underlying ban bug related to this that causes two btcd nodes to ban each other due to "transaction not found" errors.