### PR TITLE
btcd: Add memory profiling flag

### DIFF
--- a/btcd.go
+++ b/btcd.go
@@ -88,6 +88,18 @@ func btcdMain(serverChan chan<- *server) error {
 		defer pprof.StopCPUProfile()
 	}
 
+	// Write mem profile if requested.
+	if cfg.MemoryProfile != "" {
+		f, err := os.Create(cfg.MemoryProfile)
+		if err != nil {
+			btcdLog.Errorf("Unable to create memory profile: %v", err)
+			return err
+		}
+		defer f.Close()
+		defer pprof.WriteHeapProfile(f)
+		defer runtime.GC()
+	}
+
 	// Perform upgrades to btcd as new versions require it.
 	if err := doUpgrades(); err != nil {
 		btcdLog.Errorf("%v", err)

--- a/config.go
+++ b/config.go
@@ -111,6 +111,7 @@ type config struct {
 	ConfigFile           string        `short:"C" long:"configfile" description:"Path to configuration file"`
 	ConnectPeers         []string      `long:"connect" description:"Connect only to the specified peers at startup"`
 	CPUProfile           string        `long:"cpuprofile" description:"Write CPU profile to the specified file"`
+	MemoryProfile        string        `long:"memprofile" description:"Write memory profile to the specified file"`
 	DataDir              string        `short:"b" long:"datadir" description:"Directory to store data"`
 	DbType               string        `long:"dbtype" description:"Database backend to use for the Block Chain"`
 	DebugLevel           string        `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`


### PR DESCRIPTION
Enables Go memory profiling.  If the cpuprofile shows a lot of time spent on gc, it's useful to then do a memory profile to see where the memory alloctions happen.

Unlike the --profile flag, this allows for easy generation of a memory profile for the entire duration of which btcd has been running for in various readble graphs.