### PR TITLE
btcec/schnorr/musig2: fix BenchmarkPartialVerify

### DIFF
--- a/btcec/schnorr/musig2/bench_test.go
+++ b/btcec/schnorr/musig2/bench_test.go
@@ -45,12 +45,7 @@ func genSigner(t *testing.B) signer {
 		t.Fatalf("unable to gen priv key: %v", err)
 	}
 
-	pubKey, err := schnorr.ParsePubKey(
-		schnorr.SerializePubKey(privKey.PubKey()),
-	)
-	if err != nil {
-		t.Fatalf("unable to gen key: %v", err)
-	}
+	pubKey := privKey.PubKey()
 
 	nonces, err := GenNonces(WithPublicKey(pubKey))
 	if err != nil {


### PR DESCRIPTION
In this commit, we fix the `BenchmarkPartialVerify` test. When we moved to musig 1.0, we stopped requiring the input as an x-only key. So we need to remove the round trip serialization to force the key to be x-only.