### PR TITLE
Add new serialized pubkey type

### DIFF
--- a/btcec/pubkey.go
+++ b/btcec/pubkey.go
@@ -51,3 +51,38 @@ type PublicKey = secp.PublicKey
 func NewPublicKey(x, y *FieldVal) *PublicKey {
 	return secp.NewPublicKey(x, y)
 }
+
+// SerializedKey is a type for representing a public key in its compressed
+// serialized form.
+//
+// NOTE: This type is useful when using public keys as keys in maps.
+type SerializedKey [PubKeyBytesLenCompressed]byte
+
+// ToPubKey returns the public key parsed from the serialized key.
+func (s SerializedKey) ToPubKey() (*PublicKey, error) {
+	return ParsePubKey(s[:])
+}
+
+// SchnorrSerialized returns the Schnorr serialized, x-only 32-byte
+// representation of the serialized key.
+func (s SerializedKey) SchnorrSerialized() [32]byte {
+	var serializedSchnorr [32]byte
+	copy(serializedSchnorr[:], s[1:])
+	return serializedSchnorr
+}
+
+// CopyBytes returns a copy of the underlying array as a byte slice.
+func (s SerializedKey) CopyBytes() []byte {
+	c := make([]byte, PubKeyBytesLenCompressed)
+	copy(c, s[:])
+
+	return c
+}
+
+// ToSerialized serializes a public key into its compressed form.
+func ToSerialized(pubKey *PublicKey) SerializedKey {
+	var serialized SerializedKey
+	copy(serialized[:], pubKey.SerializeCompressed())
+
+	return serialized
+}

--- a/btcec/pubkey.go
+++ b/btcec/pubkey.go
@@ -10,6 +10,8 @@ import (
 
 // These constants define the lengths of serialized public keys.
 const (
+	// PubKeyBytesLenCompressed is the bytes length of a serialized compressed
+	// public key.
 	PubKeyBytesLenCompressed = 33
 )
 


### PR DESCRIPTION
This commit adds a new type called `SerializedKey`.

A serialized type is useful when using public keys as map keys. This is because functionally identical public keys can have different internal representations. These differences would cause the map to treat them as different keys.