### PR TITLE
refactor: add `make help` to display the usage for project Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,10 @@ define print
 	echo $(GREEN)$1$(NC)
 endef
 
+#? default: Run `make build`
 default: build
 
+#? all: Run `make build` and `make check`
 all: build check
 
 # ============
@@ -55,6 +57,7 @@ $(GOACC_BIN):
 	@$(call print, "Fetching go-acc")
 	$(DEPGET) $(GOACC_PKG)@$(GOACC_COMMIT)
 
+#? goimports: Install goimports
 goimports:
 	@$(call print, "Installing goimports.")
 	$(DEPGET) $(GOIMPORTS_PKG)
@@ -63,6 +66,7 @@ goimports:
 # INSTALLATION
 # ============
 
+#? build: Build all binaries, place them in project directory
 build:
 	@$(call print, "Building all binaries")
 	$(GOBUILD) $(PKG)
@@ -71,6 +75,7 @@ build:
 	$(GOBUILD) $(PKG)/cmd/findcheckpoint
 	$(GOBUILD) $(PKG)/cmd/addblock
 
+#? install: Install all binaries, place them in $GOPATH/bin
 install:
 	@$(call print, "Installing all binaries")
 	$(GOINSTALL) $(PKG)
@@ -79,6 +84,7 @@ install:
 	$(GOINSTALL) $(PKG)/cmd/findcheckpoint
 	$(GOINSTALL) $(PKG)/cmd/addblock
 
+#? release-install: Install btcd and btcctl release binaries, place them in $GOPATH/bin
 release-install:
 	@$(call print, "Installing btcd and btcctl release binaries")
 	env CGO_ENABLED=0 $(GOINSTALL) -trimpath -ldflags="-s -w -buildid=" $(PKG)
@@ -88,8 +94,10 @@ release-install:
 # TESTING
 # =======
 
+#? check: Run `make unit`
 check: unit
 
+#? unit: Run unit tests
 unit:
 	@$(call print, "Running unit tests.")
 	$(GOTEST_DEV) ./... -test.timeout=20m
@@ -97,6 +105,7 @@ unit:
 	cd btcutil; $(GOTEST_DEV) ./... -test.timeout=20m
 	cd btcutil/psbt; $(GOTEST_DEV) ./... -test.timeout=20m
 
+#? unit-cover: Run unit coverage tests
 unit-cover: $(GOACC_BIN)
 	@$(call print, "Running unit coverage tests.")
 	$(GOACC_BIN) ./...
@@ -109,6 +118,7 @@ unit-cover: $(GOACC_BIN)
 
 	cd btcutil/psbt; $(GOACC_BIN) ./...
 
+#? unit-race: Run unit race tests
 unit-race:
 	@$(call print, "Running unit race tests.")
 	env CGO_ENABLED=1 GORACE="history_size=7 halt_on_errors=1" $(GOTEST) -race -test.timeout=20m ./...
@@ -120,20 +130,24 @@ unit-race:
 # UTILITIES
 # =========
 
+#? fmt: Fix imports and formatting source
 fmt: goimports
 	@$(call print, "Fixing imports.")
 	goimports -w $(GOFILES_NOVENDOR)
 	@$(call print, "Formatting source.")
 	gofmt -l -w -s $(GOFILES_NOVENDOR)
 
+#? lint: Lint source
 lint: $(LINT_BIN)
 	@$(call print, "Linting source.")
 	$(LINT)
 
+#? clean: Clean source
 clean:
 	@$(call print, "Cleaning source.$(NC)")
 	$(RM) coverage.txt btcec/coverage.txt btcutil/coverage.txt btcutil/psbt/coverage.txt
 	
+#? tidy-module: Run 'go mod tidy' for all modules
 tidy-module:
 	echo "Running 'go mod tidy' for all modules"
 	scripts/tidy_modules.sh
@@ -148,3 +162,10 @@ tidy-module:
 	fmt \
 	lint \
 	clean
+
+#? help: Get more info on make commands
+help: Makefile
+	@echo " Choose a command run in btcd:"
+	@sed -n 's/^#?//p' $< | column -t -s ':' |  sort | sed -e 's/^/ /'
+
+.PHONY: help


### PR DESCRIPTION
# Description

This pr added a new `make help` function for displaying which commonly used commands that the Makefile supported. This is useful when a new developer goes to find a helpful tool for testing or building etc.

![image](https://github.com/btcsuite/btcd/assets/25278203/ed2a7acd-e997-4448-bea2-8878b84fcd2a)
