### PR TITLE
blockchain: Use slices when fetching utxos

### DIFF
--- a/blockchain/bench_test.go
+++ b/blockchain/bench_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
 )
 
 // BenchmarkIsCoinBase performs a simple benchmark against the IsCoinBase
@@ -27,5 +28,35 @@ func BenchmarkIsCoinBaseTx(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		IsCoinBaseTx(tx)
+	}
+}
+
+func BenchmarkUtxoFetchMap(b *testing.B) {
+	block := Block100000
+	transactions := block.Transactions
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		needed := make(map[wire.OutPoint]struct{}, len(transactions))
+		for _, tx := range transactions[1:] {
+			for _, txIn := range tx.TxIn {
+				needed[txIn.PreviousOutPoint] = struct{}{}
+			}
+		}
+	}
+}
+
+func BenchmarkUtxoFetchSlices(b *testing.B) {
+	block := Block100000
+	transactions := block.Transactions
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		needed := make([]wire.OutPoint, 0, len(transactions))
+		for _, tx := range transactions[1:] {
+			for _, txIn := range tx.TxIn {
+				needed = append(needed, txIn.PreviousOutPoint)
+			}
+		}
 	}
 }

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -302,8 +302,8 @@ func CheckTransactionSanity(tx *btcutil.Tx) error {
 // target difficulty as claimed.
 //
 // The flags modify the behavior of this function as follows:
-//  - BFNoPoWCheck: The check to ensure the block hash is less than the target
-//    difficulty is not performed.
+//   - BFNoPoWCheck: The check to ensure the block hash is less than the target
+//     difficulty is not performed.
 func checkProofOfWork(header *wire.BlockHeader, powLimit *big.Int, flags BehaviorFlags) error {
 	// The target difficulty must be larger than zero.
 	target := CompactToBig(header.Bits)
@@ -637,8 +637,8 @@ func checkSerializedHeight(coinbaseTx *btcutil.Tx, wantHeight int32) error {
 // which depend on its position within the block chain.
 //
 // The flags modify the behavior of this function as follows:
-//  - BFFastAdd: All checks except those involving comparing the header against
-//    the checkpoints are not performed.
+//   - BFFastAdd: All checks except those involving comparing the header against
+//     the checkpoints are not performed.
 //
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode *blockNode, flags BehaviorFlags) error {
@@ -716,8 +716,8 @@ func (b *BlockChain) checkBlockHeaderContext(header *wire.BlockHeader, prevNode 
 // on its position within the block chain.
 //
 // The flags modify the behavior of this function as follows:
-//  - BFFastAdd: The transaction are not checked to see if they are finalized
-//    and the somewhat expensive BIP0034 validation is not performed.
+//   - BFFastAdd: The transaction are not checked to see if they are finalized
+//     and the somewhat expensive BIP0034 validation is not performed.
 //
 // The flags are also passed to checkBlockHeaderContext.  See its documentation
 // for how the flags modify its behavior.
@@ -832,22 +832,22 @@ func (b *BlockChain) checkBlockContext(block *btcutil.Block, prevNode *blockNode
 func (b *BlockChain) checkBIP0030(node *blockNode, block *btcutil.Block, view *UtxoViewpoint) error {
 	// Fetch utxos for all of the transaction ouputs in this block.
 	// Typically, there will not be any utxos for any of the outputs.
-	fetchSet := make(map[wire.OutPoint]struct{})
+	fetch := make([]wire.OutPoint, 0, len(block.Transactions()))
 	for _, tx := range block.Transactions() {
 		prevOut := wire.OutPoint{Hash: *tx.Hash()}
 		for txOutIdx := range tx.MsgTx().TxOut {
 			prevOut.Index = uint32(txOutIdx)
-			fetchSet[prevOut] = struct{}{}
+			fetch = append(fetch, prevOut)
 		}
 	}
-	err := view.fetchUtxos(b.db, fetchSet)
+	err := view.fetchUtxos(b.db, fetch)
 	if err != nil {
 		return err
 	}
 
 	// Duplicate transactions are only allowed if the previous transaction
 	// is fully spent.
-	for outpoint := range fetchSet {
+	for _, outpoint := range fetch {
 		utxo := view.LookupEntry(outpoint)
 		if utxo != nil && !utxo.IsSpent() {
 			str := fmt.Sprintf("tried to overwrite transaction %v "+


### PR DESCRIPTION
Maps have a higher overhead than slices.  As slices can be used instead of maps, we avoid the overhead of making a map.

This was one of the overheads I've noticed when profiling ibd for PR #1955 