### PR TITLE
Convert `witnessToHex` into a method `ToHexStrings` on `TxWitness`

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -646,23 +646,6 @@ func handleDebugLevel(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) 
 	return "Done.", nil
 }
 
-// witnessToHex formats the passed witness stack as a slice of hex-encoded
-// strings to be used in a JSON response.
-func witnessToHex(witness wire.TxWitness) []string {
-	// Ensure nil is returned when there are no entries versus an empty
-	// slice so it can properly be omitted as necessary.
-	if len(witness) == 0 {
-		return nil
-	}
-
-	result := make([]string, 0, len(witness))
-	for _, wit := range witness {
-		result = append(result, hex.EncodeToString(wit))
-	}
-
-	return result
-}
-
 // createVinList returns a slice of JSON objects for the inputs of the passed
 // transaction.
 func createVinList(mtx *wire.MsgTx) []btcjson.Vin {
@@ -672,7 +655,7 @@ func createVinList(mtx *wire.MsgTx) []btcjson.Vin {
 		txIn := mtx.TxIn[0]
 		vinList[0].Coinbase = hex.EncodeToString(txIn.SignatureScript)
 		vinList[0].Sequence = txIn.Sequence
-		vinList[0].Witness = witnessToHex(txIn.Witness)
+		vinList[0].Witness = txIn.Witness.ToHexStrings()
 		return vinList
 	}
 
@@ -692,7 +675,7 @@ func createVinList(mtx *wire.MsgTx) []btcjson.Vin {
 		}
 
 		if mtx.HasWitness() {
-			vinEntry.Witness = witnessToHex(txIn.Witness)
+			vinEntry.Witness = txIn.Witness.ToHexStrings()
 		}
 	}
 
@@ -3052,7 +3035,7 @@ func createVinListPrevOut(s *rpcServer, mtx *wire.MsgTx, chainParams *chaincfg.P
 		}
 
 		if len(txIn.Witness) != 0 {
-			vinEntry.Witness = witnessToHex(txIn.Witness)
+			vinEntry.Witness = txIn.Witness.ToHexStrings()
 		}
 
 		// Add the entry to the list now if it already passed the filter

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -300,6 +301,22 @@ func (t TxWitness) SerializeSize() int {
 	}
 
 	return n
+}
+
+// ToHexStrings formats the witness stack as a slice of hex-encoded strings.
+func (t TxWitness) ToHexStrings() []string {
+	// Ensure nil is returned when there are no entries versus an empty
+	// slice so it can properly be omitted as necessary.
+	if len(t) == 0 {
+		return nil
+	}
+
+	result := make([]string, len(t))
+	for idx, wit := range t {
+		result[idx] = hex.EncodeToString(wit)
+	}
+
+	return result
 }
 
 // TxOut defines a bitcoin transaction output.


### PR DESCRIPTION
Add a method `ToHexStrings` to `TxWitness`. Remove stand alone function `witnessToHex(witness wire.TxWitness) []string`.

Motivation: `witnessToHex` is hard to access and to find.