### PR TITLE
Update petertodd seed DNS to .net

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -287,6 +287,7 @@ var MainNetParams = Params{
 		{"seed.bitcoinstats.com", true},
 		{"seed.bitnodes.io", false},
 		{"seed.bitcoin.jonasschnelli.ch", true},
+		{"seed.btc.petertodd.net", true},
 	},
 
 	// Chain parameters
@@ -541,7 +542,7 @@ var TestNet3Params = Params{
 	DNSSeeds: []DNSSeed{
 		{"testnet-seed.bitcoin.jonasschnelli.ch", true},
 		{"testnet-seed.bitcoin.schildbach.de", false},
-		{"seed.tbtc.petertodd.org", true},
+		{"seed.tbtc.petertodd.net", true},
 		{"testnet-seed.bluematt.me", false},
 	},
 


### PR DESCRIPTION
Also, add mainnet seed.

I changed the DNS to .net due to issues with DNS blacklists. The .org domain will stay up for now. But I may have to take it down in the future.