### PR TITLE
musig2: fix early nonce gen option

### DIFF
--- a/btcec/schnorr/musig2/context.go
+++ b/btcec/schnorr/musig2/context.go
@@ -234,22 +234,21 @@ func NewContext(signingKey *btcec.PrivateKey, shouldSort bool,
 		opts.keySet = make([]*btcec.PublicKey, 0, opts.numSigners)
 		opts.keySet = append(opts.keySet, pubKey)
 
-		// If early nonce generation is specified, then we'll generate
-		// the nonce now to pass in to the session once all the callers
-		// are known.
-		if opts.earlyNonce {
-			var err error
-			ctx.sessionNonce, err = GenNonces(
-				WithPublicKey(ctx.pubKey),
-				WithNonceSecretKeyAux(signingKey),
-			)
-			if err != nil {
-				return nil, err
-			}
-		}
-
 	default:
 		return nil, ErrSignersNotSpecified
+	}
+
+	// If early nonce generation is specified, then we'll generate the
+	// nonce now to pass in to the session once all the callers are known.
+	if opts.earlyNonce {
+		var err error
+		ctx.sessionNonce, err = GenNonces(
+			WithPublicKey(ctx.pubKey),
+			WithNonceSecretKeyAux(signingKey),
+		)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return ctx, nil

--- a/btcec/schnorr/musig2/musig2_test.go
+++ b/btcec/schnorr/musig2/musig2_test.go
@@ -278,7 +278,8 @@ func TestMuSigEarlyNonce(t *testing.T) {
 		t.Fatalf("unexpected ctx error: %v", err)
 	}
 
-	numSigners := 2
+	signers := []*btcec.PublicKey{privKey1.PubKey(), privKey2.PubKey()}
+	numSigners := len(signers)
 
 	ctx1, err := NewContext(
 		privKey1, true, WithNumSigners(numSigners), WithEarlyNonceGen(),
@@ -289,20 +290,21 @@ func TestMuSigEarlyNonce(t *testing.T) {
 	pubKey1 := ctx1.PubKey()
 
 	ctx2, err := NewContext(
-		privKey2, true, WithNumSigners(numSigners), WithEarlyNonceGen(),
+		privKey2, true, WithKnownSigners(signers), WithEarlyNonceGen(),
 	)
 	if err != nil {
 		t.Fatalf("unable to make ctx: %v", err)
 	}
 	pubKey2 := ctx2.PubKey()
 
-	// At this point, the combined key shouldn't be available for both
-	// signers, since we only know of the sole signers.
+	// At this point, the combined key shouldn't be available for signer 1,
+	// but should be for signer 2, as they know about all signers.
 	if _, err := ctx1.CombinedKey(); !errors.Is(err, ErrNotEnoughSigners) {
 		t.Fatalf("unepxected error: %v", err)
 	}
-	if _, err := ctx2.CombinedKey(); !errors.Is(err, ErrNotEnoughSigners) {
-		t.Fatalf("unepxected error: %v", err)
+	_, err = ctx2.CombinedKey()
+	if err != nil {
+		t.Fatalf("unable to get combined key: %v", err)
 	}
 
 	// The early nonces _should_ be available at this point.
@@ -320,8 +322,8 @@ func TestMuSigEarlyNonce(t *testing.T) {
 		t.Fatalf("expected 1 signer, instead have: %v",
 			ctx1.NumRegisteredSigners())
 	}
-	if ctx2.NumRegisteredSigners() != 1 {
-		t.Fatalf("expected 1 signer, instead have: %v",
+	if ctx2.NumRegisteredSigners() != 2 {
+		t.Fatalf("expected 2 signers, instead have: %v",
 			ctx2.NumRegisteredSigners())
 	}
 
@@ -336,20 +338,13 @@ func TestMuSigEarlyNonce(t *testing.T) {
 		t.Fatalf("unexpected combined key error: %v", err)
 	}
 
-	// We'll now register the other signer for both parties.
+	// We'll now register the other signer for party 1.
 	done, err := ctx1.RegisterSigner(&pubKey2)
 	if err != nil {
 		t.Fatalf("unable to register signer: %v", err)
 	}
 	if !done {
 		t.Fatalf("signer 1 doesn't have all keys")
-	}
-	done, err = ctx2.RegisterSigner(&pubKey1)
-	if err != nil {
-		t.Fatalf("unable to register signer: %v", err)
-	}
-	if !done {
-		t.Fatalf("signer 2 doesn't have all keys")
 	}
 
 	// If we try to register the signer again, we should get an error.


### PR DESCRIPTION
Previously the early nonce generation option was not being respected when creating the context, with the `WithKnownSigners` option being used.