### PR TITLE
blockchain, cmd, netsync, main: Add utxocache

### DIFF
--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -51,6 +51,10 @@ var (
 	// chain state.
 	chainStateKeyName = []byte("chainstate")
 
+	// utxoStateConsistencyKeyName is the name of the db key used to store the
+	// consistency status of the utxo state.
+	utxoStateConsistencyKeyName = []byte("utxostateconsistency")
+
 	// spendJournalVersionKeyName is the name of the db key used to store
 	// the version of the spend journal currently in the database.
 	spendJournalVersionKeyName = []byte("spendjournalversion")
@@ -1012,6 +1016,21 @@ func dbPutBestState(dbTx database.Tx, snapshot *BestState, workSum *big.Int) err
 
 	// Store the current best chain state into the database.
 	return dbTx.Metadata().Put(chainStateKeyName, serializedData)
+}
+
+// dbPutUtxoStateConsistency uses an existing database transaction to
+// update the utxo state consistency status with the given parameters.
+func dbPutUtxoStateConsistency(dbTx database.Tx, hash *chainhash.Hash) error {
+	// Store the utxo state consistency status into the database.
+	return dbTx.Metadata().Put(utxoStateConsistencyKeyName, hash[:])
+}
+
+// dbFetchUtxoStateConsistency uses an existing database transaction to retrieve
+// the utxo state consistency status from the database.  The code is 0 when
+// nothing was found.
+func dbFetchUtxoStateConsistency(dbTx database.Tx) []byte {
+	// Fetch the serialized data from the database.
+	return dbTx.Metadata().Get(utxoStateConsistencyKeyName)
 }
 
 // createChainState initializes both the database and the chain state to the

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -795,6 +795,7 @@ func dbPutUtxoView(dbTx database.Tx, view *UtxoViewpoint) error {
 	if view == nil {
 		return nil
 	}
+
 	utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
 	for outpoint, entry := range view.entries {
 		// No need to update the database if the entry was not modified.

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -748,11 +748,12 @@ func dbFetchUtxoEntryByHash(dbTx database.Tx, hash *chainhash.Hash) (*UtxoEntry,
 //
 // When there is no entry for the provided output, nil will be returned for both
 // the entry and the error.
-func dbFetchUtxoEntry(dbTx database.Tx, outpoint wire.OutPoint) (*UtxoEntry, error) {
+func dbFetchUtxoEntry(dbTx database.Tx, utxoBucket database.Bucket,
+	outpoint wire.OutPoint) (*UtxoEntry, error) {
+
 	// Fetch the unspent transaction output information for the passed
 	// transaction output.  Return now when there is no entry.
 	key := outpointKey(outpoint)
-	utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
 	serializedUtxo := utxoBucket.Get(*key)
 	recycleOutpointKey(key)
 	if serializedUtxo == nil {

--- a/blockchain/chainio.go
+++ b/blockchain/chainio.go
@@ -790,6 +790,10 @@ func dbFetchUtxoEntry(dbTx database.Tx, outpoint wire.OutPoint) (*UtxoEntry, err
 // particular, only the entries that have been marked as modified are written
 // to the database.
 func dbPutUtxoView(dbTx database.Tx, view *UtxoViewpoint) error {
+	// Return early if the view is nil.
+	if view == nil {
+		return nil
+	}
 	utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
 	for outpoint, entry := range view.entries {
 		// No need to update the database if the entry was not modified.

--- a/blockchain/sizehelper.go
+++ b/blockchain/sizehelper.go
@@ -1,0 +1,221 @@
+// Copyright (c) 2023 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+package blockchain
+
+import (
+	"math"
+)
+
+// These constants are related to bitcoin.
+const (
+	// outpointSize is the size of an outpoint.
+	//
+	// This value is calculated by running the following:
+	//	unsafe.Sizeof(wire.OutPoint{})
+	outpointSize = 36
+
+	// uint64Size is the size of an uint64 allocated in memory.
+	uint64Size = 8
+
+	// bucketSize is the size of the bucket in the cache map.  Exact
+	// calculation is (16 + keysize*8 + valuesize*8) where for the map of:
+	// map[wire.OutPoint]*UtxoEntry would have a keysize=36 and valuesize=8.
+	//
+	// https://github.com/golang/go/issues/34561#issuecomment-536115805
+	bucketSize = 16 + uint64Size*outpointSize + uint64Size*uint64Size
+
+	// This value is calculated by running the following on a 64-bit system:
+	//   unsafe.Sizeof(UtxoEntry{})
+	baseEntrySize = 40
+
+	// pubKeyHashLen is the length of a P2PKH script.
+	pubKeyHashLen = 25
+
+	// avgEntrySize is how much each entry we expect it to be.  Since most
+	// txs are p2pkh, we can assume the entry to be more or less the size
+	// of a p2pkh tx.  We add on 7 to make it 32 since 64 bit systems will
+	// align by 8 bytes.
+	avgEntrySize = baseEntrySize + (pubKeyHashLen + 7)
+)
+
+// The code here is shamelessely taken from the go runtime package.  All the relevant
+// code and variables are copied to here.  These values are only correct for a 64 bit
+// system.
+
+const (
+	_MaxSmallSize   = 32768
+	smallSizeDiv    = 8
+	smallSizeMax    = 1024
+	largeSizeDiv    = 128
+	_NumSizeClasses = 68
+	_PageShift      = 13
+	_PageSize       = 1 << _PageShift
+
+	MaxUintptr = ^uintptr(0)
+
+	// Maximum number of key/elem pairs a bucket can hold.
+	bucketCntBits = 3
+	bucketCnt     = 1 << bucketCntBits
+
+	// Maximum average load of a bucket that triggers growth is 6.5.
+	// Represent as loadFactorNum/loadFactorDen, to allow integer math.
+	loadFactorNum = 13
+	loadFactorDen = 2
+
+	// maxAlloc is the maximum size of an allocation. On 64-bit,
+	// it's theoretically possible to allocate 1<<heapAddrBits bytes. On
+	// 32-bit, however, this is one less than 1<<32 because the
+	// number of bytes in the address space doesn't actually fit
+	// in a uintptr.
+	//
+	// NOTE (kcalvinalvin): I just took the constant for a 64 bit system.
+	maxAlloc = 281474976710656
+)
+
+var class_to_size = [_NumSizeClasses]uint16{0, 8, 16, 24, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 896, 1024, 1152, 1280, 1408, 1536, 1792, 2048, 2304, 2688, 3072, 3200, 3456, 4096, 4864, 5376, 6144, 6528, 6784, 6912, 8192, 9472, 9728, 10240, 10880, 12288, 13568, 14336, 16384, 18432, 19072, 20480, 21760, 24576, 27264, 28672, 32768}
+var size_to_class8 = [smallSizeMax/smallSizeDiv + 1]uint8{0, 1, 2, 3, 4, 5, 5, 6, 6, 7, 7, 8, 8, 9, 9, 10, 10, 11, 11, 12, 12, 13, 13, 14, 14, 15, 15, 16, 16, 17, 17, 18, 18, 19, 19, 19, 19, 20, 20, 20, 20, 21, 21, 21, 21, 22, 22, 22, 22, 23, 23, 23, 23, 24, 24, 24, 24, 25, 25, 25, 25, 26, 26, 26, 26, 27, 27, 27, 27, 27, 27, 27, 27, 28, 28, 28, 28, 28, 28, 28, 28, 29, 29, 29, 29, 29, 29, 29, 29, 30, 30, 30, 30, 30, 30, 30, 30, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 31, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32, 32}
+var size_to_class128 = [(_MaxSmallSize-smallSizeMax)/largeSizeDiv + 1]uint8{32, 33, 34, 35, 36, 37, 37, 38, 38, 39, 39, 40, 40, 40, 41, 41, 41, 42, 43, 43, 44, 44, 44, 44, 44, 45, 45, 45, 45, 45, 45, 46, 46, 46, 46, 47, 47, 47, 47, 47, 47, 48, 48, 48, 49, 49, 50, 51, 51, 51, 51, 51, 51, 51, 51, 51, 51, 52, 52, 52, 52, 52, 52, 52, 52, 52, 52, 53, 53, 54, 54, 54, 54, 55, 55, 55, 55, 55, 56, 56, 56, 56, 56, 56, 56, 56, 56, 56, 56, 57, 57, 57, 57, 57, 57, 57, 57, 57, 57, 58, 58, 58, 58, 58, 58, 59, 59, 59, 59, 59, 59, 59, 59, 59, 59, 59, 59, 59, 59, 59, 59, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 60, 61, 61, 61, 61, 61, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 62, 63, 63, 63, 63, 63, 63, 63, 63, 63, 63, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 65, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 66, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67, 67}
+
+// calculateRoughMapSize returns a close enough estimate of the
+// total memory allocated by a map.
+// hint should be the same value as the number you give when
+// making a map with the following syntax: make(map[k]v, hint)
+//
+// bucketsize is (16 + keysize*8 + valuesize*8).  For a map of:
+// map[int64]int64, keysize=8 and valuesize=8.  There are edge cases
+// where the bucket size is different that I can't find the source code
+// for. https://github.com/golang/go/issues/34561#issuecomment-536115805
+//
+// I suspect it's because of alignment and how the compiler handles it but
+// when compared with how much the compiler allocates, it's a couple hundred
+// bytes off.
+func calculateRoughMapSize(hint int, bucketSize uintptr) int {
+	// This code is copied from makemap() in runtime/map.go.
+	//
+	// TODO check once in a while to see if this algorithm gets
+	// changed.
+	mem, overflow := mulUintptr(uintptr(hint), uintptr(bucketSize))
+	if overflow || mem > maxAlloc {
+		hint = 0
+	}
+
+	// Find the size parameter B which will hold the requested # of elements.
+	// For hint < 0 overLoadFactor returns false since hint < bucketCnt.
+	B := uint8(0)
+	for overLoadFactor(hint, B) {
+		B++
+	}
+
+	// This code is copied from makeBucketArray() in runtime/map.go.
+	//
+	// TODO check once in a while to see if this algorithm gets
+	// changed.
+	//
+	// For small b, overflow buckets are unlikely.
+	// Avoid the overhead of the calculation.
+	base := bucketShift(B)
+	numBuckets := base
+	if B >= 4 {
+		// Add on the estimated number of overflow buckets
+		// required to insert the median number of elements
+		// used with this value of b.
+		numBuckets += bucketShift(B - 4)
+		sz := bucketSize * numBuckets
+		up := roundupsize(sz)
+		if up != sz {
+			numBuckets = up / bucketSize
+		}
+	}
+	total, _ := mulUintptr(bucketSize, numBuckets)
+
+	if base != numBuckets {
+		// Add 24 for mapextra struct overhead. Refer to
+		// runtime/map.go in the std library for the struct.
+		total += 24
+	}
+
+	// 48 is the number of bytes needed for the map header in a
+	// 64 bit system. Refer to hmap in runtime/map.go in the go
+	// standard library.
+	total += 48
+	return int(total)
+}
+
+// calculateMinEntries returns the minimum number of entries that will make the
+// map allocate the given total bytes.  -1 on the returned entry count will
+// make the map allocate half as much total bytes (for returned entry count that's
+// greater than 0).
+func calculateMinEntries(totalBytes int, bucketSize int) int {
+	// 48 is the number of bytes needed for the map header in a
+	// 64 bit system. Refer to hmap in runtime/map.go in the go
+	// standard library.
+	totalBytes -= 48
+
+	numBuckets := totalBytes / bucketSize
+	B := uint8(math.Log2(float64(numBuckets)))
+	if B < 4 {
+		switch B {
+		case 0:
+			return 0
+		case 1:
+			return 9
+		case 2:
+			return 14
+		default:
+			return 27
+		}
+	}
+
+	B -= 1
+
+	return (int(loadFactorNum * (bucketShift(B) / loadFactorDen))) + 1
+}
+
+// mulUintptr returns a * b and whether the multiplication overflowed.
+// On supported platforms this is an intrinsic lowered by the compiler.
+func mulUintptr(a, b uintptr) (uintptr, bool) {
+	if a|b < 1<<(4*8) || a == 0 {
+		return a * b, false
+	}
+	overflow := b > MaxUintptr/a
+	return a * b, overflow
+}
+
+// divRoundUp returns ceil(n / a).
+func divRoundUp(n, a uintptr) uintptr {
+	// a is generally a power of two. This will get inlined and
+	// the compiler will optimize the division.
+	return (n + a - 1) / a
+}
+
+// alignUp rounds n up to a multiple of a. a must be a power of 2.
+func alignUp(n, a uintptr) uintptr {
+	return (n + a - 1) &^ (a - 1)
+}
+
+// Returns size of the memory block that mallocgc will allocate if you ask for the size.
+func roundupsize(size uintptr) uintptr {
+	if size < _MaxSmallSize {
+		if size <= smallSizeMax-8 {
+			return uintptr(class_to_size[size_to_class8[divRoundUp(size, smallSizeDiv)]])
+		} else {
+			return uintptr(class_to_size[size_to_class128[divRoundUp(size-smallSizeMax, largeSizeDiv)]])
+		}
+	}
+	if size+_PageSize < size {
+		return size
+	}
+	return alignUp(size, _PageSize)
+}
+
+// overLoadFactor reports whether count items placed in 1<<B buckets is over loadFactor.
+func overLoadFactor(count int, B uint8) bool {
+	return count > bucketCnt && uintptr(count) > loadFactorNum*(bucketShift(B)/loadFactorDen)
+}
+
+// bucketShift returns 1<<b, optimized for code generation.
+func bucketShift(b uint8) uintptr {
+	// Masking the shift amount allows overflow checks to be elided.
+	return uintptr(1) << (b & (8*8 - 1))
+}

--- a/blockchain/sizehelper_test.go
+++ b/blockchain/sizehelper_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) 2023 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+package blockchain
+
+import (
+	"math"
+	"testing"
+)
+
+// calculateEntries returns a number of entries that will make the map allocate
+// the given total bytes.  The returned number is always the maximum number of
+// entries that will allocate inside the given parameters.
+func calculateEntries(totalBytes int, bucketSize int) int {
+	// 48 is the number of bytes needed for the map header in a
+	// 64 bit system. Refer to hmap in runtime/map.go in the go
+	// standard library.
+	totalBytes -= 48
+
+	numBuckets := totalBytes / bucketSize
+	B := uint8(math.Log2(float64(numBuckets)))
+	if B == 0 {
+		// For 0 buckets, the max is the bucket count.
+		return bucketCnt
+	}
+
+	return int(loadFactorNum * (bucketShift(B) / loadFactorDen))
+}
+
+func TestCalculateEntries(t *testing.T) {
+	for i := 0; i < 10_000_000; i++ {
+		// It's not possible to calculate the exact amount of entries since
+		// the map will only allocate for 2^N where N is the amount of buckets.
+		//
+		// So to see if the calculate entries function is working correctly,
+		// we get the rough map size for i entries, then calculate the entries
+		// for that map size.  If the size is the same, the function is correct.
+		roughMapSize := calculateRoughMapSize(i, bucketSize)
+		entries := calculateEntries(roughMapSize, bucketSize)
+		gotRoughMapSize := calculateRoughMapSize(entries, bucketSize)
+
+		if roughMapSize != gotRoughMapSize {
+			t.Errorf("For hint of %d, expected %v, got %v\n",
+				i, roughMapSize, gotRoughMapSize)
+		}
+
+		// Test that the entries returned are the maximum for the given map size.
+		// If we increment the entries by one, we should get a bigger map.
+		gotRoughMapSizeWrong := calculateRoughMapSize(entries+1, bucketSize)
+		if roughMapSize == gotRoughMapSizeWrong {
+			t.Errorf("For hint %d incremented by 1, expected %v, got %v\n",
+				i, gotRoughMapSizeWrong*2, gotRoughMapSizeWrong)
+		}
+
+		minEntries := calculateMinEntries(roughMapSize, bucketSize)
+		gotMinRoughMapSize := calculateRoughMapSize(minEntries, bucketSize)
+		if roughMapSize != gotMinRoughMapSize {
+			t.Errorf("For hint of %d, expected %v, got %v\n",
+				i, roughMapSize, gotMinRoughMapSize)
+		}
+
+		// Can only test if they'll be half the size if the entries aren't 0.
+		if minEntries > 0 {
+			gotMinRoughMapSizeWrong := calculateRoughMapSize(minEntries-1, bucketSize)
+			if gotMinRoughMapSize == gotMinRoughMapSizeWrong {
+				t.Errorf("For hint %d decremented by 1, expected %v, got %v\n",
+					i, gotRoughMapSizeWrong/2, gotRoughMapSizeWrong)
+			}
+		}
+	}
+}

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -5,8 +5,14 @@
 package blockchain
 
 import (
+	"fmt"
 	"sync"
+	"time"
 
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/database"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
 )
 
@@ -164,4 +170,411 @@ func (ms *mapSlice) deleteMaps() {
 	size := ms.maxEntries[0]
 	ms.maxEntries = []int{size}
 	ms.maps = ms.maps[:1]
+}
+
+const (
+	// utxoFlushPeriodicInterval is the interval at which a flush is performed
+	// when the flush mode FlushPeriodic is used.  This is used when the initial
+	// block download is complete and it's useful to flush periodically in case
+	// of unforseen shutdowns.
+	utxoFlushPeriodicInterval = time.Minute * 5
+)
+
+// FlushMode is used to indicate the different urgency types for a flush.
+type FlushMode uint8
+
+const (
+	// FlushRequired is the flush mode that means a flush must be performed
+	// regardless of the cache state.  For example right before shutting down.
+	FlushRequired FlushMode = iota
+
+	// FlushPeriodic is the flush mode that means a flush can be performed
+	// when it would be almost needed.  This is used to periodically signal when
+	// no I/O heavy operations are expected soon, so there is time to flush.
+	FlushPeriodic
+
+	// FlushIfNeeded is the flush mode that means a flush must be performed only
+	// if the cache is exceeding a safety threshold very close to its maximum
+	// size.  This is used mostly internally in between operations that can
+	// increase the cache size.
+	FlushIfNeeded
+)
+
+// utxoCache is a cached utxo view in the chainstate of a BlockChain.
+type utxoCache struct {
+	db database.DB
+
+	// maxTotalMemoryUsage is the maximum memory usage in bytes that the state
+	// should contain in normal circumstances.
+	maxTotalMemoryUsage uint64
+
+	// cachedEntries keeps the internal cache of the utxo state.  The tfModified
+	// flag indicates that the state of the entry (potentially) deviates from the
+	// state in the database.  Explicit nil values in the map are used to
+	// indicate that the database does not contain the entry.
+	cachedEntries    mapSlice
+	totalEntryMemory uint64 // Total memory usage in bytes.
+
+	// Below fields are used to indicate when the last flush happened.
+	lastFlushHash chainhash.Hash
+	lastFlushTime time.Time
+}
+
+// newUtxoCache initiates a new utxo cache instance with its memory usage limited
+// to the given maximum.
+func newUtxoCache(db database.DB, maxTotalMemoryUsage uint64) *utxoCache {
+	// While the entry isn't included in the map size, add the average size to the
+	// bucket size so we get some leftover space for entries to take up.
+	numMaxElements := calculateMinEntries(int(maxTotalMemoryUsage), bucketSize+avgEntrySize)
+	numMaxElements -= 1
+
+	log.Infof("Pre-alloacting for %d MiB: ", maxTotalMemoryUsage/(1024*1024)+1)
+
+	m := make(map[wire.OutPoint]*UtxoEntry, numMaxElements)
+
+	return &utxoCache{
+		db:                  db,
+		maxTotalMemoryUsage: maxTotalMemoryUsage,
+		cachedEntries: mapSlice{
+			maps:                []map[wire.OutPoint]*UtxoEntry{m},
+			maxEntries:          []int{numMaxElements},
+			maxTotalMemoryUsage: maxTotalMemoryUsage,
+		},
+	}
+}
+
+// totalMemoryUsage returns the total memory usage in bytes of the UTXO cache.
+func (s *utxoCache) totalMemoryUsage() uint64 {
+	// Total memory is the map size + the size that the utxo entries are
+	// taking up.
+	size := uint64(s.cachedEntries.size())
+	size += s.totalEntryMemory
+
+	return size
+}
+
+// fetchEntries returns the UTXO entries for the given outpoints.  The function always
+// returns as many entries as there are outpoints and the returns entries are in the
+// same order as the outpoints.  It returns nil if there is no entry for the outpoint
+// in the UTXO set.
+//
+// The returned entries are NOT safe for concurrent access.
+func (s *utxoCache) fetchEntries(outpoints []wire.OutPoint) ([]*UtxoEntry, error) {
+	entries := make([]*UtxoEntry, len(outpoints))
+	var missingOps []wire.OutPoint
+	var missingOpsIdx []int
+	for i := range outpoints {
+		if entry, ok := s.cachedEntries.get(outpoints[i]); ok {
+			entries[i] = entry
+			continue
+		}
+
+		// At this point, we have missing outpoints.  Allocate them now
+		// so that we never allocate if the cache never misses.
+		if len(missingOps) == 0 {
+			missingOps = make([]wire.OutPoint, 0, len(outpoints))
+			missingOpsIdx = make([]int, 0, len(outpoints))
+		}
+
+		missingOpsIdx = append(missingOpsIdx, i)
+		missingOps = append(missingOps, outpoints[i])
+	}
+
+	// Return early and don't attempt access the database if we don't have any
+	// missing outpoints.
+	if len(missingOps) == 0 {
+		return entries, nil
+	}
+
+	// Fetch the missing outpoints in the cache from the database.
+	dbEntries := make([]*UtxoEntry, len(missingOps))
+	err := s.db.View(func(dbTx database.Tx) error {
+		utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
+
+		for i := range missingOps {
+			entry, err := dbFetchUtxoEntry(dbTx, utxoBucket, missingOps[i])
+			if err != nil {
+				return err
+			}
+
+			dbEntries[i] = entry
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// Add each of the entries to the UTXO cache and update their memory
+	// usage.
+	//
+	// NOTE: When the fetched entry is nil, it is still added to the cache
+	// as a miss; this prevents future lookups to perform the same database
+	// fetch.
+	for i := range dbEntries {
+		s.cachedEntries.put(missingOps[i], dbEntries[i], s.totalEntryMemory)
+		s.totalEntryMemory += dbEntries[i].memoryUsage()
+	}
+
+	// Fill in the entries with the ones fetched from the database.
+	for i := range missingOpsIdx {
+		entries[missingOpsIdx[i]] = dbEntries[i]
+	}
+
+	return entries, nil
+}
+
+// addTxOut adds the specified output to the cache if it is not provably
+// unspendable.  When the cache already has an entry for the output, it will be
+// overwritten with the given output.  All fields will be updated for existing
+// entries since it's possible it has changed during a reorg.
+func (s *utxoCache) addTxOut(
+	outpoint wire.OutPoint, txOut *wire.TxOut, isCoinBase bool, blockHeight int32) error {
+
+	// Don't add provably unspendable outputs.
+	if txscript.IsUnspendable(txOut.PkScript) {
+		return nil
+	}
+
+	entry := new(UtxoEntry)
+	entry.amount = txOut.Value
+	// Deep copy the script when the script in the entry differs from the one in
+	// the txout.  This is required since the txout script is a subslice of the
+	// overall contiguous buffer that the msg tx houses for all scripts within
+	// the tx.  It is deep copied here since this entry may be added to the utxo
+	// cache, and we don't want the utxo cache holding the entry to prevent all
+	// of the other tx scripts from getting garbage collected.
+	entry.pkScript = make([]byte, len(txOut.PkScript))
+	copy(entry.pkScript, txOut.PkScript)
+
+	entry.blockHeight = blockHeight
+	entry.packedFlags = tfFresh | tfModified
+	if isCoinBase {
+		entry.packedFlags |= tfCoinBase
+	}
+
+	s.cachedEntries.put(outpoint, entry, s.totalEntryMemory)
+	s.totalEntryMemory += entry.memoryUsage()
+
+	return nil
+}
+
+// addTxOuts adds all outputs in the passed transaction which are not provably
+// unspendable to the view.  When the view already has entries for any of the
+// outputs, they are simply marked unspent.  All fields will be updated for
+// existing entries since it's possible it has changed during a reorg.
+func (s *utxoCache) addTxOuts(tx *btcutil.Tx, blockHeight int32) error {
+	// Loop all of the transaction outputs and add those which are not
+	// provably unspendable.
+	isCoinBase := IsCoinBase(tx)
+	prevOut := wire.OutPoint{Hash: *tx.Hash()}
+	for txOutIdx, txOut := range tx.MsgTx().TxOut {
+		// Update existing entries.  All fields are updated because it's
+		// possible (although extremely unlikely) that the existing
+		// entry is being replaced by a different transaction with the
+		// same hash.  This is allowed so long as the previous
+		// transaction is fully spent.
+		prevOut.Index = uint32(txOutIdx)
+		err := s.addTxOut(prevOut, txOut, isCoinBase, blockHeight)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// addTxIn will add the given input to the cache if the previous outpoint the txin
+// is pointing to exists in the utxo set.  The utxo that is being spent by the input
+// will be marked as spent and if the utxo is fresh (meaning that the database on disk
+// never saw it), it will be removed from the cache.
+func (s *utxoCache) addTxIn(txIn *wire.TxIn, stxos *[]SpentTxOut) error {
+	// Ensure the referenced utxo exists in the view.  This should
+	// never happen unless there is a bug is introduced in the code.
+	entries, err := s.fetchEntries([]wire.OutPoint{txIn.PreviousOutPoint})
+	if err != nil {
+		return err
+	}
+	if len(entries) != 1 || entries[0] == nil {
+		return AssertError(fmt.Sprintf("missing input %v",
+			txIn.PreviousOutPoint))
+	}
+
+	// Only create the stxo details if requested.
+	entry := entries[0]
+	if stxos != nil {
+		// Populate the stxo details using the utxo entry.
+		var stxo = SpentTxOut{
+			Amount:     entry.Amount(),
+			PkScript:   entry.PkScript(),
+			Height:     entry.BlockHeight(),
+			IsCoinBase: entry.IsCoinBase(),
+		}
+
+		*stxos = append(*stxos, stxo)
+	}
+
+	// Mark the entry as spent.
+	entry.Spend()
+
+	// If an entry is fresh it indicates that this entry was spent before it could be
+	// flushed to the database. Because of this, we can just delete it from the map of
+	// cached entries.
+	if entry.isFresh() {
+		// If the entry is fresh, we will always have it in the cache.
+		s.cachedEntries.delete(txIn.PreviousOutPoint)
+		s.totalEntryMemory -= entry.memoryUsage()
+	} else {
+		// Can leave the entry to be garbage collected as the only purpose
+		// of this entry now is so that the entry on disk can be deleted.
+		entry = nil
+		s.totalEntryMemory -= entry.memoryUsage()
+	}
+
+	return nil
+}
+
+// addTxIns will add the given inputs of the tx if it's not a coinbase tx and if
+// the previous output that the input is pointing to exists in the utxo set.  The
+// utxo that is being spent by the input will be marked as spent and if the utxo
+// is fresh (meaning that the database on disk never saw it), it will be removed
+// from the cache.
+func (s *utxoCache) addTxIns(tx *btcutil.Tx, stxos *[]SpentTxOut) error {
+	// Coinbase transactions don't have any inputs to spend.
+	if IsCoinBase(tx) {
+		return nil
+	}
+
+	for _, txIn := range tx.MsgTx().TxIn {
+		err := s.addTxIn(txIn, stxos)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// connectTransaction updates the cache by adding all new utxos created by the
+// passed transaction and marking and/or removing all utxos that the transactions
+// spend as spent.  In addition, when the 'stxos' argument is not nil, it will
+// be updated to append an entry for each spent txout.  An error will be returned
+// if the cache and the database does not contain the required utxos.
+func (s *utxoCache) connectTransaction(
+	tx *btcutil.Tx, blockHeight int32, stxos *[]SpentTxOut) error {
+
+	err := s.addTxIns(tx, stxos)
+	if err != nil {
+		return err
+	}
+
+	// Add the transaction's outputs as available utxos.
+	return s.addTxOuts(tx, blockHeight)
+}
+
+// connectTransactions updates the cache by adding all new utxos created by all
+// of the transactions in the passed block, marking and/or removing all utxos
+// the transactions spend as spent, and setting the best hash for the view to
+// the passed block.  In addition, when the 'stxos' argument is not nil, it will
+// be updated to append an entry for each spent txout.
+func (s *utxoCache) connectTransactions(block *btcutil.Block, stxos *[]SpentTxOut) error {
+	for _, tx := range block.Transactions() {
+		err := s.connectTransaction(tx, block.Height(), stxos)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// writeCache writes all the entries that are cached in memory to the database atomically.
+func (s *utxoCache) writeCache(dbTx database.Tx, bestState *BestState) error {
+	// Update commits and flushes the cache to the database.
+	// NOTE: The database has its own cache which gets atomically written
+	// to leveldb.
+	utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
+	for i := range s.cachedEntries.maps {
+		for outpoint, entry := range s.cachedEntries.maps[i] {
+			// If the entry is nil or spent, remove the entry from the database
+			// and the cache.
+			if entry == nil || entry.IsSpent() {
+				err := dbDeleteUtxoEntry(utxoBucket, outpoint)
+				if err != nil {
+					return err
+				}
+				delete(s.cachedEntries.maps[i], outpoint)
+
+				continue
+			}
+
+			// No need to update the cache if the entry was not modified.
+			if !entry.isModified() {
+				delete(s.cachedEntries.maps[i], outpoint)
+				continue
+			}
+
+			// Entry is fresh and needs to be put into the database.
+			err := dbPutUtxoEntry(utxoBucket, outpoint, entry)
+			if err != nil {
+				return err
+			}
+			delete(s.cachedEntries.maps[i], outpoint)
+		}
+	}
+	s.cachedEntries.deleteMaps()
+	s.totalEntryMemory = 0
+
+	// When done, store the best state hash in the database to indicate the state
+	// is consistent until that hash.
+	err := dbPutUtxoStateConsistency(dbTx, &bestState.Hash)
+	if err != nil {
+		return err
+	}
+
+	// The best state is the new last flush hash.
+	s.lastFlushHash = bestState.Hash
+	s.lastFlushTime = time.Now()
+
+	return nil
+}
+
+// flush flushes the UTXO state to the database if a flush is needed with the given flush mode.
+//
+// This function MUST be called with the chain state lock held (for writes).
+func (s *utxoCache) flush(dbTx database.Tx, mode FlushMode, bestState *BestState) error {
+	var threshold uint64
+	switch mode {
+	case FlushRequired:
+		threshold = 0
+
+	case FlushIfNeeded:
+		// If we performed a flush in the current best state, we have nothing to do.
+		if bestState.Hash == s.lastFlushHash {
+			return nil
+		}
+
+		threshold = s.maxTotalMemoryUsage
+
+	case FlushPeriodic:
+		// If the time since the last flush is over the periodic interval,
+		// force a flush.  Otherwise just flush when the cache is full.
+		if time.Since(s.lastFlushTime) > utxoFlushPeriodicInterval {
+			threshold = 0
+		} else {
+			threshold = s.maxTotalMemoryUsage
+		}
+	}
+
+	if s.totalMemoryUsage() >= threshold {
+		// Add one to round up the integer division.
+		totalMiB := s.totalMemoryUsage() / ((1024 * 1024) + 1)
+		log.Infof("Flushing UTXO cache of %d MiB with %d entries to disk. For large sizes, "+
+			"this can take up to several minutes...", totalMiB, s.cachedEntries.length())
+
+		return s.writeCache(dbTx, bestState)
+	}
+
+	return nil
 }

--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2023 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package blockchain
+
+import (
+	"sync"
+
+	"github.com/btcsuite/btcd/wire"
+)
+
+// mapSlice is a slice of maps for utxo entries.  The slice of maps are needed to
+// guarantee that the map will only take up N amount of bytes.  As of v1.20, the
+// go runtime will allocate 2^N + few extra buckets, meaning that for large N, we'll
+// allocate a lot of extra memory if the amount of entries goes over the previously
+// allocated buckets.  A slice of maps allows us to have a better control of how much
+// total memory gets allocated by all the maps.
+type mapSlice struct {
+	// mtx protects against concurrent access for the map slice.
+	mtx sync.Mutex
+
+	// maps are the underlying maps in the slice of maps.
+	maps []map[wire.OutPoint]*UtxoEntry
+
+	// maxEntries is the maximum amount of elements that the map is allocated for.
+	maxEntries []int
+
+	// maxTotalMemoryUsage is the maximum memory usage in bytes that the state
+	// should contain in normal circumstances.
+	maxTotalMemoryUsage uint64
+}
+
+// length returns the length of all the maps in the map slice added together.
+//
+// This function is safe for concurrent access.
+func (ms *mapSlice) length() int {
+	ms.mtx.Lock()
+	defer ms.mtx.Unlock()
+
+	var l int
+	for _, m := range ms.maps {
+		l += len(m)
+	}
+
+	return l
+}
+
+// size returns the size of all the maps in the map slice added together.
+//
+// This function is safe for concurrent access.
+func (ms *mapSlice) size() int {
+	ms.mtx.Lock()
+	defer ms.mtx.Unlock()
+
+	var size int
+	for _, num := range ms.maxEntries {
+		size += calculateRoughMapSize(num, bucketSize)
+	}
+
+	return size
+}
+
+// get looks for the outpoint in all the maps in the map slice and returns
+// the entry.  nil and false is returned if the outpoint is not found.
+//
+// This function is safe for concurrent access.
+func (ms *mapSlice) get(op wire.OutPoint) (*UtxoEntry, bool) {
+	ms.mtx.Lock()
+	defer ms.mtx.Unlock()
+
+	var entry *UtxoEntry
+	var found bool
+
+	for _, m := range ms.maps {
+		entry, found = m[op]
+		if found {
+			return entry, found
+		}
+	}
+
+	return nil, false
+}
+
+// put puts the outpoint and the entry into one of the maps in the map slice.  If the
+// existing maps are all full, it will allocate a new map based on how much memory we
+// have left over.  Leftover memory is calculated as:
+// maxTotalMemoryUsage - (totalEntryMemory + mapSlice.size())
+//
+// This function is safe for concurrent access.
+func (ms *mapSlice) put(op wire.OutPoint, entry *UtxoEntry, totalEntryMemory uint64) {
+	ms.mtx.Lock()
+	defer ms.mtx.Unlock()
+
+	for i, maxNum := range ms.maxEntries {
+		m := ms.maps[i]
+		_, found := m[op]
+		if found {
+			// If the key is found, overwrite it.
+			m[op] = entry
+			return // Return as we were successful in adding the entry.
+		}
+		if len(m) >= maxNum {
+			// Don't try to insert if the map already at max since
+			// that'll force the map to allocate double the memory it's
+			// currently taking up.
+			continue
+		}
+
+		m[op] = entry
+		return // Return as we were successful in adding the entry.
+	}
+
+	// We only reach this code if we've failed to insert into the map above as
+	// all the current maps were full.  We thus make a new map and insert into
+	// it.
+	m := ms.makeNewMap(totalEntryMemory)
+	m[op] = entry
+}
+
+// delete attempts to delete the given outpoint in all of the maps. No-op if the
+// outpoint doesn't exist.
+//
+// This function is safe for concurrent access.
+func (ms *mapSlice) delete(op wire.OutPoint) {
+	ms.mtx.Lock()
+	defer ms.mtx.Unlock()
+
+	for i := 0; i < len(ms.maps); i++ {
+		delete(ms.maps[i], op)
+	}
+}
+
+// makeNewMap makes and appends the new map into the map slice.
+//
+// This function is NOT safe for concurrent access and must be called with the
+// lock held.
+func (ms *mapSlice) makeNewMap(totalEntryMemory uint64) map[wire.OutPoint]*UtxoEntry {
+	// Get the size of the leftover memory.
+	memSize := ms.maxTotalMemoryUsage - totalEntryMemory
+	for _, maxNum := range ms.maxEntries {
+		memSize -= uint64(calculateRoughMapSize(maxNum, bucketSize))
+	}
+
+	// Get a new map that's sized to house inside the leftover memory.
+	// -1 on the returned value will make the map allocate half as much total
+	// bytes.  This is done to make sure there's still room left for utxo
+	// entries to take up.
+	numMaxElements := calculateMinEntries(int(memSize), bucketSize+avgEntrySize)
+	numMaxElements -= 1
+	ms.maxEntries = append(ms.maxEntries, numMaxElements)
+	ms.maps = append(ms.maps, make(map[wire.OutPoint]*UtxoEntry, numMaxElements))
+
+	return ms.maps[len(ms.maps)-1]
+}
+
+// deleteMaps deletes all maps except for the first one which should be the biggest.
+//
+// This function is safe for concurrent access.
+func (ms *mapSlice) deleteMaps() {
+	ms.mtx.Lock()
+	defer ms.mtx.Unlock()
+
+	size := ms.maxEntries[0]
+	ms.maxEntries = []int{size}
+	ms.maps = ms.maps[:1]
+}

--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2023 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+package blockchain
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire"
+)
+
+func TestMapSlice(t *testing.T) {
+	tests := []struct {
+		keys []wire.OutPoint
+	}{
+		{
+			keys: func() []wire.OutPoint {
+				outPoints := make([]wire.OutPoint, 1000)
+				for i := uint32(0); i < uint32(len(outPoints)); i++ {
+					var buf [4]byte
+					binary.BigEndian.PutUint32(buf[:], i)
+					hash := sha256.Sum256(buf[:])
+
+					op := wire.OutPoint{Hash: hash, Index: i}
+					outPoints[i] = op
+				}
+				return outPoints
+			}(),
+		},
+	}
+
+	for _, test := range tests {
+		m := make(map[wire.OutPoint]*UtxoEntry)
+
+		maxSize := calculateRoughMapSize(1000, bucketSize)
+
+		maxEntriesFirstMap := 500
+		ms1 := make(map[wire.OutPoint]*UtxoEntry, maxEntriesFirstMap)
+		ms := mapSlice{
+			maps:                []map[wire.OutPoint]*UtxoEntry{ms1},
+			maxEntries:          []int{maxEntriesFirstMap},
+			maxTotalMemoryUsage: uint64(maxSize),
+		}
+
+		for _, key := range test.keys {
+			m[key] = nil
+			ms.put(key, nil, 0)
+		}
+
+		// Put in the same elements twice to test that the map slice won't hold duplicates.
+		for _, key := range test.keys {
+			m[key] = nil
+			ms.put(key, nil, 0)
+		}
+
+		if len(m) != ms.length() {
+			t.Fatalf("expected len of %d, got %d", len(m), ms.length())
+		}
+
+		for _, key := range test.keys {
+			expected, found := m[key]
+			if !found {
+				t.Fatalf("expected key %s to exist in the go map", key.String())
+			}
+
+			got, found := ms.get(key)
+			if !found {
+				t.Fatalf("expected key %s to exist in the map slice", key.String())
+			}
+
+			if !reflect.DeepEqual(got, expected) {
+				t.Fatalf("expected value of %v, got %v", expected, got)
+			}
+		}
+	}
+}
+
+// TestMapsliceConcurrency just tests that the mapslice won't result in a panic
+// on concurrent access.
+func TestMapsliceConcurrency(t *testing.T) {
+	tests := []struct {
+		keys []wire.OutPoint
+	}{
+		{
+			keys: func() []wire.OutPoint {
+				outPoints := make([]wire.OutPoint, 10000)
+				for i := uint32(0); i < uint32(len(outPoints)); i++ {
+					var buf [4]byte
+					binary.BigEndian.PutUint32(buf[:], i)
+					hash := sha256.Sum256(buf[:])
+
+					op := wire.OutPoint{Hash: hash, Index: i}
+					outPoints[i] = op
+				}
+				return outPoints
+			}(),
+		},
+	}
+
+	for _, test := range tests {
+		maxSize := calculateRoughMapSize(1000, bucketSize)
+
+		maxEntriesFirstMap := 500
+		ms1 := make(map[wire.OutPoint]*UtxoEntry, maxEntriesFirstMap)
+		ms := mapSlice{
+			maps:                []map[wire.OutPoint]*UtxoEntry{ms1},
+			maxEntries:          []int{maxEntriesFirstMap},
+			maxTotalMemoryUsage: uint64(maxSize),
+		}
+
+		var wg sync.WaitGroup
+
+		wg.Add(1)
+		go func(m *mapSlice, keys []wire.OutPoint) {
+			defer wg.Done()
+			for i := 0; i < 5000; i++ {
+				m.put(keys[i], nil, 0)
+			}
+		}(&ms, test.keys)
+
+		wg.Add(1)
+		go func(m *mapSlice, keys []wire.OutPoint) {
+			defer wg.Done()
+			for i := 5000; i < 10000; i++ {
+				m.put(keys[i], nil, 0)
+			}
+		}(&ms, test.keys)
+
+		wg.Add(1)
+		go func(m *mapSlice) {
+			defer wg.Done()
+			for i := 0; i < 10000; i++ {
+				m.size()
+			}
+		}(&ms)
+
+		wg.Add(1)
+		go func(m *mapSlice) {
+			defer wg.Done()
+			for i := 0; i < 10000; i++ {
+				m.length()
+			}
+		}(&ms)
+
+		wg.Add(1)
+		go func(m *mapSlice, keys []wire.OutPoint) {
+			defer wg.Done()
+			for i := 0; i < 10000; i++ {
+				m.get(keys[i])
+			}
+		}(&ms, test.keys)
+
+		wg.Add(1)
+		go func(m *mapSlice, keys []wire.OutPoint) {
+			defer wg.Done()
+			for i := 0; i < 5000; i++ {
+				m.delete(keys[i])
+			}
+		}(&ms, test.keys)
+
+		wg.Wait()
+	}
+}

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -540,8 +540,9 @@ func (view *UtxoViewpoint) fetchUtxosMain(db database.DB, outpoints []wire.OutPo
 	// so other code can use the presence of an entry in the store as a way
 	// to unnecessarily avoid attempting to reload it from the database.
 	return db.View(func(dbTx database.Tx) error {
+		utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
 		for i := range outpoints {
-			entry, err := dbFetchUtxoEntry(dbTx, outpoints[i])
+			entry, err := dbFetchUtxoEntry(dbTx, utxoBucket, outpoints[i])
 			if err != nil {
 				return err
 			}
@@ -691,7 +692,8 @@ func (b *BlockChain) FetchUtxoEntry(outpoint wire.OutPoint) (*UtxoEntry, error) 
 	var entry *UtxoEntry
 	err := b.db.View(func(dbTx database.Tx) error {
 		var err error
-		entry, err = dbFetchUtxoEntry(dbTx, outpoint)
+		utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
+		entry, err = dbFetchUtxoEntry(dbTx, utxoBucket, outpoint)
 		return err
 	})
 	if err != nil {

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -71,6 +71,16 @@ func (entry *UtxoEntry) isFresh() bool {
 	return entry.packedFlags&tfFresh == tfFresh
 }
 
+// memoryUsage returns the memory usage in bytes of for the utxo entry.
+// It returns 0 for a nil entry.
+func (entry *UtxoEntry) memoryUsage() uint64 {
+	if entry == nil {
+		return 0
+	}
+
+	return baseEntrySize + uint64(cap(entry.pkScript))
+}
+
 // IsCoinBase returns whether or not the output was contained in a coinbase
 // transaction.
 func (entry *UtxoEntry) IsCoinBase() bool {

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -889,7 +889,7 @@ func (b *BlockChain) checkBIP0030(node *blockNode, block *btcutil.Block, view *U
 			fetch = append(fetch, prevOut)
 		}
 	}
-	err := view.fetchUtxos(b.db, fetch)
+	err := view.fetchUtxos(b.utxoCache, fetch)
 	if err != nil {
 		return err
 	}
@@ -1080,11 +1080,11 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *btcutil.Block, vi
 	}
 
 	// Load all of the utxos referenced by the inputs for all transactions
-	// in the block don't already exist in the utxo view from the database.
+	// in the block don't already exist in the utxo view from the cache.
 	//
 	// These utxo entries are needed for verification of things such as
 	// transaction inputs, counting pay-to-script-hashes, and scripts.
-	err := view.fetchInputUtxos(b.db, block)
+	err := view.fetchInputUtxos(nil, b.utxoCache, block)
 	if err != nil {
 		return err
 	}

--- a/cmd/addblock/import.go
+++ b/cmd/addblock/import.go
@@ -287,6 +287,16 @@ func (bi *blockImporter) Import() chan *importResults {
 	// the status handler when done.
 	go func() {
 		bi.wg.Wait()
+
+		// Flush the changes made to the blockchain.
+		log.Info("Flushing blockchain caches to the disk...")
+		if err := bi.chain.FlushUtxoCache(blockchain.FlushRequired); err != nil {
+			log.Errorf("Error while flushing the blockchain state: %v", err)
+			bi.errChan <- err
+			return
+		}
+		log.Info("Done flushing blockchain caches to disk")
+
 		bi.doneChan <- true
 	}()
 

--- a/config.go
+++ b/config.go
@@ -63,6 +63,7 @@ const (
 	defaultMaxOrphanTransactions = 100
 	defaultMaxOrphanTxSize       = 100000
 	defaultSigCacheMaxSize       = 100000
+	defaultUtxoCacheMaxSizeMiB   = 250
 	sampleConfigFilename         = "sample-btcd.conf"
 	defaultTxIndex               = false
 	defaultAddrIndex             = false
@@ -171,6 +172,7 @@ type config struct {
 	TestNet3             bool          `long:"testnet" description:"Use the test network"`
 	TorIsolation         bool          `long:"torisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`
 	TrickleInterval      time.Duration `long:"trickleinterval" description:"Minimum time between attempts to send new inventory to a connected peer"`
+	UtxoCacheMaxSizeMiB  uint          `long:"utxocachemaxsize" description:"The maximum size in MiB of the UTXO cache"`
 	TxIndex              bool          `long:"txindex" description:"Maintain a full hash-based transaction index which makes all transactions available via the getrawtransaction RPC"`
 	UserAgentComments    []string      `long:"uacomment" description:"Comment to add to the user agent -- See BIP 14 for more information."`
 	Upnp                 bool          `long:"upnp" description:"Use UPnP to map our listening port outside of NAT"`
@@ -439,6 +441,7 @@ func loadConfig() (*config, []string, error) {
 		BlockPrioritySize:    mempool.DefaultBlockPrioritySize,
 		MaxOrphanTxs:         defaultMaxOrphanTransactions,
 		SigCacheMaxSize:      defaultSigCacheMaxSize,
+		UtxoCacheMaxSizeMiB:  defaultUtxoCacheMaxSizeMiB,
 		Generate:             defaultGenerate,
 		TxIndex:              defaultTxIndex,
 		AddrIndex:            defaultAddrIndex,

--- a/database/ffldb/driver_test.go
+++ b/database/ffldb/driver_test.go
@@ -340,6 +340,19 @@ func TestPrune(t *testing.T) {
 		// This should leave 3 files on disk.
 		err = db.Update(func(tx database.Tx) error {
 			deletedBlocks, err = tx.PruneBlocks(blockFileSize * 3)
+			if err != nil {
+				return err
+			}
+
+			pruned, err := tx.BeenPruned()
+			if err != nil {
+				return err
+			}
+
+			if pruned {
+				err = fmt.Errorf("The database hasn't been commited yet " +
+					"but files were already deleted")
+			}
 			return err
 		})
 		if err != nil {

--- a/database/ffldb/export.go
+++ b/database/ffldb/export.go
@@ -2,13 +2,6 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-/*
-This test file is part of the ffldb package rather than than the ffldb_test
-package so it can bridge access to the internals to properly test cases which
-are either not possible or can't reliably be tested via the public interface.
-The functions are only exported while the tests are being run.
-*/
-
 package ffldb
 
 import (
@@ -18,6 +11,8 @@ import (
 // TstRunWithMaxBlockFileSize runs the passed function with the maximum allowed
 // file size for the database set to the provided value.  The value will be set
 // back to the original value upon completion.
+//
+// Callers should only use this for testing.
 func TstRunWithMaxBlockFileSize(idb database.DB, size uint32, fn func()) {
 	ffldb := idb.(*db)
 	origSize := ffldb.store.maxBlockFileSize

--- a/netsync/blocklogger.go
+++ b/netsync/blocklogger.go
@@ -5,9 +5,11 @@
 package netsync
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
+	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btclog"
 )
@@ -41,7 +43,7 @@ func newBlockProgressLogger(progressMessage string, logger btclog.Logger) *block
 // LogBlockHeight logs a new block height as an information message to show
 // progress to the user. In order to prevent spam, it limits logging to one
 // message every 10 seconds with duration and totals included.
-func (b *blockProgressLogger) LogBlockHeight(block *btcutil.Block) {
+func (b *blockProgressLogger) LogBlockHeight(block *btcutil.Block, chain *blockchain.BlockChain) {
 	b.Lock()
 	defer b.Unlock()
 
@@ -67,9 +69,10 @@ func (b *blockProgressLogger) LogBlockHeight(block *btcutil.Block) {
 	if b.receivedLogTx == 1 {
 		txStr = "transaction"
 	}
-	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, height %d, %s)",
+	cacheSizeStr := fmt.Sprintf("~%d MiB", chain.CachedStateSize()/1024/1024)
+	b.subsystemLogger.Infof("%s %d %s in the last %s (%d %s, height %d, %s, %s cache)",
 		b.progressAction, b.receivedLogBlocks, blockStr, tDuration, b.receivedLogTx,
-		txStr, block.Height(), block.MsgBlock().Header.Timestamp)
+		txStr, block.Height(), block.MsgBlock().Header.Timestamp, cacheSizeStr)
 
 	b.receivedLogBlocks = 0
 	b.receivedLogTx = 0

--- a/server.go
+++ b/server.go
@@ -2826,15 +2826,16 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 	// Create a new block chain instance with the appropriate configuration.
 	var err error
 	s.chain, err = blockchain.New(&blockchain.Config{
-		DB:           s.db,
-		Interrupt:    interrupt,
-		ChainParams:  s.chainParams,
-		Checkpoints:  checkpoints,
-		TimeSource:   s.timeSource,
-		SigCache:     s.sigCache,
-		IndexManager: indexManager,
-		HashCache:    s.hashCache,
-		Prune:        cfg.Prune * 1024 * 1024,
+		DB:               s.db,
+		Interrupt:        interrupt,
+		ChainParams:      s.chainParams,
+		Checkpoints:      checkpoints,
+		TimeSource:       s.timeSource,
+		SigCache:         s.sigCache,
+		IndexManager:     indexManager,
+		HashCache:        s.hashCache,
+		Prune:            cfg.Prune * 1024 * 1024,
+		UtxoCacheMaxSize: uint64(cfg.UtxoCacheMaxSizeMiB) * 1024 * 1024,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Updated the PR and is now very different from #1373.

Main differences are:

## No utxoviewpoint middleman during headers-first sync

In #1373, the view is still used as a middleman. The flow for doing block validation would be:
```
1. Make a new UtxoViewPoint.
2. Load the relevant inputs into the UtxoViewPoint from the cache.
3. Connect transactions in the UtxoViewPoint
4. Apply the connections to the cache from the UtxoViewPoint
5. Flush the cache to the database when needed
```
The problems with these approach were:
(2) is extremely expensive as there a lot of memory allocated by creating a whole new set of key/value pairs of the existing UTXOs.
(4) introduces a new code path from [view -> cache] and in turn introduces a whole new set of bugs.

The new code is different where the flow during headers-first (blocks up until the checkpoint) is:
```
1. Connect transactions in the cache
2. Flush the cache to the database when needed
```
This flow is much simpler and faster than the previous code.

For when the node is not in headers-first mode:
```
1. Make a new UtxoViewPoint
2. Load the relevant inputs into the UtxoViewPoint from the cache.
3. CheckConnectBlock with the UtxoViewPoint
4. Connect transactions in the cache
5. Flush the cache to the database when needed
```
This flow still has the overhead of (2) but no longer has the new bugs introduced by applying the transaction connections from [view -> cache]. Instead, the view is only used as a temporary mutable map **just for checkConnectBlock** and the txs are connected in cache just like in headers-first mode.

## No use of the cache during reorganizations

During reorganizations, a whole new possible bug was introduced where if the node is unexpectedly shutdown, the disconnected txs may only have been updated in the cache and not in the database. The new code forces a flush *before* the reorganization happens and keeps the same code as before, eliminating the new case of bugs introduced in #1373.

This allowed the removal of `TestUtxoCache_Reorg` and all the associated (and duplicated) code.

## No more utxoStateConsistency struct

It was enough to just save the block hash and not the single byte indicating if the cache is consistent or not. All the related code was removed.

## Map slice instead of a singular map

The singular map doubles in size when the map gets full. For bigger maps, this may result in us going over the promised memory limit. The mapslice allows us to allocate multiple maps with differing sizes, allowing acute control of the memory allocated memory.

Another solution to this would be to just force the user to only allow fixed amounts of memory for the utxo cache (1GB, 2GB, 4GB, 8GB, etc). This would get rid of the code in `sizehelper.go` and mapslice related code in `utxocache.go` but wouldn't allow the user flexibility. I'm ok with either route. This would get rid of 491 lines of code from being added.

## Known issue

During a flush, there's a large allocation of memory due to the fact that `database/ffldb` will hold onto every single bucket write to guarantee atomicity. It'll usually result in 2x the memory from what the cache is using. If the cache is using up 2GB, ffldb will allocate 2GB as well, resulting in 4GB of memory being taken up by btcd. I don't think there's any easy way around this other than making a different code path for utxo cache flushes.