### PR TITLE
chore: remove trailing continue

### DIFF
--- a/mining/mining.go
+++ b/mining/mining.go
@@ -563,9 +563,6 @@ mempoolLoop:
 				}
 				prioItem.dependsOn[*originHash] = struct{}{}
 
-				// Skip the check below. We already know the
-				// referenced transaction is available.
-				continue
 			}
 		}
 


### PR DESCRIPTION
No need for `continue` since it's already at the end.