### PR TITLE
wire: add method TxID to MsgTx

### DIFF
--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -353,6 +353,11 @@ func (msg *MsgTx) TxHash() chainhash.Hash {
 	return chainhash.DoubleHashRaw(msg.SerializeNoWitness)
 }
 
+// TxID generates the transaction ID of the transaction.
+func (msg *MsgTx) TxID() string {
+	return msg.TxHash().String()
+}
+
 // WitnessHash generates the hash of the transaction serialized according to
 // the new witness serialization defined in BIP0141 and BIP0144. The final
 // output is used within the Segregated Witness commitment of all the witnesses

--- a/wire/msgtx_test.go
+++ b/wire/msgtx_test.go
@@ -756,6 +756,34 @@ func TestTxSerializeSizeStripped(t *testing.T) {
 	}
 }
 
+// TestTxID performs tests to ensure the serialize size for various transactions
+// is accurate.
+func TestTxID(t *testing.T) {
+	// Empty tx message.
+	noTx := NewMsgTx(1)
+	noTx.Version = 1
+
+	tests := []struct {
+		in   *MsgTx // Tx to encode.
+		txid string // Expected transaction ID.
+	}{
+		// No inputs or outputs.
+		{noTx, "d21633ba23f70118185227be58a63527675641ad37967e2aa461559f577aec43"},
+
+		// Transaction with an input and an output.
+		{multiTx, "0100d15a522ff38de05c164ca0a56379a1b77dd1e4805a6534dc9b3d88290e9d"},
+
+		// Transaction with an input which includes witness data, and
+		// one output.
+		{multiWitnessTx, "0f167d1385a84d1518cfee208b653fc9163b605ccf1b75347e2850b3e2eb19f3"},
+	}
+
+	for i, test := range tests {
+		txid := test.in.TxID()
+		require.Equal(t, test.txid, txid, "test #%d", i)
+	}
+}
+
 // TestTxWitnessSize performs tests to ensure that the serialized size for
 // various types of transactions that include witness data is accurate.
 func TestTxWitnessSize(t *testing.T) {


### PR DESCRIPTION
This commit adds a method to MsgTx called TxID. This method returns the transaction ID (txid) of the subject transaction. This commit also adds a function for deriving the transaction ID from the double hash of the transaction.