### PR TITLE
refactor: set strconv.ParseFloat bitsize to 64

### DIFF
--- a/btcjson/cmdparse.go
+++ b/btcjson/cmdparse.go
@@ -451,7 +451,7 @@ func assignField(paramNum int, fieldName string, dest reflect.Value, src reflect
 
 		// String -> float of varying size.
 		case reflect.Float32, reflect.Float64:
-			srcFloat, err := strconv.ParseFloat(src.String(), 0)
+			srcFloat, err := strconv.ParseFloat(src.String(), 64)
 			if err != nil {
 				str := fmt.Sprintf("parameter #%d '%s' must "+
 					"parse to a %v", paramNum, fieldName,


### PR DESCRIPTION
`strconv.ParseFloat` will always treat `bizSize` parameter as 64 if we don't set it to 32, it's odd to set it to 0, although this won't affect the result