### PR TITLE
blockchain: refactor and export header validation checks

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -437,7 +437,7 @@ func (b *BlockChain) calcSequenceLock(node *blockNode, tx *btcutil.Tx, utxoView 
 				prevInputHeight = 0
 			}
 			blockNode := node.Ancestor(prevInputHeight)
-			medianTime := blockNode.CalcPastMedianTime()
+			medianTime := CalcPastMedianTime(blockNode)
 
 			// Time based relative time-locks as defined by BIP 68
 			// have a time granularity of RelativeLockSeconds, so
@@ -595,7 +595,8 @@ func (b *BlockChain) connectBlock(node *blockNode, block *btcutil.Block,
 	blockSize := uint64(block.MsgBlock().SerializeSize())
 	blockWeight := uint64(GetBlockWeight(block))
 	state := newBestState(node, blockSize, blockWeight, numTxns,
-		curTotalTxns+numTxns, node.CalcPastMedianTime())
+		curTotalTxns+numTxns, CalcPastMedianTime(node),
+	)
 
 	// Atomically insert info into the database.
 	err = b.db.Update(func(dbTx database.Tx) error {
@@ -708,7 +709,7 @@ func (b *BlockChain) disconnectBlock(node *blockNode, block *btcutil.Block, view
 	blockWeight := uint64(GetBlockWeight(prevBlock))
 	newTotalTxns := curTotalTxns - uint64(len(block.MsgBlock().Transactions))
 	state := newBestState(prevNode, blockSize, blockWeight, numTxns,
-		newTotalTxns, prevNode.CalcPastMedianTime())
+		newTotalTxns, CalcPastMedianTime(prevNode))
 
 	err = b.db.Update(func(dbTx database.Tx) error {
 		// Update best block state.

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -163,13 +163,13 @@ func TestCalcSequenceLock(t *testing.T) {
 	// Obtain the median time past from the PoV of the input created above.
 	// The MTP for the input is the MTP from the PoV of the block *prior*
 	// to the one that included it.
-	medianTime := node.RelativeAncestor(5).CalcPastMedianTime().Unix()
+	medianTime := CalcPastMedianTime(node.RelativeAncestor(5)).Unix()
 
 	// The median time calculated from the PoV of the best block in the
 	// test chain.  For unconfirmed inputs, this value will be used since
 	// the MTP will be calculated from the PoV of the yet-to-be-mined
 	// block.
-	nextMedianTime := node.CalcPastMedianTime().Unix()
+	nextMedianTime := CalcPastMedianTime(node).Unix()
 	nextBlockHeight := int32(numBlocksToActivate) + 1
 
 	// Add an additional transaction which will serve as our unconfirmed

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -1236,7 +1236,7 @@ func (b *BlockChain) initChainState() error {
 		blockWeight := uint64(GetBlockWeight(btcutil.NewBlock(&block)))
 		numTxns := uint64(len(block.Transactions))
 		b.stateSnapshot = newBestState(tip, blockSize, blockWeight,
-			numTxns, state.totalTxns, tip.CalcPastMedianTime())
+			numTxns, state.totalTxns, CalcPastMedianTime(tip))
 
 		return nil
 	})

--- a/blockchain/interfaces.go
+++ b/blockchain/interfaces.go
@@ -1,0 +1,55 @@
+package blockchain
+
+import (
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+// ChainCtx is an interface that abstracts away blockchain parameters.
+type ChainCtx interface {
+	// ChainParams returns the chain's configured chaincfg.Params.
+	ChainParams() *chaincfg.Params
+
+	// BlocksPerRetarget returns the number of blocks before retargeting
+	// occurs.
+	BlocksPerRetarget() int32
+
+	// MinRetargetTimespan returns the minimum amount of time to use in the
+	// difficulty calculation.
+	MinRetargetTimespan() int64
+
+	// MaxRetargetTimespan returns the maximum amount of time to use in the
+	// difficulty calculation.
+	MaxRetargetTimespan() int64
+
+	// VerifyCheckpoint returns whether the passed height and hash match
+	// the checkpoint data. Not all instances of VerifyCheckpoint will use
+	// this function for validation.
+	VerifyCheckpoint(height int32, hash *chainhash.Hash) bool
+
+	// FindPreviousCheckpoint returns the most recent checkpoint that we
+	// have validated. Not all instances of FindPreviousCheckpoint will use
+	// this function for validation.
+	FindPreviousCheckpoint() (HeaderCtx, error)
+}
+
+// HeaderCtx is an interface that describes information about a block. This is
+// used so that external libraries can provide their own context (the header's
+// parent, bits, etc.) when attempting to contextually validate a header.
+type HeaderCtx interface {
+	// Height returns the header's height.
+	Height() int32
+
+	// Bits returns the header's bits.
+	Bits() uint32
+
+	// Timestamp returns the header's timestamp.
+	Timestamp() int64
+
+	// Parent returns the header's parent.
+	Parent() HeaderCtx
+
+	// RelativeAncestorCtx returns the header's ancestor that is distance
+	// blocks before it in the chain.
+	RelativeAncestorCtx(distance int32) HeaderCtx
+}

--- a/blockchain/thresholdstate.go
+++ b/blockchain/thresholdstate.go
@@ -153,7 +153,7 @@ func (b *BlockChain) PastMedianTime(blockHeader *wire.BlockHeader) (time.Time, e
 
 	blockNode := newBlockNode(blockHeader, prevNode)
 
-	return blockNode.CalcPastMedianTime(), nil
+	return CalcPastMedianTime(blockNode), nil
 }
 
 // thresholdStateTransition given a state, a previous node, and a toeholds

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -633,22 +633,30 @@ func checkSerializedHeight(coinbaseTx *btcutil.Tx, wantHeight int32) error {
 	return nil
 }
 
-// checkBlockHeaderContext performs several validation checks on the block header
+// CheckBlockHeaderContext performs several validation checks on the block header
 // which depend on its position within the block chain.
 //
 // The flags modify the behavior of this function as follows:
 //   - BFFastAdd: All checks except those involving comparing the header against
 //     the checkpoints are not performed.
 //
+// The skipCheckpoint boolean is used so that libraries can skip the checkpoint
+// sanity checks.
+//
 // This function MUST be called with the chain state lock held (for writes).
-func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode *blockNode, flags BehaviorFlags) error {
+// NOTE: Ignore the above lock requirement if this function is not passed a
+// *Blockchain instance as the ChainCtx argument.
+func CheckBlockHeaderContext(header *wire.BlockHeader, prevNode HeaderCtx,
+	flags BehaviorFlags, c ChainCtx, skipCheckpoint bool) error {
+
 	fastAdd := flags&BFFastAdd == BFFastAdd
 	if !fastAdd {
 		// Ensure the difficulty specified in the block header matches
 		// the calculated difficulty based on the previous block and
 		// difficulty retarget rules.
-		expectedDifficulty, err := b.calcNextRequiredDifficulty(prevNode,
-			header.Timestamp)
+		expectedDifficulty, err := calcNextRequiredDifficulty(
+			prevNode, header.Timestamp, c,
+		)
 		if err != nil {
 			return err
 		}
@@ -661,7 +669,7 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 
 		// Ensure the timestamp for the block header is after the
 		// median time of the last several blocks (medianTimeBlocks).
-		medianTime := prevNode.CalcPastMedianTime()
+		medianTime := CalcPastMedianTime(prevNode)
 		if !header.Timestamp.After(medianTime) {
 			str := "block timestamp of %v is not after expected %v"
 			str = fmt.Sprintf(str, header.Timestamp, medianTime)
@@ -671,11 +679,30 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 
 	// The height of this block is one more than the referenced previous
 	// block.
-	blockHeight := prevNode.height + 1
+	blockHeight := prevNode.Height() + 1
+
+	// Reject outdated block versions once a majority of the network
+	// has upgraded.  These were originally voted on by BIP0034,
+	// BIP0065, and BIP0066.
+	params := c.ChainParams()
+	if header.Version < 2 && blockHeight >= params.BIP0034Height ||
+		header.Version < 3 && blockHeight >= params.BIP0066Height ||
+		header.Version < 4 && blockHeight >= params.BIP0065Height {
+
+		str := "new blocks with version %d are no longer valid"
+		str = fmt.Sprintf(str, header.Version)
+		return ruleError(ErrBlockVersionTooOld, str)
+	}
+
+	if skipCheckpoint {
+		// If the caller wants us to skip the checkpoint checks, we'll
+		// return early.
+		return nil
+	}
 
 	// Ensure chain matches up to predetermined checkpoints.
 	blockHash := header.BlockHash()
-	if !b.verifyCheckpoint(blockHeight, &blockHash) {
+	if !c.VerifyCheckpoint(blockHeight, &blockHash) {
 		str := fmt.Sprintf("block at height %d does not match "+
 			"checkpoint hash", blockHeight)
 		return ruleError(ErrBadCheckpoint, str)
@@ -685,28 +712,15 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 	// chain before it.  This prevents storage of new, otherwise valid,
 	// blocks which build off of old blocks that are likely at a much easier
 	// difficulty and therefore could be used to waste cache and disk space.
-	checkpointNode, err := b.findPreviousCheckpoint()
+	checkpointNode, err := c.FindPreviousCheckpoint()
 	if err != nil {
 		return err
 	}
-	if checkpointNode != nil && blockHeight < checkpointNode.height {
+	if checkpointNode != nil && blockHeight < checkpointNode.Height() {
 		str := fmt.Sprintf("block at height %d forks the main chain "+
 			"before the previous checkpoint at height %d",
-			blockHeight, checkpointNode.height)
+			blockHeight, checkpointNode.Height())
 		return ruleError(ErrForkTooOld, str)
-	}
-
-	// Reject outdated block versions once a majority of the network
-	// has upgraded.  These were originally voted on by BIP0034,
-	// BIP0065, and BIP0066.
-	params := b.chainParams
-	if header.Version < 2 && blockHeight >= params.BIP0034Height ||
-		header.Version < 3 && blockHeight >= params.BIP0066Height ||
-		header.Version < 4 && blockHeight >= params.BIP0065Height {
-
-		str := "new blocks with version %d are no longer valid"
-		str = fmt.Sprintf(str, header.Version)
-		return ruleError(ErrBlockVersionTooOld, str)
 	}
 
 	return nil
@@ -726,7 +740,7 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 func (b *BlockChain) checkBlockContext(block *btcutil.Block, prevNode *blockNode, flags BehaviorFlags) error {
 	// Perform all block header related validation checks.
 	header := &block.MsgBlock().Header
-	err := b.checkBlockHeaderContext(header, prevNode, flags)
+	err := CheckBlockHeaderContext(header, prevNode, flags, b, false)
 	if err != nil {
 		return err
 	}
@@ -746,7 +760,7 @@ func (b *BlockChain) checkBlockContext(block *btcutil.Block, prevNode *blockNode
 		// timestamps for all lock-time based checks.
 		blockTime := header.Timestamp
 		if csvState == ThresholdActive {
-			blockTime = prevNode.CalcPastMedianTime()
+			blockTime = CalcPastMedianTime(prevNode)
 		}
 
 		// The height of this block is one more than the referenced
@@ -1186,7 +1200,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *btcutil.Block, vi
 
 		// We obtain the MTP of the *previous* block in order to
 		// determine if transactions in the current block are final.
-		medianTime := node.parent.CalcPastMedianTime()
+		medianTime := CalcPastMedianTime(node.parent)
 
 		// Additionally, if the CSV soft-fork package is now active,
 		// then we also enforce the relative sequence number based
@@ -1288,3 +1302,68 @@ func (b *BlockChain) CheckConnectBlockTemplate(block *btcutil.Block) error {
 	newNode := newBlockNode(&header, tip)
 	return b.checkConnectBlock(newNode, block, view, nil)
 }
+
+// ChainParams returns the Blockchain's configured chaincfg.Params.
+//
+// NOTE: Part of the ChainCtx interface.
+func (b *BlockChain) ChainParams() *chaincfg.Params {
+	return b.chainParams
+}
+
+// BlocksPerRetarget returns the number of blocks before retargeting occurs.
+//
+// NOTE: Part of the ChainCtx interface.
+func (b *BlockChain) BlocksPerRetarget() int32 {
+	return b.blocksPerRetarget
+}
+
+// MinRetargetTimespan returns the minimum amount of time to use in the
+// difficulty calculation.
+//
+// NOTE: Part of the ChainCtx interface.
+func (b *BlockChain) MinRetargetTimespan() int64 {
+	return b.minRetargetTimespan
+}
+
+// MaxRetargetTimespan returns the maximum amount of time to use in the
+// difficulty calculation.
+//
+// NOTE: Part of the ChainCtx interface.
+func (b *BlockChain) MaxRetargetTimespan() int64 {
+	return b.maxRetargetTimespan
+}
+
+// VerifyCheckpoint checks that the height and hash match the stored
+// checkpoints.
+//
+// NOTE: Part of the ChainCtx interface.
+func (b *BlockChain) VerifyCheckpoint(height int32,
+	hash *chainhash.Hash) bool {
+
+	return b.verifyCheckpoint(height, hash)
+}
+
+// FindPreviousCheckpoint finds the checkpoint we've encountered during
+// validation.
+//
+// NOTE: Part of the ChainCtx interface.
+func (b *BlockChain) FindPreviousCheckpoint() (HeaderCtx, error) {
+	checkpoint, err := b.findPreviousCheckpoint()
+	if err != nil {
+		return nil, err
+	}
+
+	if checkpoint == nil {
+		// This check is necessary because if we just return the nil
+		// blockNode as a HeaderCtx, a caller performing a nil-check
+		// will fail. This is a quirk of go where a nil value stored in
+		// an interface is different from the actual nil interface.
+		return nil, nil
+	}
+
+	return checkpoint, err
+}
+
+// A compile-time assertion to ensure BlockChain implements the ChainCtx
+// interface.
+var _ ChainCtx = (*BlockChain)(nil)

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -421,13 +421,15 @@ func CountP2SHSigOps(tx *btcutil.Tx, isCoinBaseTx bool, utxoView *UtxoViewpoint)
 	return totalSigOps, nil
 }
 
-// checkBlockHeaderSanity performs some preliminary checks on a block header to
+// CheckBlockHeaderSanity performs some preliminary checks on a block header to
 // ensure it is sane before continuing with processing.  These checks are
 // context free.
 //
 // The flags do not modify the behavior of this function directly, however they
 // are needed to pass along to checkProofOfWork.
-func checkBlockHeaderSanity(header *wire.BlockHeader, powLimit *big.Int, timeSource MedianTimeSource, flags BehaviorFlags) error {
+func CheckBlockHeaderSanity(header *wire.BlockHeader, powLimit *big.Int,
+	timeSource MedianTimeSource, flags BehaviorFlags) error {
+
 	// Ensure the proof of work bits in the block header is in min/max range
 	// and the block hash is less than the target value described by the
 	// bits.
@@ -467,7 +469,7 @@ func checkBlockHeaderSanity(header *wire.BlockHeader, powLimit *big.Int, timeSou
 func checkBlockSanity(block *btcutil.Block, powLimit *big.Int, timeSource MedianTimeSource, flags BehaviorFlags) error {
 	msgBlock := block.MsgBlock()
 	header := &msgBlock.Header
-	err := checkBlockHeaderSanity(header, powLimit, timeSource, flags)
+	err := CheckBlockHeaderSanity(header, powLimit, timeSource, flags)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR allows an external library like `neutrino` to be able to perform contextual and context-free header validation. This is achieved by introducing two new interfaces `HeaderCtx` (which replaces `*blockNode` in the relevant functions) and `ChainCtx` (which replaces `*BlockChain` in the relevant functions). A library calling into these functions needs to only satisfy the interface to be able to validate any received headers.