### PR TITLE
feat: Expose newFutureError for developer friendliness

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -984,6 +984,11 @@ func newFutureError(err error) chan *Response {
 	return responseChan
 }
 
+// Expose newFutureError for developer usage when creating custom commands.
+func NewFutureError(err error) chan *Response {
+	return newFutureError(err)
+}
+
 // ReceiveFuture receives from the passed futureResult channel to extract a
 // reply or any errors.  The examined errors include an error in the
 // futureResult and the error in the reply from the server.  This will block


### PR DESCRIPTION
Becuase the `rpcclient.Response` struct's fields are not exported we can not mirror the functionality of `newFutureError` ourselves. This is an issue especially when creating custom commands because we are forced to panic any errors in the `*Async` function. For example:
```go
func SignRawTransactionWithKeyAsync(client *rpcclient.Client, tx *wire.MsgTx, privKeysWIF []string) FutureSignRawTransactionWithKeyResult {
	txHex := ""
	if tx != nil {
		buf := bytes.NewBuffer(make([]byte, 0, tx.SerializeSize()))
		if err := tx.Serialize(buf); err != nil {
			responseChan := make(chan *rpcclient.Response, 1)
			responseChan <- &rpcclient.Response{result: nil, err: err} // Can not compile because 'unknown field err in struct literal of type rpcclient.Response'
			return responseChan
		}
		txHex = hex.EncodeToString(buf.Bytes())
	}
	cmd := NewSignRawTransactionKeyCmd(txHex, &privKeysWIF)
	return client.SendCmd(cmd)
}
```