### PR TITLE
fix: use HOME dir if set

### DIFF
--- a/btcutil/appdata.go
+++ b/btcutil/appdata.go
@@ -29,18 +29,14 @@ func appDataDir(goos, appName string, roaming bool) string {
 	appNameUpper := string(unicode.ToUpper(rune(appName[0]))) + appName[1:]
 	appNameLower := string(unicode.ToLower(rune(appName[0]))) + appName[1:]
 
-	// Get the OS specific home directory via the Go standard lib.
 	var homeDir string
-	usr, err := user.Current()
-	if err == nil {
-		homeDir = usr.HomeDir
-	}
+	// If HOME is set, use it
+	homeDir = os.Getenv("HOME")
 
-	// Fall back to standard HOME environment variable that works
-	// for most POSIX OSes if the directory from the Go standard
-	// lib failed.
+	// If not, Get the OS specific home directory via the Go standard lib.
+	usr, err := user.Current()
 	if err != nil || homeDir == "" {
-		homeDir = os.Getenv("HOME")
+		homeDir = usr.HomeDir
 	}
 
 	switch goos {


### PR DESCRIPTION
HOME directory should be preferred source of home directory information.

It's a common pattern to run software with a custom HOME to temporarily isolate it from the system-set home directory. All Unix software I ever worked with would respect HOME.

Preferring `user.Current()` (which I guess reads from `/etc/passwd`) make it impossible to temporarily change effective home, as changing `/etc/passwd` is not an option.

I'm currently migrating things to a self-hosted github-actions runner, where one system user is used for all github actions runners, but each instance gets a different `HOME`, and is otherwise sandboxed to not even have permissions to touch the original home. Everything works except `lncli` which fails with:

```
[lncli] could not load global options: could not read profile file /home/github-runner/.lncli/profiles.json: could not load profile file /home/github-runner/.lncli/profiles.json: open /home/github-runner/.lncli/profiles.json: permission denied
```

and I traced it to this code.