### PR TITLE
release: add darwin-arm64 to target binaries

### DIFF
--- a/release/release.sh
+++ b/release/release.sh
@@ -40,6 +40,7 @@ cd $MAINDIR
 # for a subset of systems/architectures.
 SYS=${BTCDBUILDSYS:-"
         darwin-amd64
+        darwin-arm64
         dragonfly-amd64
         freebsd-386
         freebsd-amd64


### PR DESCRIPTION
All currently released Apple computers have arm architecture and it's good to release something native for these computers.