### PR TITLE
chaincfg: update dnsseeds

### DIFF
--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -59,6 +59,7 @@ var (
 	// DefaultSignetDNSSeeds is the list of seed nodes for the default
 	// (public, Taproot enabled) signet network.
 	DefaultSignetDNSSeeds = []DNSSeed{
+		{"seed.signet.bitcoin.sprovoost.nl", true},
 		{"178.128.221.177", false},
 		{"2a01:7c8:d005:390::5", false},
 		{"v7ajjeirttkbnt32wpy3c6w3emwnfr3fkla7hpxcfokr3ysd3kqtzmqd.onion:38333", false},
@@ -288,6 +289,7 @@ var MainNetParams = Params{
 		{"seed.bitnodes.io", false},
 		{"seed.bitcoin.jonasschnelli.ch", true},
 		{"seed.btc.petertodd.net", true},
+		{"seed.bitcoin.sprovoost.nl", true},
 	},
 
 	// Chain parameters
@@ -545,6 +547,7 @@ var TestNet3Params = Params{
 	DNSSeeds: []DNSSeed{
 		{"testnet-seed.bitcoin.jonasschnelli.ch", true},
 		{"seed.tbtc.petertodd.net", true},
+		{"seed.testnet.bitcoin.sprovoost.nl", true},
 		{"testnet-seed.bluematt.me", false},
 	},
 

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -544,7 +544,6 @@ var TestNet3Params = Params{
 	DefaultPort: "18333",
 	DNSSeeds: []DNSSeed{
 		{"testnet-seed.bitcoin.jonasschnelli.ch", true},
-		{"testnet-seed.bitcoin.schildbach.de", false},
 		{"seed.tbtc.petertodd.net", true},
 		{"testnet-seed.bluematt.me", false},
 	},

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -285,7 +285,6 @@ var MainNetParams = Params{
 		{"seed.bitcoin.sipa.be", true},
 		{"dnsseed.bluematt.me", true},
 		{"dnsseed.bitcoin.dashjr.org", false},
-		{"seed.bitcoinstats.com", true},
 		{"seed.bitnodes.io", false},
 		{"seed.bitcoin.jonasschnelli.ch", true},
 		{"seed.btc.petertodd.net", true},

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -289,6 +289,7 @@ var MainNetParams = Params{
 		{"seed.bitcoin.jonasschnelli.ch", true},
 		{"seed.btc.petertodd.net", true},
 		{"seed.bitcoin.sprovoost.nl", true},
+		{"seed.bitcoin.wiz.biz", true},
 	},
 
 	// Chain parameters


### PR DESCRIPTION
To summarize:

Removed two seeds: `testnet-seed.bitcoin.schildbach.de`(testnet), `seed.bitcoinstats.com`(mainnet).

One from schildbach.de is completely unreachable and is also removed in Core. bitcoinstats.com seed is reachable but returns bad results. Documented at https://github.com/bitcoin/bitcoin/issues/29911

Added seeds from Sjors on all three networks.
Added seed from Wiz on mainnet.


I can separate the commits out into different PRs if desired