### PR TITLE
rpcclient: catch shutdown signal when sending RPC requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ coverage.txt
 btcec/coverage.txt
 btcutil/coverage.txt
 btcutil/psbt/coverage.txt
+
+# vim
+*.swp

--- a/btcutil/go.sum
+++ b/btcutil/go.sum
@@ -60,6 +60,7 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -928,9 +928,13 @@ func (c *Client) sendPostRequest(jReq *jsonRequest) {
 	default:
 	}
 
-	log.Tracef("Sending command [%s] with id %d", jReq.method, jReq.id)
+	select {
+	case c.sendPostChan <- jReq:
+		log.Tracef("Sent command [%s] with id %d", jReq.method, jReq.id)
 
-	c.sendPostChan <- jReq
+	case <-c.shutdown:
+		return
+	}
 }
 
 // newFutureError returns a new future result channel that already has the

--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -761,9 +761,7 @@ out:
 // handleSendPostMessage handles performing the passed HTTP request, reading the
 // result, unmarshalling it, and delivering the unmarshalled result to the
 // provided response channel.
-func (c *Client) handleSendPostMessage(jReq *jsonRequest,
-	shutdown chan struct{}) {
-
+func (c *Client) handleSendPostMessage(jReq *jsonRequest) {
 	protocol := "http"
 	if !c.config.DisableTLS {
 		protocol = "https"
@@ -825,7 +823,7 @@ func (c *Client) handleSendPostMessage(jReq *jsonRequest,
 		select {
 		case <-time.After(backoff):
 
-		case <-shutdown:
+		case <-c.shutdown:
 			return
 		}
 	}
@@ -893,7 +891,7 @@ out:
 		// is closed.
 		select {
 		case jReq := <-c.sendPostChan:
-			c.handleSendPostMessage(jReq, c.shutdown)
+			c.handleSendPostMessage(jReq)
 
 		case <-c.shutdown:
 			break out
@@ -917,7 +915,6 @@ cleanup:
 	}
 	c.wg.Done()
 	log.Tracef("RPC client send handler done for %s", c.config.Host)
-
 }
 
 // sendPostRequest sends the passed HTTP request to the RPC server using the


### PR DESCRIPTION
This PR updates gitignore, go mod, and catches shutdown signal when sending RPC requests.