### PR TITLE
blockchain+chaincfg: disable retargeting for regtest

### DIFF
--- a/blockchain/difficulty.go
+++ b/blockchain/difficulty.go
@@ -219,7 +219,15 @@ func (b *BlockChain) findPrevTestNetDifficulty(startNode *blockNode) uint32 {
 // This function differs from the exported CalcNextRequiredDifficulty in that
 // the exported version uses the current best chain as the previous block node
 // while this function accepts any block node.
-func (b *BlockChain) calcNextRequiredDifficulty(lastNode *blockNode, newBlockTime time.Time) (uint32, error) {
+func (b *BlockChain) calcNextRequiredDifficulty(lastNode *blockNode,
+	newBlockTime time.Time) (uint32, error) {
+
+	// Emulate the same behavior as Bitcoin Core that for regtest there is
+	// no difficulty retargeting.
+	if b.chainParams.PoWNoRetargeting {
+		return b.chainParams.PowLimitBits, nil
+	}
+
 	// Genesis block.
 	if lastNode == nil {
 		return b.chainParams.PowLimitBits, nil

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -183,6 +183,11 @@ type Params struct {
 	// block in compact form.
 	PowLimitBits uint32
 
+	// PoWNoRetargeting defines whether the network has difficulty
+	// retargeting enabled or not. This should only be set to true for
+	// regtest like networks.
+	PoWNoRetargeting bool
+
 	// These fields define the block heights at which the specified softfork
 	// BIP became active.
 	BIP0034Height int32
@@ -432,6 +437,7 @@ var RegressionNetParams = Params{
 	GenesisHash:              &regTestGenesisHash,
 	PowLimit:                 regressionPowLimit,
 	PowLimitBits:             0x207fffff,
+	PoWNoRetargeting:         true,
 	CoinbaseMaturity:         100,
 	BIP0034Height:            100000000, // Not active - Permit ver 1 blocks
 	BIP0065Height:            1351,      // Used by regression tests


### PR DESCRIPTION
This commit emulates the behavior of Bitcoin Core introduced in https://github.com/bitcoin/bitcoin/pull/6853 that disables retargeting of the required proof of work for regtest.

Attempts to fix https://github.com/lightninglabs/neutrino/pull/256 in a less hacky way (needs a PR in that repo as well after this one has been merged).