### PR TITLE
Update Dockerfile to Alpine 3.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN set -ex \
   && echo "Compiling for $GOARCH" \
   && go install -v . ./cmd/...
 
-FROM $ARCH/alpine:3.12
+FROM $ARCH/alpine:3.16
 
 COPY --from=build-container /go/bin /bin
 


### PR DESCRIPTION
Alpine 3.12 is EOL and contains multiple vulnerabilites.
Deploying on Alpine 3.16 works fine.