### PR TITLE
blockchain: Test & Check Memory Usage

### DIFF
--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -960,3 +960,20 @@ func TestInitConsistentState(t *testing.T) {
 			blocks[len(blocks)-1].Height())
 	}
 }
+
+func TestTotalMemoryUsage(t *testing.T) {
+	// Mocked utxoCache instance
+	s := newUtxoCache(nil, 1*1024*1024)
+
+	// Call the totalMemoryUsage method
+	result := s.totalMemoryUsage()
+
+	expectedSize := uint64(1 * 1024 * 1024)
+
+	resultShoulBeTrue := result == expectedSize
+
+	// Compare the expected result with the actual result
+	if resultShoulBeTrue {
+		t.Errorf("Expected memory usage %d, got %d", expectedSize, result)
+	}
+}


### PR DESCRIPTION
Use the newUtxoCache function to create a 1MB simulated newUtxoCache instance.

Call the totalMemoryUsage method to compare the returned result to the expected size of 1 MB.

If the result is different from the expected size, the test fails and outputs an error message.

This test code is responsible for ensuring that the memory usage of newUtxoCache matches the expected value.