### PR TITLE
chainhash, wire, btcutil, main: Memory efficient txhash

### DIFF
--- a/chaincfg/chainhash/hashfuncs.go
+++ b/chaincfg/chainhash/hashfuncs.go
@@ -5,7 +5,10 @@
 
 package chainhash
 
-import "crypto/sha256"
+import (
+	"crypto/sha256"
+	"io"
+)
 
 // HashB calculates hash(b) and returns the resulting bytes.
 func HashB(b []byte) []byte {
@@ -30,4 +33,25 @@ func DoubleHashB(b []byte) []byte {
 func DoubleHashH(b []byte) Hash {
 	first := sha256.Sum256(b)
 	return Hash(sha256.Sum256(first[:]))
+}
+
+// DoubleHashRaw calculates hash(hash(w)) where w is the resulting bytes from
+// the given serialize function and returns the resulting bytes as a Hash.
+func DoubleHashRaw(serialize func(w io.Writer) error) Hash {
+	// Encode the transaction into the hash.  Ignore the error returns
+	// since the only way the encode could fail is being out of memory
+	// or due to nil pointers, both of which would cause a run-time panic.
+	h := sha256.New()
+	_ = serialize(h)
+
+	// This buf is here because Sum() will append the result to the passed
+	// in byte slice.  Pre-allocating here saves an allocation on the second
+	// hash as we can reuse it.  This allocation also does not escape to the
+	// heap, saving an allocation.
+	buf := make([]byte, 0, HashSize)
+	first := h.Sum(buf)
+	h.Reset()
+	h.Write(first)
+	res := h.Sum(buf)
+	return *(*Hash)(res)
 }

--- a/chaincfg/chainhash/hashfuncs_test.go
+++ b/chaincfg/chainhash/hashfuncs_test.go
@@ -6,6 +6,7 @@ package chainhash
 
 import (
 	"fmt"
+	"io"
 	"testing"
 )
 
@@ -129,6 +130,22 @@ func TestDoubleHashFuncs(t *testing.T) {
 		h := fmt.Sprintf("%x", hash[:])
 		if h != test.out {
 			t.Errorf("DoubleHashH(%q) = %s, want %s", test.in, h,
+				test.out)
+			continue
+		}
+	}
+
+	// Ensure the hash function which accepts a hash.Hash returns the expected
+	// result when given a hash.Hash that is of type SHA256.
+	for _, test := range tests {
+		serialize := func(w io.Writer) error {
+			w.Write([]byte(test.in))
+			return nil
+		}
+		hash := DoubleHashRaw(serialize)
+		h := fmt.Sprintf("%x", hash[:])
+		if h != test.out {
+			t.Errorf("DoubleHashRaw(%q) = %s, want %s", test.in, h,
 				test.out)
 			continue
 		}


### PR DESCRIPTION

When profiling the ibd, I noticed that `TxHash()` is allocating quite a bit of memory.

![IMG_0153](https://user-images.githubusercontent.com/37185887/236520199-474f7632-84ae-4be8-a6b1-b37fcaaa2ec3.jpeg)

I also noticed this with utreexod in the past and I resolved this by creating a new double hash function. I've benchmarked it and made is more efficient in this PR.


Benchstat for `BenchmarkTxHash()` showed a slight bit of increase in `sec/op` which is likely due to the overhead of serializing into a `hash.Hash` instead of the `bytes.Buffer` in the previous `TxHash()`. However, for real life cases, the new `TxHash()` will be faster as we're saving on the unnecessary serialization into `bytes.Buffer` as [sha256.Sum256()](https://cs.opensource.google/go/go/+/refs/tags/go1.20.4:src/crypto/sha256/sha256.go;l=252-261)will call `Write()` into the hash anyways.

The memory allocation savings is ~37% compared to the old `TxHash()`. This matters a lot because `TxHash()` gets called a lot.
```
goos: linux
goarch: amd64
pkg: github.com/btcsuite/btcd/wire
cpu: AMD Ryzen 5 3600 6-Core Processor              
          │   old.txt   │              new.txt               │
          │   sec/op    │   sec/op     vs base               │
TxHash-10   1.347µ ± 1%   1.411µ ± 2%  +4.79% (p=0.000 n=10)

          │  old.txt   │              new.txt               │
          │    B/op    │    B/op     vs base                │
TxHash-10   256.0 ± 0%   160.0 ± 0%  -37.50% (p=0.000 n=10)

          │  old.txt   │            new.txt             │
          │ allocs/op  │ allocs/op   vs base            │
TxHash-10   2.000 ± 0%   2.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

For bigger transactions, the memory savings is even greater. I performed the same test but with `multiTx` instead of `genesisCoinbaseTx`.

```diff
diff --git a/wire/bench_test.go b/wire/bench_test.go
index b9f18b83..e4cb9c88 100644
--- a/wire/bench_test.go
+++ b/wire/bench_test.go
@@ -598,7 +598,7 @@ func BenchmarkDecodeMerkleBlock(b *testing.B) {
 // transaction.
 func BenchmarkTxHash(b *testing.B) {
        for i := 0; i < b.N; i++ {
-               genesisCoinbaseTx.TxHash()
+               multiTx.TxHash()
        }
 }
```

Below is the benchstat for that test. We see less of a penalty for speed and see ~41% savings in memory allocated.

```
goos: linux
goarch: amd64
pkg: github.com/btcsuite/btcd/wire
cpu: AMD Ryzen 5 3600 6-Core Processor              
          │ old-multitx.txt │          new-multitx.txt           │
          │     sec/op      │   sec/op     vs base               │
TxHash-10       1.507µ ± 0%   1.543µ ± 2%  +2.39% (p=0.000 n=10)

          │ old-multitx.txt │          new-multitx.txt           │
          │      B/op       │    B/op     vs base                │
TxHash-10        272.0 ± 0%   160.0 ± 0%  -41.18% (p=0.000 n=10)

          │ old-multitx.txt │        new-multitx.txt         │
          │    allocs/op    │ allocs/op   vs base            │
TxHash-10        2.000 ± 0%   2.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal
```

The benchmarks for `BenchmarkDoubleHash*` show a significant speedup for `DoubleHashRaw()`. This is likely because the other hashes have to call `digest.Write()` in `sha256.Sum256()` while the `DoubleHashRaw()` function gets to skip that.

```
[I] calvin@bitcoin ~/b/g/u/g/s/g/b/b/wire (memory-efficient-txhash) [1]> go test -run=XXX -bench=BenchmarkDoubleHash -benchmem
goos: linux
goarch: amd64
pkg: github.com/btcsuite/btcd/wire
cpu: AMD Ryzen 5 3600 6-Core Processor              
BenchmarkDoubleHashB-10          1581974               758.1 ns/op            32 B/op          1 allocs/op
BenchmarkDoubleHashH-10          1600311               750.5 ns/op             0 B/op          0 allocs/op
BenchmarkDoubleHashRaw-10        3185388               370.1 ns/op            32 B/op          1 allocs/op
PASS
```

I can also post some before and after ibd profiling if requested.