### PR TITLE
Update Docker documentation towards building your own image

### DIFF
--- a/docs/using_docker.md
+++ b/docs/using_docker.md
@@ -93,7 +93,7 @@ services:
   btcd:
     container_name: btcd
     hostname: btcd
-    image: btcsuite/btcd:latest
+    build: https://github.com/btcsuite/btcd.git#master
     restart: unless-stopped
     volumes:
       - btcd-data:/root/.btcd
@@ -115,7 +115,7 @@ services:
   btcd:
     container_name: btcd
     hostname: btcd
-    image: btcsuite/btcd:latest
+    build: https://github.com/btcsuite/btcd.git#master
     restart: unless-stopped
     volumes:
       - btcd-data:/root/.btcd
@@ -142,7 +142,7 @@ services:
   btcd:
     container_name: btcd
     hostname: btcd
-    image: btcsuite/btcd:latest
+    build: https://github.com/btcsuite/btcd.git#master
     restart: unless-stopped
     volumes:
       - btcd-data:/root/.btcd


### PR DESCRIPTION
As DockerHub the image is now non existant, this updates the documentation for Compose towards building your own image instead.
fixes #1833