### PR TITLE
Sighash taproot keyspend bug fix

### DIFF
--- a/txscript/sign.go
+++ b/txscript/sign.go
@@ -95,7 +95,7 @@ func RawTxInTaprootSignature(tx *wire.MsgTx, sigHashes *TxSigHashes, idx int,
 
 	// If this is sighash default, then we can just return the signature
 	// directly.
-	if hashType&SigHashDefault == SigHashDefault {
+	if hashType == SigHashDefault {
 		return sig, nil
 	}
 

--- a/txscript/taproot.go
+++ b/txscript/taproot.go
@@ -774,3 +774,11 @@ func AssembleTaprootScriptTree(leaves ...TapLeaf) *IndexedTapScriptTree {
 
 	return scriptTree
 }
+
+// PayToTaprootScript creates a pk script for a pay-to-taproot output key.
+func PayToTaprootScript(taprootKey *btcec.PublicKey) ([]byte, error) {
+	return NewScriptBuilder().
+		AddOp(OP_1).
+		AddData(schnorr.SerializePubKey(taprootKey)).
+		Script()
+}


### PR DESCRIPTION
In this PR, we fix a bug in RawTxInTaprootSignature that would cause
the function to not properly apply the sighash flag for non-default
sighash signatures. The logic would end up applying `0x00` as a mask,
which will always be `0x00` on the other end.

The RawTxInTapscriptSignature function was correct, though it had the
ordering switched as it applies the sighash if the type doesn't equal
default.

The second commit adds tests that fail w/o the first commit. Without 
the first commit, the test fails for the keyspend sigs as they're always 
64 bytes, since the sighash wasn't added for non-default types. 

