### PR TITLE
docs: Update Go version as per the Readme.

### DIFF
--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -297,7 +297,7 @@ Rejoice as you will now be listed as a [contributor](https://github.com/btcsuite
 
 ## Contribution Checklist
 
-- [&nbsp;&nbsp;] All changes are Go version 1.3 compliant
+- [&nbsp;&nbsp;] All changes are Go version 1.16 compliant
 - [&nbsp;&nbsp;] The code being submitted is commented according to the
   [Code Documentation and Commenting](#CodeDocumentation) section
 - [&nbsp;&nbsp;] For new code: Code is accompanied by tests which exercise both


### PR DESCRIPTION
This PR proposes an update to the Go version, specified in the contribution guidelines as per:
- The Go version, [specified](https://github.com/btcsuite/btcd/blob/ecf98ce34fbc7a707a917272afd2ca0ebfb7ee1c/README.md) in the Readme file.
- The actual PR which updated the minimum supported Go versions, namely: https://github.com/btcsuite/btcd/pull/1753.