### PR TITLE
txscript:Add supported script type WitnessV1PubKeyHash

### DIFF
--- a/btcutil/address.go
+++ b/btcutil/address.go
@@ -172,6 +172,9 @@ func DecodeAddress(addr string, defaultNet *chaincfg.Params) (Address, error) {
 
 			switch len(witnessProg) {
 			case 20:
+				if witnessVer == 1 {
+					return newAddressWitnessPubKeyHashV1(hrp, witnessProg)
+				}
 				return newAddressWitnessPubKeyHash(hrp, witnessProg)
 			case 32:
 				if witnessVer == 1 {
@@ -619,6 +622,37 @@ func newAddressWitnessPubKeyHash(hrp string,
 		AddressSegWit{
 			hrp:            strings.ToLower(hrp),
 			witnessVersion: 0x00,
+			witnessProgram: witnessProg,
+		},
+	}
+
+	return addr, nil
+}
+
+// NewAddressWitnessPubKeyHashV1 returns a new AddressWitnessPubKeyHashV1.
+func NewAddressWitnessPubKeyHashV1(witnessProg []byte,
+	net *chaincfg.Params) (*AddressWitnessPubKeyHash, error) {
+
+	return newAddressWitnessPubKeyHashV1(net.Bech32HRPSegwit, witnessProg)
+}
+
+// newAddressWitnessPubKeyHashV1 is an internal helper function to create an
+// AddressWitnessPubKeyHash with a known human-readable part, rather than
+// looking it up through its parameters.
+func newAddressWitnessPubKeyHashV1(hrp string,
+	witnessProg []byte) (*AddressWitnessPubKeyHash, error) {
+
+	// Check for valid program length for witness version 1, which is 20
+	// for P2WPKH.
+	if len(witnessProg) != 20 {
+		return nil, errors.New("witness program must be 20 " +
+			"bytes for p2wpkh")
+	}
+
+	addr := &AddressWitnessPubKeyHash{
+		AddressSegWit{
+			hrp:            strings.ToLower(hrp),
+			witnessVersion: 0x01,
 			witnessProgram: witnessProg,
 		},
 	}

--- a/btcutil/address_test.go
+++ b/btcutil/address_test.go
@@ -432,6 +432,25 @@ func TestAddresses(t *testing.T) {
 			net: &chaincfg.MainNetParams,
 		},
 		{
+			name:    "segwit mainnet p2wpkh v1",
+			addr:    "BC1PCHJS0JHPGA0LRQWWN26K6A9V5HJ9PR8E522VQ8",
+			encoded: "bc1pchjs0jhpga0lrqwwn26k6a9v5hj9pr8e522vq8",
+			valid:   true,
+			result: btcutil.TstAddressWitnessPubKeyHash(
+				1,
+				[20]byte{
+					0xc5, 0xe5, 0x07, 0xca, 0xe1, 0x47, 0x5f, 0xf1, 0x81, 0xce,
+					0x9a, 0xb5, 0x6d, 0x74, 0xac, 0xa5, 0xe4, 0x50, 0x8c, 0xf9},
+				chaincfg.MainNetParams.Bech32HRPSegwit),
+			f: func() (btcutil.Address, error) {
+				pkHash := []byte{
+					0xc5, 0xe5, 0x07, 0xca, 0xe1, 0x47, 0x5f, 0xf1, 0x81, 0xce,
+					0x9a, 0xb5, 0x6d, 0x74, 0xac, 0xa5, 0xe4, 0x50, 0x8c, 0xf9}
+				return btcutil.NewAddressWitnessPubKeyHashV1(pkHash, &chaincfg.MainNetParams)
+			},
+			net: &chaincfg.MainNetParams,
+		},
+		{
 			name:    "segwit mainnet p2wsh v0",
 			addr:    "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
 			encoded: "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
@@ -827,7 +846,6 @@ func TestAddresses(t *testing.T) {
 						test.name, saddr, p)
 					return
 				}
-
 			case *btcutil.AddressWitnessScriptHash:
 				if hrp := a.Hrp(); test.net.Bech32HRPSegwit != hrp {
 					t.Errorf("%v: hrps do not match:\n%x != \n%x",

--- a/txscript/pkscript.go
+++ b/txscript/pkscript.go
@@ -102,7 +102,7 @@ func ParsePkScript(pkScript []byte) (PkScript, error) {
 // PkScript struct.
 func isSupportedScriptType(class ScriptClass) bool {
 	switch class {
-	case PubKeyHashTy, WitnessV0PubKeyHashTy, ScriptHashTy,
+	case PubKeyHashTy, WitnessV0PubKeyHashTy, WitnessV1PubKeyHashTy, ScriptHashTy,
 		WitnessV0ScriptHashTy, WitnessV1TaprootTy:
 		return true
 	default:


### PR DESCRIPTION
# support script type P2WPKH V1. 

I noticed some pk script couldn't be parsed

Example:
Tx:ba5fd9fe19d4b4b859779a98602e279c13072d17367aa6fb0bc81c2bb2e1e006

This tx's first output pk script is 5114c5e507cae1475ff181ce9ab56d74aca5e4508cf9, which means the first opcode is OP_1, and the second opcode is OP_DATA_20. That is a version 1 P2WPKH, and not be supported, so I add support script type P2WPKH V1 code. I hope this is helpful.

[BIP350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki)