### PR TITLE
blockchain: set the lastflushtime when setting the lastflushhash

### DIFF
--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -634,6 +634,10 @@ func (b *BlockChain) InitConsistentState(tip *blockNode, interrupt <-chan struct
 		// it to the tip since we checked it's consistent.
 		s.lastFlushHash = tip.hash
 
+		// Set the last flush time as now since we know the state is consistent
+		// at this time.
+		s.lastFlushTime = time.Now()
+
 		return nil
 	}
 


### PR DESCRIPTION
On startup when the headers-first mode is off, when receiving the first block, the periodic flush will trigger.  The lastflushtime wasn't set which resulted in the flush being triggered on the first block on restart.

Addresses #2087 