### PR TITLE
blockchain: fix inconsistent utxocache and database on reorg

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -960,7 +960,7 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 
 		// Load all of the utxos referenced by the block that aren't
 		// already in the view.
-		err = view.fetchInputUtxos(nil, b.utxoCache, block)
+		err = view.fetchInputUtxos(b.utxoCache, block)
 		if err != nil {
 			return err
 		}
@@ -1027,7 +1027,7 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 		// checkConnectBlock gets skipped, we still need to update the UTXO
 		// view.
 		if b.index.NodeStatus(n).KnownValid() {
-			err = view.fetchInputUtxos(nil, b.utxoCache, block)
+			err = view.fetchInputUtxos(b.utxoCache, block)
 			if err != nil {
 				return err
 			}
@@ -1089,7 +1089,7 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 
 		// Load all of the utxos referenced by the block that aren't
 		// already in the view.
-		err := view.fetchInputUtxos(nil, b.utxoCache, block)
+		err := view.fetchInputUtxos(b.utxoCache, block)
 		if err != nil {
 			return err
 		}

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -666,15 +666,11 @@ func (view *UtxoViewpoint) findInputsToFetch(block *btcutil.Block) []wire.OutPoi
 
 // fetchInputUtxos loads the unspent transaction outputs for the inputs
 // referenced by the transactions in the given block into the view from the
-// database or the cache as needed.  In particular, referenced entries that
-// are earlier in the block are added to the view and entries that are already
-// in the view are not modified.
-func (view *UtxoViewpoint) fetchInputUtxos(db database.DB, cache *utxoCache, block *btcutil.Block) error {
-	if cache != nil {
-		return view.fetchUtxosFromCache(cache, view.findInputsToFetch(block))
-	}
-	// Request the input utxos from the cache.
-	return view.fetchUtxosMain(db, view.findInputsToFetch(block))
+// cache as needed.  In particular, referenced entries that are earlier in
+// the block are added to the view and entries that are already in the view
+// are not modified.
+func (view *UtxoViewpoint) fetchInputUtxos(cache *utxoCache, block *btcutil.Block) error {
+	return view.fetchUtxosFromCache(cache, view.findInputsToFetch(block))
 }
 
 // NewUtxoViewpoint returns a new empty unspent transaction output view.

--- a/blockchain/utxoviewpoint.go
+++ b/blockchain/utxoviewpoint.go
@@ -519,41 +519,6 @@ func (view *UtxoViewpoint) commit() {
 	}
 }
 
-// fetchUtxosMain fetches unspent transaction output data about the provided
-// set of outpoints from the point of view of the end of the main chain at the
-// time of the call.
-//
-// Upon completion of this function, the view will contain an entry for each
-// requested outpoint.  Spent outputs, or those which otherwise don't exist,
-// will result in a nil entry in the view.
-func (view *UtxoViewpoint) fetchUtxosMain(db database.DB, outpoints []wire.OutPoint) error {
-	// Nothing to do if there are no requested outputs.
-	if len(outpoints) == 0 {
-		return nil
-	}
-
-	// Load the requested set of unspent transaction outputs from the point
-	// of view of the end of the main chain.
-	//
-	// NOTE: Missing entries are not considered an error here and instead
-	// will result in nil entries in the view.  This is intentionally done
-	// so other code can use the presence of an entry in the store as a way
-	// to unnecessarily avoid attempting to reload it from the database.
-	return db.View(func(dbTx database.Tx) error {
-		utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
-		for i := range outpoints {
-			entry, err := dbFetchUtxoEntry(dbTx, utxoBucket, outpoints[i])
-			if err != nil {
-				return err
-			}
-
-			view.entries[outpoints[i]] = entry
-		}
-
-		return nil
-	})
-}
-
 // fetchUtxosFromCache fetches unspent transaction output data about the provided
 // set of outpoints from the point of view of the end of the main chain at the
 // time of the call.  It attempts to fetch them from the cache and whatever entries

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -1084,7 +1084,7 @@ func (b *BlockChain) checkConnectBlock(node *blockNode, block *btcutil.Block, vi
 	//
 	// These utxo entries are needed for verification of things such as
 	// transaction inputs, counting pay-to-script-hashes, and scripts.
-	err := view.fetchInputUtxos(nil, b.utxoCache, block)
+	err := view.fetchInputUtxos(b.utxoCache, block)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
During reorgs, the assumption being made was that the utxocache is ignored and we're directly accessing the database for utxo set modifications.

However, after a block disconnect, the `BlockChain.chainLock`, the lock that prevents modifications to the utxo set, was being freed for the callback functions for the blockchain notifications.
https://github.com/btcsuite/btcd/blob/13152b35e191385a874294a9dbc902e48b1d71b0/blockchain/chain.go#L853-L858

If a caller calls either of the two methods below, the utxocache could be loaded with utxos that are fetched from the database:

https://github.com/btcsuite/btcd/blob/13152b35e191385a874294a9dbc902e48b1d71b0/blockchain/utxoviewpoint.go#L687-L693

https://github.com/btcsuite/btcd/blob/13152b35e191385a874294a9dbc902e48b1d71b0/blockchain/utxoviewpoint.go#L722-L732

Since the UTXOs fetched here are considered unmodified and therefore wouldn't be saved in the database when the `utxoCache` is flushed at the end of a reorganization, if a caller makes a call to the above two functions during a reorg, they could be mistakenly think that a utxo exists when it was removed from the utxo set.


Example:

There's a chain like so where a utxo created in `b1001` is spent in `b1002`. Blocks `b1002` and `b1001` are being disconnected out by a longer chain.
```
b1000() -> b1001(b1000.tx[1].out[0]) -> b1002(b1001.tx[1].out[0])
```

Mempool tries to fetch `b1001.tx[1].out[0]` three times in total. `2`, `8` and `11`.
At `6` the utxo `b1001.tx[1].out[0]` get loaded up to the cache. The cache never gets reset and that utxo gets fetched at `12`. When the reorg finishes, the mempool can no longer fetch `b1001.tx[1].out[0]`

```
         database                 UTXO cache                 BlockChain                                     Mempool

1.     {b1002.tx[0].out[0]}       {}                         chainLock.Lock() (for reorg)
2.     {b1002.tx[0].out[0]}       {}                                                                        Try to acquire lock (fetch output b1001.tx[1].out[0])
4.     {b1001.tx[1].out[0]}       {}                         disconnect b1002                               Try to acquire lock (fetch output b1001.tx[1].out[0])
5.     {}                         {}                         chainLock.Unlock() (subscriber callback)       Acquired lock (fetch output b1001.tx[1].out[0])
6.     {}                         {b1001.tx[1].out[0]}                                                      Fetched b1001.tx[1].out[0] (should happen)
7.     {}                         {b1001.tx[1].out[0]}       chainLock.Lock()   (finished callback)
8.     {}                         {b1001.tx[1].out[0]}                                                      Try to acquire lock (fetch output b1001.tx[1].out[0])
9.     {}                         {b1001.tx[1].out[0]}                                                      Try to acquire lock (fetch output b1001.tx[1].out[0])
10.    {b1000.tx[1].out[0]}       {b1001.tx[1].out[0]}       disconnect b1001                               Try to acquire lock (fetch output b1001.tx[1].out[0])
11.    {b1000.tx[1].out[0]}       {b1001.tx[1].out[0]}       chainLock.Unlock() (subscriber callback)       Acquired lock (fetch output b1001.tx[1].out[0])
12.    {b1000.tx[1].out[0]}       {b1001.tx[1].out[0]}                                                      Fetched b1001.tx[1].out[0] (shouldn't happen)
13.    {b1000.tx[1].out[0]}       {b1001.tx[1].out[0]}       chainLock.Lock()   (finished callback)
14.    {b1000.tx[1].out[0]}       {}                         Flush UTXO set
15.    {b1000.tx[1].out[0]}       {}                                                                        Try to acquire lock (fetch output b1001.tx[1].out[0])
16.    {b1000.tx[1].out[0]}       {}                                                                        Acquired lock (fetch output b1001.tx[1].out[0])
17.    {b1000.tx[1].out[0]}       {}                                                                        Did not find b1001.tx[1].out[0] (should happen)
```