### PR TITLE
Export MakeScritpNum, AsSmallInt, and IsSmallInt

### DIFF
--- a/txscript/opcode.go
+++ b/txscript/opcode.go
@@ -1073,7 +1073,7 @@ func opcodeCheckLockTimeVerify(op *opcode, data []byte, vm *Engine) error {
 	if err != nil {
 		return err
 	}
-	lockTime, err := makeScriptNum(so, vm.dstack.verifyMinimalData, 5)
+	lockTime, err := MakeScriptNum(so, vm.dstack.verifyMinimalData, 5)
 	if err != nil {
 		return err
 	}
@@ -1147,7 +1147,7 @@ func opcodeCheckSequenceVerify(op *opcode, data []byte, vm *Engine) error {
 	if err != nil {
 		return err
 	}
-	stackSequence, err := makeScriptNum(so, vm.dstack.verifyMinimalData, 5)
+	stackSequence, err := MakeScriptNum(so, vm.dstack.verifyMinimalData, 5)
 	if err != nil {
 		return err
 	}

--- a/txscript/script.go
+++ b/txscript/script.go
@@ -40,13 +40,13 @@ const (
 	MaxScriptElementSize  = 520 // Max bytes pushable to the stack.
 )
 
-// isSmallInt returns whether or not the opcode is considered a small integer,
+// IsSmallInt returns whether or not the opcode is considered a small integer,
 // which is an OP_0, or OP_1 through OP_16.
 //
 // NOTE: This function is only valid for version 0 opcodes.  Since the function
 // does not accept a script version, the results are undefined for other script
 // versions.
-func isSmallInt(op byte) bool {
+func IsSmallInt(op byte) bool {
 	return op == OP_0 || (op >= OP_1 && op <= OP_16)
 }
 
@@ -294,9 +294,9 @@ func removeOpcodeByData(script []byte, dataToRemove []byte) []byte {
 	return result
 }
 
-// asSmallInt returns the passed opcode, which must be true according to
-// isSmallInt(), as an integer.
-func asSmallInt(op byte) int {
+// AsSmallInt returns the passed opcode, which must be true according to
+// IsSmallInt(), as an integer.
+func AsSmallInt(op byte) int {
 	if op == OP_0 {
 		return 0
 	}
@@ -342,7 +342,7 @@ func countSigOpsV0(script []byte, precise bool) int {
 			// operations in new script versions should move to
 			// aggregated schemes such as Schnorr instead.
 			if precise && prevOp >= OP_1 && prevOp <= OP_16 {
-				numSigOps += asSmallInt(prevOp)
+				numSigOps += AsSmallInt(prevOp)
 			} else {
 				numSigOps += MaxPubKeysPerMultiSig
 			}

--- a/txscript/scriptnum.go
+++ b/txscript/scriptnum.go
@@ -51,7 +51,7 @@ const (
 // method to get the serialized representation (including values that overflow).
 //
 // Then, whenever data is interpreted as an integer, it is converted to this
-// type by using the makeScriptNum function which will return an error if the
+// type by using the MakeScriptNum function which will return an error if the
 // number is out of range or not minimally encoded depending on parameters.
 // Since all numeric opcodes involve pulling data from the stack and
 // interpreting it as an integer, it provides the required behavior.
@@ -151,7 +151,7 @@ func (n scriptNum) Bytes() []byte {
 // provide this behavior.
 //
 // In practice, for most opcodes, the number should never be out of range since
-// it will have been created with makeScriptNum using the defaultScriptLen
+// it will have been created with MakeScriptNum using the defaultScriptLen
 // value, which rejects them.  In case something in the future ends up calling
 // this function against the result of some arithmetic, which IS allowed to be
 // out of range before being reinterpreted as an integer, this will provide the
@@ -168,7 +168,7 @@ func (n scriptNum) Int32() int32 {
 	return int32(n)
 }
 
-// makeScriptNum interprets the passed serialized bytes as an encoded integer
+// MakeScriptNum interprets the passed serialized bytes as an encoded integer
 // and returns the result as a script number.
 //
 // Since the consensus rules dictate that serialized bytes interpreted as ints
@@ -194,7 +194,7 @@ func (n scriptNum) Int32() int32 {
 // overflows.
 //
 // See the Bytes function documentation for example encodings.
-func makeScriptNum(v []byte, requireMinimal bool, scriptNumLen int) (scriptNum, error) {
+func MakeScriptNum(v []byte, requireMinimal bool, scriptNumLen int) (scriptNum, error) {
 	// Interpreting data requires that it is not larger than
 	// the the passed scriptNumLen value.
 	if len(v) > scriptNumLen {

--- a/txscript/scriptnum_test.go
+++ b/txscript/scriptnum_test.go
@@ -195,15 +195,15 @@ func TestMakeScriptNum(t *testing.T) {
 	for _, test := range tests {
 		// Ensure the error code is of the expected type and the error
 		// code matches the value specified in the test instance.
-		gotNum, err := makeScriptNum(test.serialized, test.minimalEncoding,
+		gotNum, err := MakeScriptNum(test.serialized, test.minimalEncoding,
 			test.numLen)
 		if e := tstCheckScriptError(err, test.err); e != nil {
-			t.Errorf("makeScriptNum(%#x): %v", test.serialized, e)
+			t.Errorf("MakeScriptNum(%#x): %v", test.serialized, e)
 			continue
 		}
 
 		if gotNum != test.num {
-			t.Errorf("makeScriptNum(%#x): did not get expected "+
+			t.Errorf("MakeScriptNum(%#x): did not get expected "+
 				"number - got %d, want %d", test.serialized,
 				gotNum, test.num)
 			continue

--- a/txscript/stack.go
+++ b/txscript/stack.go
@@ -86,7 +86,7 @@ func (s *stack) PopInt() (scriptNum, error) {
 		return 0, err
 	}
 
-	return makeScriptNum(so, s.verifyMinimalData, maxScriptNumLen)
+	return MakeScriptNum(so, s.verifyMinimalData, maxScriptNumLen)
 }
 
 // PopBool pops the value off the top of the stack, converts it into a bool, and
@@ -123,7 +123,7 @@ func (s *stack) PeekInt(idx int32) (scriptNum, error) {
 		return 0, err
 	}
 
-	return makeScriptNum(so, s.verifyMinimalData, maxScriptNumLen)
+	return MakeScriptNum(so, s.verifyMinimalData, maxScriptNumLen)
 }
 
 // PeekBool returns the Nth item on the stack as a bool without removing it.

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -238,10 +238,10 @@ func extractMultisigScriptDetails(scriptVersion uint16, script []byte, extractPu
 	// The first opcode must be a small integer specifying the number of
 	// signatures required.
 	tokenizer := MakeScriptTokenizer(scriptVersion, script)
-	if !tokenizer.Next() || !isSmallInt(tokenizer.Opcode()) {
+	if !tokenizer.Next() || !IsSmallInt(tokenizer.Opcode()) {
 		return multiSigDetails{}
 	}
-	requiredSigs := asSmallInt(tokenizer.Opcode())
+	requiredSigs := AsSmallInt(tokenizer.Opcode())
 
 	// The next series of opcodes must either push public keys or be a small
 	// integer specifying the number of public keys.
@@ -251,7 +251,7 @@ func extractMultisigScriptDetails(scriptVersion uint16, script []byte, extractPu
 		pubKeys = make([][]byte, 0, MaxPubKeysPerMultiSig)
 	}
 	for tokenizer.Next() {
-		if isSmallInt(tokenizer.Opcode()) {
+		if IsSmallInt(tokenizer.Opcode()) {
 			break
 		}
 
@@ -271,7 +271,7 @@ func extractMultisigScriptDetails(scriptVersion uint16, script []byte, extractPu
 	// The next opcode must be a small integer specifying the number of public
 	// keys required.
 	op := tokenizer.Opcode()
-	if !isSmallInt(op) || asSmallInt(op) != numPubKeys {
+	if !IsSmallInt(op) || AsSmallInt(op) != numPubKeys {
 		return multiSigDetails{}
 	}
 
@@ -422,11 +422,11 @@ func extractWitnessProgramInfo(script []byte) (int, []byte, bool) {
 
 	// The first opcode must be a small int.
 	if !tokenizer.Next() ||
-		!isSmallInt(tokenizer.Opcode()) {
+		!IsSmallInt(tokenizer.Opcode()) {
 
 		return 0, nil, false
 	}
-	version := asSmallInt(tokenizer.Opcode())
+	version := AsSmallInt(tokenizer.Opcode())
 
 	// The second opcode must be a canonical data push, the length of the
 	// data push is bounded to 40 by the initial check on overall script
@@ -520,7 +520,7 @@ func isNullDataScript(scriptVersion uint16, script []byte) bool {
 	// OP_RETURN followed by data push up to MaxDataCarrierSize bytes.
 	tokenizer := MakeScriptTokenizer(scriptVersion, script[1:])
 	return tokenizer.Next() && tokenizer.Done() &&
-		(isSmallInt(tokenizer.Opcode()) || tokenizer.Opcode() <= OP_PUSHDATA4) &&
+		(IsSmallInt(tokenizer.Opcode()) || tokenizer.Opcode() <= OP_PUSHDATA4) &&
 		len(tokenizer.Data()) <= MaxDataCarrierSize
 }
 
@@ -627,7 +627,7 @@ func expectedInputs(script []byte, class ScriptClass) int {
 		// the original bitcoind bug where OP_CHECKMULTISIG pops an
 		// additional item from the stack, add an extra expected input
 		// for the extra push that is required to compensate.
-		return asSmallInt(script[0]) + 1
+		return AsSmallInt(script[0]) + 1
 
 	case NullDataTy:
 		fallthrough
@@ -1119,14 +1119,14 @@ func ExtractAtomicSwapDataPushes(version uint16, pkScript []byte) (*AtomicSwapDa
 		if tplEntry.expectCanonicalInt {
 			switch {
 			case data != nil:
-				val, err := makeScriptNum(data, true, tplEntry.maxIntBytes)
+				val, err := MakeScriptNum(data, true, tplEntry.maxIntBytes)
 				if err != nil {
 					return nil, err
 				}
 				tplEntry.extractedInt = int64(val)
 
-			case isSmallInt(op):
-				tplEntry.extractedInt = int64(asSmallInt(op))
+			case IsSmallInt(op):
+				tplEntry.extractedInt = int64(AsSmallInt(op))
 
 			// Not an atomic swap script if the opcode does not push an int.
 			default:


### PR DESCRIPTION
I would like to import these functions to use in https://github.com/decred/dcrdex/pull/2196. The exact same functions are exported in dcrd, but I'd rather import from here on the off chance that something changes.

Thanks!