### PR TITLE
rpctest: integration test harness fixes

### DIFF
--- a/blockchain/sizehelper.go
+++ b/blockchain/sizehelper.go
@@ -63,14 +63,32 @@ const (
 	loadFactorNum = 13
 	loadFactorDen = 2
 
-	// maxAlloc is the maximum size of an allocation. On 64-bit,
-	// it's theoretically possible to allocate 1<<heapAddrBits bytes. On
-	// 32-bit, however, this is one less than 1<<32 because the
-	// number of bytes in the address space doesn't actually fit
-	// in a uintptr.
+	// _64bit = 1 on 64-bit systems, 0 on 32-bit systems
+	_64bit = 1 << (^uintptr(0) >> 63) / 2
+
+	// PtrSize is the size of a pointer in bytes - unsafe.Sizeof(uintptr(0))
+	// but as an ideal constant. It is also the size of the machine's native
+	// word size (that is, 4 on 32-bit systems, 8 on 64-bit).
+	PtrSize = 4 << (^uintptr(0) >> 63)
+
+	// heapAddrBits is the number of bits in a heap address that's actually
+	// available for memory allocation.
 	//
-	// NOTE (kcalvinalvin): I just took the constant for a 64 bit system.
-	maxAlloc = 281474976710656
+	// NOTE (guggero): For 64-bit systems, we just assume 40 bits of address
+	// space available, as that seems to be the lowest common denominator.
+	// See heapAddrBits in runtime/malloc.go of the standard library for
+	// more details
+	heapAddrBits = 32 + (_64bit * 8)
+
+	// maxAlloc is the maximum size of an allocation on the heap.
+	//
+	// NOTE(guggero): With the somewhat simplified heapAddrBits calculation
+	// above, this will currently limit the maximum allocation size of the
+	// UTXO cache to around 300GiB on 64-bit systems. This should be more
+	// than enough for the foreseeable future, but if we ever need to
+	// increase it, we should probably use the same calculation as the
+	// standard library.
+	maxAlloc = (1 << heapAddrBits) - (1-_64bit)*1
 )
 
 var class_to_size = [_NumSizeClasses]uint16{0, 8, 16, 24, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 240, 256, 288, 320, 352, 384, 416, 448, 480, 512, 576, 640, 704, 768, 896, 1024, 1152, 1280, 1408, 1536, 1792, 2048, 2304, 2688, 3072, 3200, 3456, 4096, 4864, 5376, 6144, 6528, 6784, 6912, 8192, 9472, 9728, 10240, 10880, 12288, 13568, 14336, 16384, 18432, 19072, 20480, 21760, 24576, 27264, 28672, 32768}
