### PR TITLE
multi: modify getblockverbose result.

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -91,6 +91,28 @@ type GetBlockVerboseResult struct {
 	NextHash      string        `json:"nextblockhash,omitempty"`
 }
 
+// GetBlockVerboseResultV2 models the data from the getblock command when the
+// verbose flag is set to 2.
+type GetBlockVerboseResultV2 struct {
+	Hash          string          `json:"hash"`
+	Confirmations int64           `json:"confirmations"`
+	StrippedSize  int32           `json:"strippedsize"`
+	Size          int32           `json:"size"`
+	Weight        int32           `json:"weight"`
+	Height        int64           `json:"height"`
+	Version       int32           `json:"version"`
+	VersionHex    string          `json:"versionHex"`
+	MerkleRoot    string          `json:"merkleroot"`
+	Tx            []string        `json:"tx,omitempty"`
+	RawTx         []TxRawResultV2 `json:"rawtx,omitempty"` // Note: this field is always empty when verbose != 2.
+	Time          int64           `json:"time"`
+	Nonce         uint32          `json:"nonce"`
+	Bits          string          `json:"bits"`
+	Difficulty    float64         `json:"difficulty"`
+	PreviousHash  string          `json:"previousblockhash"`
+	NextHash      string          `json:"nextblockhash,omitempty"`
+}
+
 // GetBlockVerboseTxResult models the data from the getblock command when the
 // verbose flag is set to 2.  When the verbose flag is set to 0, getblock returns a
 // hex-encoded string. When the verbose flag is set to 1, getblock returns an object
@@ -115,6 +137,32 @@ type GetBlockVerboseTxResult struct {
 	Difficulty    float64       `json:"difficulty"`
 	PreviousHash  string        `json:"previousblockhash"`
 	NextHash      string        `json:"nextblockhash,omitempty"`
+}
+
+// GetBlockVerboseTxResultV2 models the data from the getblock command when the
+// verbose flag is set to 2.  When the verbose flag is set to 0, getblock returns a
+// hex-encoded string. When the verbose flag is set to 1, getblock returns an object
+// whose tx field is an array of transaction hashes. When the verbose flag is set to 2,
+// getblock returns an object whose tx field is an array of raw transactions.
+// Use GetBlockVerboseResult to unmarshal data received from passing verbose=1 to getblock.
+type GetBlockVerboseTxResultV2 struct {
+	Hash          string          `json:"hash"`
+	Confirmations int64           `json:"confirmations"`
+	StrippedSize  int32           `json:"strippedsize"`
+	Size          int32           `json:"size"`
+	Weight        int32           `json:"weight"`
+	Height        int64           `json:"height"`
+	Version       int32           `json:"version"`
+	VersionHex    string          `json:"versionHex"`
+	MerkleRoot    string          `json:"merkleroot"`
+	Tx            []TxRawResultV2 `json:"tx,omitempty"`
+	RawTx         []TxRawResultV2 `json:"rawtx,omitempty"` // Deprecated: removed in Bitcoin Core
+	Time          int64           `json:"time"`
+	Nonce         uint32          `json:"nonce"`
+	Bits          string          `json:"bits"`
+	Difficulty    float64         `json:"difficulty"`
+	PreviousHash  string          `json:"previousblockhash"`
+	NextHash      string          `json:"nextblockhash,omitempty"`
 }
 
 // GetChainTxStatsResult models the data from the getchaintxstats command.
@@ -723,6 +771,24 @@ type TxRawResult struct {
 	Confirmations uint64 `json:"confirmations,omitempty"`
 	Time          int64  `json:"time,omitempty"`
 	Blocktime     int64  `json:"blocktime,omitempty"`
+}
+
+// TxRawResultV2 models the data from the getrawtransaction command.
+type TxRawResultV2 struct {
+	Hex           string       `json:"hex"`
+	Txid          string       `json:"txid"`
+	Hash          string       `json:"hash,omitempty"`
+	Size          int32        `json:"size,omitempty"`
+	Vsize         int32        `json:"vsize,omitempty"`
+	Weight        int32        `json:"weight,omitempty"`
+	Version       uint32       `json:"version"`
+	LockTime      uint32       `json:"locktime"`
+	Vin           []VinPrevOut `json:"vin"`
+	Vout          []Vout       `json:"vout"`
+	BlockHash     string       `json:"blockhash,omitempty"`
+	Confirmations uint64       `json:"confirmations,omitempty"`
+	Time          int64        `json:"time,omitempty"`
+	Blocktime     int64        `json:"blocktime,omitempty"`
 }
 
 // SearchRawTransactionsResult models the data from the searchrawtransaction

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -722,7 +722,7 @@ var rpcResultTypes = map[string][]interface{}{
 	"getaddednodeinfo":       {(*[]string)(nil), (*[]btcjson.GetAddedNodeInfoResult)(nil)},
 	"getbestblock":           {(*btcjson.GetBestBlockResult)(nil)},
 	"getbestblockhash":       {(*string)(nil)},
-	"getblock":               {(*string)(nil), (*btcjson.GetBlockVerboseResult)(nil)},
+	"getblock":               {(*string)(nil), (*btcjson.GetBlockVerboseResultV2)(nil)},
 	"getblockcount":          {(*int64)(nil)},
 	"getblockhash":           {(*string)(nil)},
 	"getblockheader":         {(*string)(nil), (*btcjson.GetBlockHeaderVerboseResult)(nil)},


### PR DESCRIPTION
- this modifies getblockverbose result to include the vin values in the result.

The updated vin entry is now:

```sh
   (btcjson.VinPrevOut) {
    Coinbase: (string) "",
    Txid: (string) (len=64) "7db52406f1a9d2a179ffa6a0983f047c475732ff3bc417547088a852c6710c91",
    Vout: (uint32) 0,
    ScriptSig: (*btcjson.ScriptSig)(0x1400029a280)({
     Asm: (string) (len=211) "3045022100e4ab0b75630dcdfc3edf4434718c6463e58930c3a4ae0140941013c87e0b6dc4022042a18a95c47ca28cd187e9620bcf5c88e6a39f862727013f91b0dc21c32f7cb801 027ce8daace63087441983661f50ba335cd0df187e40888f5c4034bfc6b546b49a",
     Hex: (string) (len=214) "483045022100e4ab0b75630dcdfc3edf4434718c6463e58930c3a4ae0140941013c87e0b6dc4022042a18a95c47ca28cd187e9620bcf5c88e6a39f862727013f91b0dc21c32f7cb80121027ce8daace63087441983661f50ba335cd0df187e40888f5c4034bfc6b546b49a"
    }),
    Witness: ([]string) <nil>,
    PrevOut: (*btcjson.PrevOut)(0x1400029a2a0)({
     Addresses: ([]string) (len=1 cap=4) {
      (string) (len=34) "mnh8ABCQ1NNjTr1Mm2av2AxL934MuonnV5"
     },
     Value: (float64) 0.0189815
    }),
    Sequence: (uint32) 4294967295
   }
  },
```

which now includes the value of the output.