### PR TITLE
add go report and latest release status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ btcd
 [![Coverage Status](https://coveralls.io/repos/github/btcsuite/btcd/badge.svg?branch=master)](https://coveralls.io/github/btcsuite/btcd?branch=master)
 [![ISC License](https://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
 [![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://pkg.go.dev/github.com/btcsuite/btcd)
+[![Go Report Card](https://goreportcard.com/badge/github.com/btcsuite/btcd)](https://goreportcard.com/report/github.com/btcsuite/btcd)
+[![Latest Release](https://img.shields.io/github/v/release/btcsuite/btcd)](https://github.com/btcsuite/btcd/releases/latest)
 
 btcd is an alternative full node bitcoin implementation written in Go (golang).
 


### PR DESCRIPTION
## Change Description
*Safe and fast to merge PR*:  
Added the `go report` and `latest release` status badges to the readme in order to improve docs quality.  
See the outlook in my [fork](https://github.com/R3DRUN3/btcd/blob/master/README.md).
