### PR TITLE
txscript: modify TweakTaprootPrivKey to operate on private key copy

### DIFF
--- a/txscript/sign.go
+++ b/txscript/sign.go
@@ -82,7 +82,7 @@ func RawTxInTaprootSignature(tx *wire.MsgTx, sigHashes *TxSigHashes, idx int,
 
 	// Before we sign the sighash, we'll need to apply the taptweak to the
 	// private key based on the tapScriptRootHash.
-	privKeyTweak := TweakTaprootPrivKey(key, tapScriptRootHash)
+	privKeyTweak := TweakTaprootPrivKey(*key, tapScriptRootHash)
 
 	// With the sighash constructed, we can sign it with the specified
 	// private key.

--- a/txscript/taproot.go
+++ b/txscript/taproot.go
@@ -296,12 +296,12 @@ func ComputeTaprootKeyNoScript(internalKey *btcec.PublicKey) *btcec.PublicKey {
 // but on the private key instead. The final key is derived as: privKey +
 // h_tapTweak(internalKey || merkleRoot) % N, where N is the order of the
 // secp256k1 curve, and merkleRoot is the root hash of the tapscript tree.
-func TweakTaprootPrivKey(privKey *btcec.PrivateKey,
+func TweakTaprootPrivKey(privKey btcec.PrivateKey,
 	scriptRoot []byte) *btcec.PrivateKey {
 
 	// If the corresponding public key has an odd y coordinate, then we'll
 	// negate the private key as specified in BIP 341.
-	privKeyScalar := &privKey.Key
+	privKeyScalar := privKey.Key
 	pubKeyBytes := privKey.PubKey().SerializeCompressed()
 	if pubKeyBytes[0] == secp.PubKeyFormatCompressedOdd {
 		privKeyScalar.Negate()


### PR DESCRIPTION
In this commit, we fix an inadvertent mutation bug that would at times cause the private key passed into the tweak function to actually be *modified* in place.

We fix this by accepting the value instead of a pointer. The actual private key struct itself contains no pointer fields, so this is effectively a deep copy via dereference.

We also add a new unit test that fails w/o this change, to show that the private key was indeed being modified.