### PR TITLE
blockchain: fix a bug where a duplicate entry is possible in the mapslice

### DIFF
--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -99,7 +99,8 @@ func (ms *mapSlice) put(op wire.OutPoint, entry *UtxoEntry, totalEntryMemory uin
 	ms.mtx.Lock()
 	defer ms.mtx.Unlock()
 
-	for i, maxNum := range ms.maxEntries {
+	// Look for the key in the maps.
+	for i := range ms.maxEntries {
 		m := ms.maps[i]
 		_, found := m[op]
 		if found {
@@ -107,6 +108,10 @@ func (ms *mapSlice) put(op wire.OutPoint, entry *UtxoEntry, totalEntryMemory uin
 			m[op] = entry
 			return // Return as we were successful in adding the entry.
 		}
+	}
+
+	for i, maxNum := range ms.maxEntries {
+		m := ms.maps[i]
 		if len(m) >= maxNum {
 			// Don't try to insert if the map already at max since
 			// that'll force the map to allocate double the memory it's

--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -69,6 +69,26 @@ func TestMapSlice(t *testing.T) {
 			t.Fatalf("expected len of %d, got %d", len(m), ms.length())
 		}
 
+		// Delete the first element in the first map.
+		ms.delete(test.keys[0])
+		delete(m, test.keys[0])
+
+		// Try to insert the last element in the mapslice again.
+		ms.put(test.keys[len(test.keys)-1], &UtxoEntry{}, 0)
+		m[test.keys[len(test.keys)-1]] = &UtxoEntry{}
+
+		// Check that the duplicate didn't make it in.
+		if len(m) != ms.length() {
+			t.Fatalf("expected len of %d, got %d", len(m), ms.length())
+		}
+
+		ms.put(test.keys[0], &UtxoEntry{}, 0)
+		m[test.keys[0]] = &UtxoEntry{}
+
+		if len(m) != ms.length() {
+			t.Fatalf("expected len of %d, got %d", len(m), ms.length())
+		}
+
 		for _, key := range test.keys {
 			expected, found := m[key]
 			if !found {


### PR DESCRIPTION
Adds a test and fixes the bug to fix a case where a duplicate entry in the mapslice is possible.

Not sure if this is related to the other cases we've been seeing since the outpoints should never have duplicates, fixing this is good since the code is assuming that the mapslice will not have duplicates.