### PR TITLE
add setlabel cmd

### DIFF
--- a/btcjson/walletsvrcmds.go
+++ b/btcjson/walletsvrcmds.go
@@ -668,6 +668,21 @@ func NewSetAccountCmd(address, account string) *SetAccountCmd {
 	}
 }
 
+// SetLabelCmd defines the setlabel JSON-RPC command.
+type SetLabelCmd struct {
+	Address string
+	Label   string
+}
+
+// NewSetLabelCmd returns a new instance which can be used to issue a setlabel
+// JSON-RPC command.
+func NewSetLabelCmd(addr string, label string) *SetLabelCmd {
+	return &SetLabelCmd{
+		Address: addr,
+		Label:   label,
+	}
+}
+
 // SetTxFeeCmd defines the settxfee JSON-RPC command.
 type SetTxFeeCmd struct {
 	Amount float64 // In BTC
@@ -1128,6 +1143,7 @@ func init() {
 	MustRegisterCmd("sendmany", (*SendManyCmd)(nil), flags)
 	MustRegisterCmd("sendtoaddress", (*SendToAddressCmd)(nil), flags)
 	MustRegisterCmd("setaccount", (*SetAccountCmd)(nil), flags)
+	MustRegisterCmd("setlabel", (*SetLabelCmd)(nil), flags)
 	MustRegisterCmd("settxfee", (*SetTxFeeCmd)(nil), flags)
 	MustRegisterCmd("signmessage", (*SignMessageCmd)(nil), flags)
 	MustRegisterCmd("signrawtransaction", (*SignRawTransactionCmd)(nil), flags)

--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -481,6 +481,32 @@ func (c *Client) ListLockUnspent() ([]*wire.OutPoint, error) {
 	return c.ListLockUnspentAsync().Receive()
 }
 
+// FutureSetLabelResult is a future promise to deliver the result of a
+// SetLabelAsync RPC invocation (or an applicable error).
+type FutureSetLabelResult chan *Response
+
+// Receive waits for the Response promised by the future and returns the result
+// of setting a label to address.
+func (r FutureSetLabelResult) Receive() error {
+	_, err := ReceiveFuture(r)
+	return err
+}
+
+// SetLabelAsync returns an instance of a type that can be used to get the
+// result of the RPC at some future time by invoking the Receive function on the
+// returned instance.
+//
+// See SetLabel for the blocking version and more details.
+func (c *Client) SetLabelAsync(addr string, label string) FutureSetLabelResult {
+	cmd := btcjson.NewSetLabelCmd(addr, label)
+	return c.SendCmd(cmd)
+}
+
+// SetLabel sets an optional label to an address.
+func (c *Client) SetLabel(addr string, label string) error {
+	return c.SetLabelAsync(addr, label).Receive()
+}
+
 // FutureSetTxFeeResult is a future promise to deliver the result of a
 // SetTxFeeAsync RPC invocation (or an applicable error).
 type FutureSetTxFeeResult chan *Response


### PR DESCRIPTION
User can change wallet address label with setlabel cmd or write local additional information in bitcore wallet.