@@ -175,7 +193,7 @@ func calculateMinEntries(totalBytes int, bucketSize int) int {
 // mulUintptr returns a * b and whether the multiplication overflowed.
 // On supported platforms this is an intrinsic lowered by the compiler.
 func mulUintptr(a, b uintptr) (uintptr, bool) {
-	if a|b < 1<<(4*8) || a == 0 {
+	if a|b < 1<<(4*PtrSize) || a == 0 {
 		return a * b, false
 	}
 	overflow := b > MaxUintptr/a

--- a/integration/rpctest/rpc_harness.go
+++ b/integration/rpctest/rpc_harness.go
@@ -246,10 +246,10 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 	// Start the btcd node itself. This spawns a new process which will be
 	// managed
 	if err := h.node.start(); err != nil {
-		return err
+		return fmt.Errorf("error starting node: %w", err)
 	}
 	if err := h.connectRPCClient(); err != nil {
-		return err
+		return fmt.Errorf("error connecting RPC client: %w", err)
 	}
 
 	h.wallet.Start()
@@ -370,7 +370,9 @@ func (h *Harness) connectRPCClient() error {
 	}
 
 	if client == nil || batchClient == nil {
-		return fmt.Errorf("connection timeout")
+		return fmt.Errorf("connection timeout, tried %d times with "+
+			"timeout %v, last err: %w", h.MaxConnRetries,
+			h.ConnectionRetryTimeout, err)
 	}
 
 	h.Client = client

--- a/integration/rpctest/rpc_harness.go
+++ b/integration/rpctest/rpc_harness.go
@@ -561,6 +561,111 @@ func NextAvailablePort() int {
 	panic("no ports available for listening")
 }
 
+// NextAvailablePortForProcess returns the first port that is available for
+// listening by a new node, using a lock file to make sure concurrent access for
+// parallel tasks within the same process don't re-use the same port. It panics
+// if no port is found and the maximum available TCP port is reached.
+func NextAvailablePortForProcess(pid int) int {
+	lockFile := filepath.Join(
+		os.TempDir(), fmt.Sprintf("rpctest-port-pid-%d.lock", pid),
+	)
+	timeout := time.After(time.Second)
+	
+	var (
+		lockFileHandle *os.File
+		err error
+	)
+	for {
+		// Attempt to acquire the lock file. If it already exists, wait
+		// for a bit and retry.
+		lockFileHandle, err = os.OpenFile(
+			lockFile, os.O_CREATE|os.O_EXCL, 0600,
+		)
+		if err == nil {
+			// Lock acquired.
+			break
+		}
+
+		// Wait for a bit and retry.
+		select {
+		case <-timeout:
+			panic("timeout waiting for lock file")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+
+	// Release the lock file when we're done.
+	defer func() {
+		// Always close file first, Windows won't allow us to remove it
+		// otherwise.
+		_ = lockFileHandle.Close()
+		err := os.Remove(lockFile)
+		if err != nil {
+			panic(fmt.Errorf("couldn't remove lock file: %w", err))
+		}
+	}()
+
+	portFile := filepath.Join(
+		os.TempDir(), fmt.Sprintf("rpctest-port-pid-%d", pid),
+	)
+	port, err := os.ReadFile(portFile)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			panic(fmt.Errorf("error reading port file: %w", err))
+		}
+		port = []byte(strconv.Itoa(int(defaultNodePort)))
+	}
+
+	lastPort, err := strconv.Atoi(string(port))
+	if err != nil {
+		panic(fmt.Errorf("error parsing port: %w", err))
+	}
+
+	// We take the next one.
+	lastPort++
+	for lastPort < 65535 {
+		// If there are no errors while attempting to listen on this
+		// port, close the socket and return it as available. While it
+		// could be the case that some other process picks up this port
+		// between the time the socket is closed and it's reopened in
+		// the harness node, in practice in CI servers this seems much
+		// less likely than simply some other process already being
+		// bound at the start of the tests.
+		addr := fmt.Sprintf(ListenerFormat, lastPort)
+		l, err := net.Listen("tcp4", addr)
+		if err == nil {
+			err := l.Close()
+			if err == nil {
+				err := os.WriteFile(
+					portFile,
+					[]byte(strconv.Itoa(lastPort)), 0600,
+				)
+				if err != nil {
+					panic(fmt.Errorf("error updating "+
+						"port file: %w", err))
+				}
+
+				return lastPort
+			}
+		}
+		lastPort++
+	}
+
+	// No ports available? Must be a mistake.
+	panic("no ports available for listening")
+}
+
+// GenerateProcessUniqueListenerAddresses is a function that returns two
+// listener addresses with unique ports per the given process id and should be
+// used to overwrite rpctest's default generator which is prone to use colliding
+// ports.
+func GenerateProcessUniqueListenerAddresses(pid int) (string, string) {
+	port1 := NextAvailablePortForProcess(pid)
+	port2 := NextAvailablePortForProcess(pid)
+	return fmt.Sprintf(ListenerFormat, port1),
+		fmt.Sprintf(ListenerFormat, port2)
+}
+
 // baseDir is the directory path of the temp directory for all rpctest files.
 func baseDir() (string, error) {
 	dirPath := filepath.Join(os.TempDir(), "btcd", "rpctest")

--- a/integration/rpctest/rpc_harness.go
+++ b/integration/rpctest/rpc_harness.go
@@ -6,7 +6,6 @@ package rpctest
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -152,8 +151,7 @@ func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers,
 		return nil, err
 	}
 
-	harnessID := strconv.Itoa(numTestInstances)
-	nodeTestData, err := ioutil.TempDir(testDir, "harness-"+harnessID)
+	nodeTestData, err := os.MkdirTemp(testDir, "rpc-node")
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +171,7 @@ func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers,
 	extraArgs = append(extraArgs, miningAddr)
 
 	config, err := newConfig(
-		"rpctest", certFile, keyFile, extraArgs, customExePath,
+		nodeTestData, certFile, keyFile, extraArgs, customExePath,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes two issues with the current RPC integration test framework:
 - Generated test temp directories were created using a non-mutex-protected harness ID and a deprecated way to create temp directories, both is now fixed
 - Because Go creates a sub process for each package that is tested, a package-global variable to track used TCP ports doesn't work reliably, especially if multiple packages are run in parallel. This PR adds a new way to issue unique TCP ports per process ID, which needs to be the parent process ID of each sub-process to work as expected.