### PR TITLE
chainhash: JSON Unmarshal hash from string

### DIFF
--- a/chaincfg/chainhash/hash.go
+++ b/chaincfg/chainhash/hash.go
@@ -116,6 +116,22 @@ func (hash Hash) MarshalJSON() ([]byte, error) {
 	return json.Marshal(hash.String())
 }
 
+// UnmarshalJSON parse the hash with JSON appropriate string value.
+func (hash *Hash) UnmarshalJSON(input []byte) error {
+    var sh string
+    err := json.Unmarshal(input, &sh)
+    if err != nil {
+        return err
+    }
+
+    newHash, err := NewHashFromStr(sh)
+    if err != nil {
+        return err
+    }
+
+    return hash.SetBytes(newHash[:])
+}
+
 // NewHash returns a new Hash from a byte slice.  An error is returned if
 // the number of bytes passed in is not HashSize.
 func NewHash(newHash []byte) (*Hash, error) {


### PR DESCRIPTION
chainhash: JSON Unmarshal hash from appropriate string.
This commit(https://github.com/btcsuite/btcd/commit/1d6e578c2180a6ee45755270dd938894fb93d661) occurred a problem:
"error": "json: cannot unmarshal string into Go struct field OutPoint.TxIn.PreviousOutPoint.Hash of type chainhash.Hash"

fix it.