### PR TITLE
main: Update README.md's minimum go version

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ which are both under active development.
 
 ## Requirements
 
-[Go](http://golang.org) 1.16 or newer.
+[Go](http://golang.org) 1.17 or newer.
 
 ## Installation
 

--- a/docs/code_contribution_guidelines.md
+++ b/docs/code_contribution_guidelines.md
@@ -297,7 +297,7 @@ Rejoice as you will now be listed as a [contributor](https://github.com/btcsuite
 
 ## Contribution Checklist
 
-- [&nbsp;&nbsp;] All changes are Go version 1.16 compliant
+- [&nbsp;&nbsp;] All changes are Go version 1.17 compliant
 - [&nbsp;&nbsp;] The code being submitted is commented according to the
   [Code Documentation and Commenting](#CodeDocumentation) section
 - [&nbsp;&nbsp;] For new code: Code is accompanied by tests which exercise both

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,7 +5,7 @@ details on how to install on the supported operating systems.
 
 ## Requirements
 
-[Go](http://golang.org) 1.16 or newer.
+[Go](http://golang.org) 1.17 or newer.
 
 ## GPG Verification Key
 


### PR DESCRIPTION
The readme suggests a minimum version of 1.16 but the go.mod requires go 1.17.