### PR TITLE
rpcclient: make sure batch requests are GCed

### DIFF
--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -45,6 +45,20 @@ type MsgBlock struct {
 	Transactions []*MsgTx
 }
 
+// Copy creates a deep copy of MsgBlock.
+func (msg *MsgBlock) Copy() *MsgBlock {
+	block := &MsgBlock{
+		Header:       msg.Header,
+		Transactions: make([]*MsgTx, len(msg.Transactions)),
+	}
+
+	for i, tx := range msg.Transactions {
+		block.Transactions[i] = tx.Copy()
+	}
+
+	return block
+}
+
 // AddTransaction adds a transaction to the message.
 func (msg *MsgBlock) AddTransaction(tx *MsgTx) error {
 	msg.Transactions = append(msg.Transactions, tx)


### PR DESCRIPTION
This commit makes sure the batch requests are always GCed before sending back the responses for them. In particular,
- `removeRequest` didn't remove the item from `batchList`, which is now fixed.
- `Send` didn't remove the request from `requestMap`, which is now fixed by using `removeRequest`.

In addition, a `Copy` method is added to `MsgBlock` to fix another heap escape found in lnd's `GetBlock`.