### PR TITLE
blockchain: Add ReconsiderBlock()

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -870,192 +870,24 @@ func countSpentOutputs(block *btcutil.Block) int {
 //
 // This function MUST be called with the chain state lock held (for writes).
 func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error {
-	// Nothing to do if no reorganize nodes were provided.
-	if detachNodes.Len() == 0 && attachNodes.Len() == 0 {
-		return nil
-	}
-
-	// Ensure the provided nodes match the current best chain.
-	tip := b.bestChain.Tip()
-	if detachNodes.Len() != 0 {
-		firstDetachNode := detachNodes.Front().Value.(*blockNode)
-		if firstDetachNode.hash != tip.hash {
-			return AssertError(fmt.Sprintf("reorganize nodes to detach are "+
-				"not for the current best chain -- first detach node %v, "+
-				"current chain %v", &firstDetachNode.hash, &tip.hash))
-		}
-	}
-
-	// Ensure the provided nodes are for the same fork point.
-	if attachNodes.Len() != 0 && detachNodes.Len() != 0 {
-		firstAttachNode := attachNodes.Front().Value.(*blockNode)
-		lastDetachNode := detachNodes.Back().Value.(*blockNode)
-		if firstAttachNode.parent.hash != lastDetachNode.parent.hash {
-			return AssertError(fmt.Sprintf("reorganize nodes do not have the "+
-				"same fork point -- first attach parent %v, last detach "+
-				"parent %v", &firstAttachNode.parent.hash,
-				&lastDetachNode.parent.hash))
-		}
-	}
-
-	// Track the old and new best chains heads.
-	oldBest := tip
-	newBest := tip
-
-	// All of the blocks to detach and related spend journal entries needed
-	// to unspend transaction outputs in the blocks being disconnected must
-	// be loaded from the database during the reorg check phase below and
-	// then they are needed again when doing the actual database updates.
-	// Rather than doing two loads, cache the loaded data into these slices.
-	detachBlocks := make([]*btcutil.Block, 0, detachNodes.Len())
-	detachSpentTxOuts := make([][]SpentTxOut, 0, detachNodes.Len())
-	attachBlocks := make([]*btcutil.Block, 0, attachNodes.Len())
-
-	// Disconnect all of the blocks back to the point of the fork.  This
-	// entails loading the blocks and their associated spent txos from the
-	// database and using that information to unspend all of the spent txos
-	// and remove the utxos created by the blocks.
-	view := NewUtxoViewpoint()
-	view.SetBestHash(&oldBest.hash)
-	for e := detachNodes.Front(); e != nil; e = e.Next() {
-		n := e.Value.(*blockNode)
-		var block *btcutil.Block
-		err := b.db.View(func(dbTx database.Tx) error {
-			var err error
-			block, err = dbFetchBlockByNode(dbTx, n)
-			return err
-		})
-		if err != nil {
-			return err
-		}
-		if n.hash != *block.Hash() {
-			return AssertError(fmt.Sprintf("detach block node hash %v (height "+
-				"%v) does not match previous parent block hash %v", &n.hash,
-				n.height, block.Hash()))
-		}
-
-		// Load all of the utxos referenced by the block that aren't
-		// already in the view.
-		err = view.fetchInputUtxos(b.utxoCache, block)
-		if err != nil {
-			return err
-		}
-
-		// Load all of the spent txos for the block from the spend
-		// journal.
-		var stxos []SpentTxOut
-		err = b.db.View(func(dbTx database.Tx) error {
-			stxos, err = dbFetchSpendJournalEntry(dbTx, block)
-			return err
-		})
-		if err != nil {
-			return err
-		}
-
-		// Store the loaded block and spend journal entry for later.
-		detachBlocks = append(detachBlocks, block)
-		detachSpentTxOuts = append(detachSpentTxOuts, stxos)
-
-		err = view.disconnectTransactions(b.db, block, stxos)
-		if err != nil {
-			return err
-		}
-
-		newBest = n.parent
-	}
-
-	// Set the fork point only if there are nodes to attach since otherwise
-	// blocks are only being disconnected and thus there is no fork point.
-	var forkNode *blockNode
-	if attachNodes.Len() > 0 {
-		forkNode = newBest
-	}
-
-	// Perform several checks to verify each block that needs to be attached
-	// to the main chain can be connected without violating any rules and
-	// without actually connecting the block.
-	//
-	// NOTE: These checks could be done directly when connecting a block,
-	// however the downside to that approach is that if any of these checks
-	// fail after disconnecting some blocks or attaching others, all of the
-	// operations have to be rolled back to get the chain back into the
-	// state it was before the rule violation (or other failure).  There are
-	// at least a couple of ways accomplish that rollback, but both involve
-	// tweaking the chain and/or database.  This approach catches these
-	// issues before ever modifying the chain.
-	for e := attachNodes.Front(); e != nil; e = e.Next() {
-		n := e.Value.(*blockNode)
-
-		var block *btcutil.Block
-		err := b.db.View(func(dbTx database.Tx) error {
-			var err error
-			block, err = dbFetchBlockByNode(dbTx, n)
-			return err
-		})
-		if err != nil {
-			return err
-		}
-
-		// Store the loaded block for later.
-		attachBlocks = append(attachBlocks, block)
-
-		// Skip checks if node has already been fully validated. Although
-		// checkConnectBlock gets skipped, we still need to update the UTXO
-		// view.
-		if b.index.NodeStatus(n).KnownValid() {
-			err = view.fetchInputUtxos(b.utxoCache, block)
-			if err != nil {
-				return err
-			}
-			err = view.connectTransactions(block, nil)
-			if err != nil {
-				return err
-			}
-
-			newBest = n
-			continue
-		}
-
-		// Notice the spent txout details are not requested here and
-		// thus will not be generated.  This is done because the state
-		// is not being immediately written to the database, so it is
-		// not needed.
-		//
-		// In the case the block is determined to be invalid due to a
-		// rule violation, mark it as invalid and mark all of its
-		// descendants as having an invalid ancestor.
-		err = b.checkConnectBlock(n, block, view, nil)
-		if err != nil {
-			if _, ok := err.(RuleError); ok {
-				b.index.SetStatusFlags(n, statusValidateFailed)
-				for de := e.Next(); de != nil; de = de.Next() {
-					dn := de.Value.(*blockNode)
-					b.index.SetStatusFlags(dn, statusInvalidAncestor)
-				}
-			}
-			return err
-		}
-		b.index.SetStatusFlags(n, statusValid)
-
-		newBest = n
-	}
-
-	// Flush the utxo cache for the block disconnect below.  The disconnect
-	// code assumes that it's directly modifying the database so the cache
-	// will be left in an inconsistent state.  It needs to be flushed beforehand
-	// in order for that to not happen.
-	err := b.db.Update(func(dbTx database.Tx) error {
-		return b.utxoCache.flush(dbTx, FlushRequired, b.BestSnapshot())
-	})
+	// Check first that the detach and the attach nodes are valid and they
+	// pass verification.
+	detachBlocks, attachBlocks, detachSpentTxOuts,
+		err := b.verifyReorganizationValidity(detachNodes, attachNodes)
 	if err != nil {
 		return err
 	}
+
+	// Track the old and new best chains heads.
+	tip := b.bestChain.Tip()
+	oldBest := tip
+	newBest := tip
 
 	// Reset the view for the actual connection code below.  This is
 	// required because the view was previously modified when checking if
 	// the reorg would be successful and the connection code requires the
 	// view to be valid from the viewpoint of each block being disconnected.
-	view = NewUtxoViewpoint()
+	view := NewUtxoViewpoint()
 	view.SetBestHash(&b.bestChain.Tip().hash)
 
 	// Disconnect blocks from the main chain.
@@ -1084,6 +916,15 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 		if err != nil {
 			return err
 		}
+
+		newBest = n.parent
+	}
+
+	// Set the fork point only if there are nodes to attach since otherwise
+	// blocks are only being disconnected and thus there is no fork point.
+	var forkNode *blockNode
+	if attachNodes.Len() > 0 {
+		forkNode = newBest
 	}
 
 	// Connect the new best chain blocks using the utxocache directly.  It's more
@@ -1109,6 +950,8 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 		if err != nil {
 			return err
 		}
+
+		newBest = n
 	}
 
 	// Log the point where the chain forked and old and new best chain
@@ -1123,6 +966,176 @@ func (b *BlockChain) reorganizeChain(detachNodes, attachNodes *list.List) error 
 		newBest.hash, newBest.height)
 
 	return nil
+}
+
+// verifyReorganizationValidity will verify that the disconnects and the connects
+// that are in the list are able to be processed without mutating the chain.
+//
+// For the attach nodes, it'll check that each of the blocks are valid and will
+// change the status of the block node in the list to invalid if the block fails
+// to pass verification.  For the detach nodes, it'll check that the blocks being
+// detached and their spend journals are present on the database.
+func (b *BlockChain) verifyReorganizationValidity(detachNodes, attachNodes *list.List) (
+	[]*btcutil.Block, []*btcutil.Block, [][]SpentTxOut, error) {
+
+	// Nothing to do if no reorganize nodes were provided.
+	if detachNodes.Len() == 0 && attachNodes.Len() == 0 {
+		return nil, nil, nil, nil
+	}
+
+	// Ensure the provided nodes match the current best chain.
+	tip := b.bestChain.Tip()
+	if detachNodes.Len() != 0 {
+		firstDetachNode := detachNodes.Front().Value.(*blockNode)
+		if firstDetachNode.hash != tip.hash {
+			return nil, nil, nil,
+				AssertError(fmt.Sprintf("reorganize nodes to detach are "+
+					"not for the current best chain -- first detach node %v, "+
+					"current chain %v", &firstDetachNode.hash, &tip.hash))
+		}
+	}
+
+	// Ensure the provided nodes are for the same fork point.
+	if attachNodes.Len() != 0 && detachNodes.Len() != 0 {
+		firstAttachNode := attachNodes.Front().Value.(*blockNode)
+		lastDetachNode := detachNodes.Back().Value.(*blockNode)
+		if firstAttachNode.parent.hash != lastDetachNode.parent.hash {
+			return nil, nil, nil,
+				AssertError(fmt.Sprintf("reorganize nodes do not have the "+
+					"same fork point -- first attach parent %v, last detach "+
+					"parent %v", &firstAttachNode.parent.hash,
+					&lastDetachNode.parent.hash))
+		}
+	}
+
+	// All of the blocks to detach and related spend journal entries needed
+	// to unspend transaction outputs in the blocks being disconnected must
+	// be loaded from the database during the reorg check phase below and
+	// then they are needed again when doing the actual database updates.
+	// Rather than doing two loads, cache the loaded data into these slices.
+	detachBlocks := make([]*btcutil.Block, 0, detachNodes.Len())
+	detachSpentTxOuts := make([][]SpentTxOut, 0, detachNodes.Len())
+	attachBlocks := make([]*btcutil.Block, 0, attachNodes.Len())
+
+	// Disconnect all of the blocks back to the point of the fork.  This
+	// entails loading the blocks and their associated spent txos from the
+	// database and using that information to unspend all of the spent txos
+	// and remove the utxos created by the blocks.
+	view := NewUtxoViewpoint()
+	view.SetBestHash(&tip.hash)
+	for e := detachNodes.Front(); e != nil; e = e.Next() {
+		n := e.Value.(*blockNode)
+		var block *btcutil.Block
+		err := b.db.View(func(dbTx database.Tx) error {
+			var err error
+			block, err = dbFetchBlockByNode(dbTx, n)
+			return err
+		})
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		if n.hash != *block.Hash() {
+			return nil, nil, nil, AssertError(
+				fmt.Sprintf("detach block node hash %v (height "+
+					"%v) does not match previous parent block hash %v",
+					&n.hash, n.height, block.Hash()))
+		}
+
+		// Load all of the utxos referenced by the block that aren't
+		// already in the view.
+		err = view.fetchInputUtxos(b.utxoCache, block)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		// Load all of the spent txos for the block from the spend
+		// journal.
+		var stxos []SpentTxOut
+		err = b.db.View(func(dbTx database.Tx) error {
+			stxos, err = dbFetchSpendJournalEntry(dbTx, block)
+			return err
+		})
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		// Store the loaded block and spend journal entry for later.
+		detachBlocks = append(detachBlocks, block)
+		detachSpentTxOuts = append(detachSpentTxOuts, stxos)
+
+		err = view.disconnectTransactions(b.db, block, stxos)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+	}
+
+	// Perform several checks to verify each block that needs to be attached
+	// to the main chain can be connected without violating any rules and
+	// without actually connecting the block.
+	//
+	// NOTE: These checks could be done directly when connecting a block,
+	// however the downside to that approach is that if any of these checks
+	// fail after disconnecting some blocks or attaching others, all of the
+	// operations have to be rolled back to get the chain back into the
+	// state it was before the rule violation (or other failure).  There are
+	// at least a couple of ways accomplish that rollback, but both involve
+	// tweaking the chain and/or database.  This approach catches these
+	// issues before ever modifying the chain.
+	for e := attachNodes.Front(); e != nil; e = e.Next() {
+		n := e.Value.(*blockNode)
+
+		var block *btcutil.Block
+		err := b.db.View(func(dbTx database.Tx) error {
+			var err error
+			block, err = dbFetchBlockByNode(dbTx, n)
+			return err
+		})
+		if err != nil {
+			return nil, nil, nil, err
+		}
+
+		// Store the loaded block for later.
+		attachBlocks = append(attachBlocks, block)
+
+		// Skip checks if node has already been fully validated. Although
+		// checkConnectBlock gets skipped, we still need to update the UTXO
+		// view.
+		if b.index.NodeStatus(n).KnownValid() {
+			err = view.fetchInputUtxos(b.utxoCache, block)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+			err = view.connectTransactions(block, nil)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+
+			continue
+		}
+
+		// Notice the spent txout details are not requested here and
+		// thus will not be generated.  This is done because the state
+		// is not being immediately written to the database, so it is
+		// not needed.
+		//
+		// In the case the block is determined to be invalid due to a
+		// rule violation, mark it as invalid and mark all of its
+		// descendants as having an invalid ancestor.
+		err = b.checkConnectBlock(n, block, view, nil)
+		if err != nil {
+			if _, ok := err.(RuleError); ok {
+				b.index.SetStatusFlags(n, statusValidateFailed)
+				for de := e.Next(); de != nil; de = de.Next() {
+					dn := de.Value.(*blockNode)
+					b.index.SetStatusFlags(dn, statusInvalidAncestor)
+				}
+			}
+			return nil, nil, nil, err
+		}
+		b.index.SetStatusFlags(n, statusValid)
+	}
+
+	return detachBlocks, attachBlocks, detachSpentTxOuts, nil
 }
 
 // connectBestChain handles connecting the passed block to the chain while

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1949,6 +1949,88 @@ func (b *BlockChain) InvalidateBlock(hash *chainhash.Hash) error {
 	return err
 }
 
+// ReconsiderBlock reconsiders the validity of the block with the given hash.
+//
+// This function is safe for concurrent access.
+func (b *BlockChain) ReconsiderBlock(hash *chainhash.Hash) error {
+	b.chainLock.Lock()
+	defer b.chainLock.Unlock()
+
+	node := b.index.LookupNode(hash)
+	if node == nil {
+		// Return an error if the block doesn't exist.
+		return fmt.Errorf("Requested block hash of %s is not found "+
+			"and thus cannot be reconsidered.", hash)
+	}
+
+	// Nothing to do if the given block is already valid.
+	if node.status.KnownValid() {
+		return nil
+	}
+
+	// Clear the status of the block being reconsidered.
+	b.index.UnsetStatusFlags(node, statusInvalidAncestor)
+	b.index.UnsetStatusFlags(node, statusValidateFailed)
+
+	// Grab all the tips.
+	tips := b.index.InactiveTips(b.bestChain)
+	tips = append(tips, b.bestChain.Tip())
+
+	// Go through all the tips and unset the status for all the descendents of the
+	// block being reconsidered.
+	var reconsiderTip *blockNode
+	for _, tip := range tips {
+		// Continue if the given inactive tip is not a descendant of the block
+		// being invalidated.
+		if !tip.IsAncestor(node) {
+			// Set as the reconsider tip if the block node being reconsidered
+			// is a tip.
+			if tip == node {
+				reconsiderTip = node
+			}
+			continue
+		}
+
+		// Mark the current tip as the tip being reconsidered.
+		reconsiderTip = tip
+
+		// Unset the status of all the parents up until it reaches the block
+		// being reconsidered.
+		for n := tip; n != nil && n != node; n = n.parent {
+			b.index.UnsetStatusFlags(n, statusInvalidAncestor)
+		}
+	}
+
+	// Compare the cumulative work for the branch being reconsidered.
+	if reconsiderTip.workSum.Cmp(b.bestChain.Tip().workSum) <= 0 {
+		return nil
+	}
+
+	// If the reconsider tip has a higher cumulative work, then reorganize
+	// to it after checking the validity of the nodes.
+	detachNodes, attachNodes := b.getReorganizeNodes(reconsiderTip)
+
+	// We're checking if the reorganization that'll happen is actually valid.
+	// While this is called in reorganizeChain, we call it beforehand as the error
+	// returned from reorganizeChain doesn't differentiate between actual disconnect/
+	// connect errors or whether the branch we're trying to fork to is invalid.
+	//
+	// The block status changes here without being flushed so we immediately flush
+	// the blockindex after we call this function.
+	_, _, _, err := b.verifyReorganizationValidity(detachNodes, attachNodes)
+	if writeErr := b.index.flushToDB(); writeErr != nil {
+		log.Warnf("Error flushing block index changes to disk: %v", writeErr)
+	}
+	if err != nil {
+		// If we errored out during the verification of the reorg branch,
+		// it's ok to return nil as we reconsidered the block and determined
+		// that it's invalid.
+		return nil
+	}
+
+	return b.reorganizeChain(detachNodes, attachNodes)
+}
+
 // IndexManager provides a generic interface that the is called when blocks are
 // connected and disconnected to and from the tip of the main chain for the
 // purpose of supporting optional indexes.

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -6,10 +6,12 @@ package blockchain
 
 import (
 	"fmt"
+	"math/rand"
 	"reflect"
 	"testing"
 	"time"
 
+	"github.com/btcsuite/btcd/blockchain/internal/testhelper"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -1309,5 +1311,314 @@ func TestIsAncestor(t *testing.T) {
 		t.Errorf("TestIsAncestor fail. Node %s is in a different chain than "+
 			"node %s but got true", fakeChain.bestChain.Genesis().hash.String(),
 			branch2Nodes[0].hash.String())
+	}
+}
+
+// randomSelect selects random amount of random elements from a slice and returns a
+// new slice.  The selected elements are removed.
+func randomSelect(input []*testhelper.SpendableOut) (
+	[]*testhelper.SpendableOut, []*testhelper.SpendableOut) {
+
+	selected := []*testhelper.SpendableOut{}
+
+	// Select random elements from the input slice
+	amount := rand.Intn(len(input))
+	for i := 0; i < amount; i++ {
+		// Generate a random index
+		randIdx := rand.Intn(len(input))
+
+		// Append the selected element to the new slice
+		selected = append(selected, input[randIdx])
+
+		// Remove the selected element from the input slice.
+		// This ensures that each selected element is unique.
+		input = append(input[:randIdx], input[randIdx+1:]...)
+	}
+
+	return input, selected
+}
+
+// addBlocks generates new blocks and adds them to the chain.  The newly generated
+// blocks will spend from the spendable outputs passed in.  The returned hases are
+// the hashes of the newly generated blocks.
+func addBlocks(count int, chain *BlockChain, prevBlock *btcutil.Block,
+	allSpendableOutputs []*testhelper.SpendableOut) (
+	[]*chainhash.Hash, [][]*testhelper.SpendableOut, error) {
+
+	blockHashes := make([]*chainhash.Hash, 0, count)
+	spendablesOuts := make([][]*testhelper.SpendableOut, 0, count)
+
+	// Always spend everything on the first block.  This ensures we get unique blocks
+	// every time.  The random select may choose not to spend any and that results
+	// in getting the same block.
+	nextSpends := allSpendableOutputs
+	allSpendableOutputs = allSpendableOutputs[:0]
+	for b := 0; b < count; b++ {
+		newBlock, newSpendableOuts, err := addBlock(chain, prevBlock, nextSpends)
+		if err != nil {
+			return nil, nil, err
+		}
+		prevBlock = newBlock
+
+		blockHashes = append(blockHashes, newBlock.Hash())
+		spendablesOuts = append(spendablesOuts, newSpendableOuts)
+		allSpendableOutputs = append(allSpendableOutputs, newSpendableOuts...)
+
+		// Grab utxos to be spent in the next block.
+		allSpendableOutputs, nextSpends = randomSelect(allSpendableOutputs)
+	}
+
+	return blockHashes, spendablesOuts, nil
+}
+
+func TestInvalidateBlock(t *testing.T) {
+	tests := []struct {
+		name     string
+		chainGen func() (*BlockChain, []*chainhash.Hash, func())
+	}{
+		{
+			name: "one branch, invalidate once",
+			chainGen: func() (*BlockChain, []*chainhash.Hash, func()) {
+				chain, params, tearDown := utxoCacheTestChain(
+					"TestInvalidateBlock-one-branch-" +
+						"invalidate-once")
+				// Grab the tip of the chain.
+				tip := btcutil.NewBlock(params.GenesisBlock)
+
+				// Create a chain with 11 blocks.
+				_, _, err := addBlocks(11, chain, tip, []*testhelper.SpendableOut{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Invalidate block 5.
+				block, err := chain.BlockByHeight(5)
+				if err != nil {
+					t.Fatal(err)
+				}
+				invalidateHash := block.Hash()
+
+				return chain, []*chainhash.Hash{invalidateHash}, tearDown
+			},
+		},
+		{
+			name: "invalidate twice",
+			chainGen: func() (*BlockChain, []*chainhash.Hash, func()) {
+				chain, params, tearDown := utxoCacheTestChain("TestInvalidateBlock-invalidate-twice")
+				// Grab the tip of the chain.
+				tip := btcutil.NewBlock(params.GenesisBlock)
+
+				// Create a chain with 11 blocks.
+				_, spendableOuts, err := addBlocks(11, chain, tip, []*testhelper.SpendableOut{})
+				//_, _, err := addBlocks(11, chain, tip, []*testhelper.SpendableOut{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Set invalidateHash as block 5.
+				block, err := chain.BlockByHeight(5)
+				if err != nil {
+					t.Fatal(err)
+				}
+				invalidateHash := block.Hash()
+
+				// Create a side chain with 7 blocks that builds on block 1.
+				b1, err := chain.BlockByHeight(1)
+				if err != nil {
+					t.Fatal(err)
+				}
+				altBlockHashes, _, err := addBlocks(6, chain, b1, spendableOuts[0])
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Grab block at height 5:
+				//
+				// b2, b3, b4, b5
+				//  0,  1,  2,  3
+				invalidateHash2 := altBlockHashes[3]
+
+				// Sanity checking that we grabbed the correct hash.
+				node := chain.index.LookupNode(invalidateHash)
+				if node == nil || node.height != 5 {
+					t.Fatalf("wanted to grab block at height 5 but got height %v",
+						node.height)
+				}
+
+				return chain, []*chainhash.Hash{invalidateHash, invalidateHash2}, tearDown
+			},
+		},
+		{
+			name: "invalidate a side branch",
+			chainGen: func() (*BlockChain, []*chainhash.Hash, func()) {
+				chain, params, tearDown := utxoCacheTestChain("TestInvalidateBlock-invalidate-side-branch")
+				tip := btcutil.NewBlock(params.GenesisBlock)
+
+				// Grab the tip of the chain.
+				tip, err := chain.BlockByHash(&chain.bestChain.Tip().hash)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Create a chain with 11 blocks.
+				_, spendableOuts, err := addBlocks(11, chain, tip, []*testhelper.SpendableOut{})
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Create a side chain with 7 blocks that builds on block 1.
+				b1, err := chain.BlockByHeight(1)
+				if err != nil {
+					t.Fatal(err)
+				}
+				altBlockHashes, _, err := addBlocks(6, chain, b1, spendableOuts[0])
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				// Grab block at height 4:
+				//
+				// b2, b3, b4
+				//  0,  1,  2
+				invalidateHash := altBlockHashes[2]
+
+				// Sanity checking that we grabbed the correct hash.
+				node := chain.index.LookupNode(invalidateHash)
+				if node == nil || node.height != 4 {
+					t.Fatalf("wanted to grab block at height 4 but got height %v",
+						node.height)
+				}
+
+				return chain, []*chainhash.Hash{invalidateHash}, tearDown
+			},
+		},
+	}
+
+	for _, test := range tests {
+		chain, invalidateHashes, tearDown := test.chainGen()
+		func() {
+			defer tearDown()
+			for _, invalidateHash := range invalidateHashes {
+				chainTipsBefore := chain.ChainTips()
+
+				// Mark if we're invalidating a block that's a part of the best chain.
+				var bestChainBlock bool
+				node := chain.index.LookupNode(invalidateHash)
+				if chain.bestChain.Contains(node) {
+					bestChainBlock = true
+				}
+
+				// Actual invalidation.
+				err := chain.InvalidateBlock(invalidateHash)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				chainTipsAfter := chain.ChainTips()
+
+				// Create a map for easy lookup.
+				chainTipMap := make(map[chainhash.Hash]ChainTip, len(chainTipsAfter))
+				activeTipCount := 0
+				for _, chainTip := range chainTipsAfter {
+					chainTipMap[chainTip.BlockHash] = chainTip
+
+					if chainTip.Status == StatusActive {
+						activeTipCount++
+					}
+				}
+				if activeTipCount != 1 {
+					t.Fatalf("TestInvalidateBlock fail. Expected "+
+						"1 active chain tip but got %d", activeTipCount)
+				}
+
+				bestTip := chain.bestChain.Tip()
+
+				validForkCount := 0
+				for _, tip := range chainTipsBefore {
+					// If the chaintip was an active tip and we invalidated a block
+					// in the active tip, assert that it's invalid now.
+					if bestChainBlock && tip.Status == StatusActive {
+						gotTip, found := chainTipMap[tip.BlockHash]
+						if !found {
+							t.Fatalf("TestInvalidateBlock fail. Expected "+
+								"block %s not found in chaintips after "+
+								"invalidateblock", tip.BlockHash.String())
+						}
+
+						if gotTip.Status != StatusInvalid {
+							t.Fatalf("TestInvalidateBlock fail. "+
+								"Expected block %s to be invalid, got status: %s",
+								gotTip.BlockHash.String(), gotTip.Status)
+						}
+					}
+
+					if !bestChainBlock && tip.Status != StatusActive {
+						gotTip, found := chainTipMap[tip.BlockHash]
+						if !found {
+							t.Fatalf("TestInvalidateBlock fail. Expected "+
+								"block %s not found in chaintips after "+
+								"invalidateblock", tip.BlockHash.String())
+						}
+
+						if gotTip.BlockHash == *invalidateHash && gotTip.Status != StatusInvalid {
+							t.Fatalf("TestInvalidateBlock fail. "+
+								"Expected block %s to be invalid, got status: %s",
+								gotTip.BlockHash.String(), gotTip.Status)
+						}
+					}
+
+					// If we're not invalidating the branch with an active tip,
+					// we expect the active tip to remain the same.
+					if !bestChainBlock && tip.Status == StatusActive && tip.BlockHash != bestTip.hash {
+						t.Fatalf("TestInvalidateBlock fail. Expected block %s as the tip but got %s",
+							tip.BlockHash.String(), bestTip.hash.String())
+					}
+
+					// If this tip is not invalid and not active, it should be
+					// lighter than the current best tip.
+					if tip.Status != StatusActive && tip.Status != StatusInvalid &&
+						tip.Height > bestTip.height {
+
+						tipNode := chain.index.LookupNode(&tip.BlockHash)
+						if bestTip.workSum.Cmp(tipNode.workSum) == -1 {
+							t.Fatalf("TestInvalidateBlock fail. Expected "+
+								"block %s to be the active tip but block %s "+
+								"was", tipNode.hash.String(), bestTip.hash.String())
+						}
+					}
+
+					if tip.Status == StatusValidFork {
+						validForkCount++
+					}
+				}
+
+				// If there are no other valid chain tips besides the active chaintip,
+				// we expect to have one more chain tip after the invalidate.
+				if validForkCount == 0 && len(chainTipsAfter) != len(chainTipsBefore)+1 {
+					t.Fatalf("TestInvalidateBlock fail. Expected %d chaintips but got %d",
+						len(chainTipsBefore)+1, len(chainTipsAfter))
+				}
+			}
+
+			// Try to invaliate the already invalidated hash.
+			err := chain.InvalidateBlock(invalidateHashes[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Try to invaliate a genesis block
+			err = chain.InvalidateBlock(chain.chainParams.GenesisHash)
+			if err == nil {
+				t.Fatalf("TestInvalidateBlock fail. Expected to err when trying to" +
+					"invalidate a genesis block.")
+			}
+
+			// Try to invaliate a block that doesn't exist.
+			err = chain.InvalidateBlock(chaincfg.MainNetParams.GenesisHash)
+			if err == nil {
+				t.Fatalf("TestInvalidateBlock fail. Expected to err when trying to" +
+					"invalidate a block that doesn't exist.")
+			}
+		}()
 	}
 }

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/btcsuite/btcd/blockchain/internal/testhelper"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
@@ -395,4 +396,97 @@ func newFakeNode(parent *blockNode, blockVersion int32, bits uint32, timestamp t
 		Timestamp: timestamp,
 	}
 	return newBlockNode(header, parent)
+}
+
+// addBlock adds a block to the blockchain that succeeds the previous block.
+// The blocks spends all the provided spendable outputs.  The new block and
+// the new spendable outputs created in the block are returned.
+func addBlock(chain *BlockChain, prev *btcutil.Block, spends []*testhelper.SpendableOut) (
+	*btcutil.Block, []*testhelper.SpendableOut, error) {
+
+	block, outs, err := newBlock(chain, prev, spends)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	_, _, err = chain.ProcessBlock(block, BFNone)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return block, outs, nil
+}
+
+// calcMerkleRoot creates a merkle tree from the slice of transactions and
+// returns the root of the tree.
+func calcMerkleRoot(txns []*wire.MsgTx) chainhash.Hash {
+	if len(txns) == 0 {
+		return chainhash.Hash{}
+	}
+
+	utilTxns := make([]*btcutil.Tx, 0, len(txns))
+	for _, tx := range txns {
+		utilTxns = append(utilTxns, btcutil.NewTx(tx))
+	}
+	return CalcMerkleRoot(utilTxns, false)
+}
+
+// newBlock creates a block to the blockchain that succeeds the previous block.
+// The blocks spends all the provided spendable outputs.  The new block and the
+// newly spendable outputs created in the block are returned.
+func newBlock(chain *BlockChain, prev *btcutil.Block,
+	spends []*testhelper.SpendableOut) (*btcutil.Block, []*testhelper.SpendableOut, error) {
+
+	blockHeight := prev.Height() + 1
+	txns := make([]*wire.MsgTx, 0, 1+len(spends))
+
+	// Create and add coinbase tx.
+	cb := testhelper.CreateCoinbaseTx(blockHeight, CalcBlockSubsidy(blockHeight, chain.chainParams))
+	txns = append(txns, cb)
+
+	// Spend all txs to be spent.
+	for _, spend := range spends {
+		cb.TxOut[0].Value += int64(testhelper.LowFee)
+
+		spendTx := testhelper.CreateSpendTx(spend, testhelper.LowFee)
+		txns = append(txns, spendTx)
+	}
+
+	// Use a timestamp that is one second after the previous block unless
+	// this is the first block in which case the current time is used.
+	var ts time.Time
+	if blockHeight == 1 {
+		ts = time.Unix(time.Now().Unix(), 0)
+	} else {
+		ts = prev.MsgBlock().Header.Timestamp.Add(time.Second)
+	}
+
+	// Create the block. The nonce will be solved in the below code in
+	// SolveBlock.
+	block := btcutil.NewBlock(&wire.MsgBlock{
+		Header: wire.BlockHeader{
+			Version:    1,
+			PrevBlock:  *prev.Hash(),
+			MerkleRoot: calcMerkleRoot(txns),
+			Bits:       chain.chainParams.PowLimitBits,
+			Timestamp:  ts,
+			Nonce:      0, // To be solved.
+		},
+		Transactions: txns,
+	})
+	block.SetHeight(blockHeight)
+
+	// Solve the block.
+	if !testhelper.SolveBlock(&block.MsgBlock().Header) {
+		return nil, nil, fmt.Errorf("Unable to solve block at height %d", blockHeight)
+	}
+
+	// Create spendable outs to return.
+	outs := make([]*testhelper.SpendableOut, len(txns))
+	for i, tx := range txns {
+		out := testhelper.MakeSpendableOutForTx(tx, 0)
+		outs[i] = &out
+	}
+
+	return block, outs, nil
 }

--- a/blockchain/difficulty.go
+++ b/blockchain/difficulty.go
@@ -8,31 +8,14 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/btcsuite/btcd/blockchain/internal/workmath"
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-)
-
-var (
-	// bigOne is 1 represented as a big.Int.  It is defined here to avoid
-	// the overhead of creating it multiple times.
-	bigOne = big.NewInt(1)
-
-	// oneLsh256 is 1 shifted left 256 bits.  It is defined here to avoid
-	// the overhead of creating it multiple times.
-	oneLsh256 = new(big.Int).Lsh(bigOne, 256)
 )
 
 // HashToBig converts a chainhash.Hash into a big.Int that can be used to
 // perform math comparisons.
 func HashToBig(hash *chainhash.Hash) *big.Int {
-	// A Hash is in little-endian, but the big package wants the bytes in
-	// big-endian, so reverse them.
-	buf := *hash
-	blen := len(buf)
-	for i := 0; i < blen/2; i++ {
-		buf[i], buf[blen-1-i] = buf[blen-1-i], buf[i]
-	}
-
-	return new(big.Int).SetBytes(buf[:])
+	return workmath.HashToBig(hash)
 }
 
 // CompactToBig converts a compact representation of a whole number N to an
@@ -60,31 +43,7 @@ func HashToBig(hash *chainhash.Hash) *big.Int {
 // which represent difficulty targets, thus there really is not a need for a
 // sign bit, but it is implemented here to stay consistent with bitcoind.
 func CompactToBig(compact uint32) *big.Int {
-	// Extract the mantissa, sign bit, and exponent.
-	mantissa := compact & 0x007fffff
-	isNegative := compact&0x00800000 != 0
-	exponent := uint(compact >> 24)
-
-	// Since the base for the exponent is 256, the exponent can be treated
-	// as the number of bytes to represent the full 256-bit number.  So,
-	// treat the exponent as the number of bytes and shift the mantissa
-	// right or left accordingly.  This is equivalent to:
-	// N = mantissa * 256^(exponent-3)
-	var bn *big.Int
-	if exponent <= 3 {
-		mantissa >>= 8 * (3 - exponent)
-		bn = big.NewInt(int64(mantissa))
-	} else {
-		bn = big.NewInt(int64(mantissa))
-		bn.Lsh(bn, 8*(exponent-3))
-	}
-
-	// Make it negative if the sign bit is set.
-	if isNegative {
-		bn = bn.Neg(bn)
-	}
-
-	return bn
+	return workmath.CompactToBig(compact)
 }
 
 // BigToCompact converts a whole number N to a compact representation using
@@ -92,41 +51,7 @@ func CompactToBig(compact uint32) *big.Int {
 // of precision, so values larger than (2^23 - 1) only encode the most
 // significant digits of the number.  See CompactToBig for details.
 func BigToCompact(n *big.Int) uint32 {
-	// No need to do any work if it's zero.
-	if n.Sign() == 0 {
-		return 0
-	}
-
-	// Since the base for the exponent is 256, the exponent can be treated
-	// as the number of bytes.  So, shift the number right or left
-	// accordingly.  This is equivalent to:
-	// mantissa = mantissa / 256^(exponent-3)
-	var mantissa uint32
-	exponent := uint(len(n.Bytes()))
-	if exponent <= 3 {
-		mantissa = uint32(n.Bits()[0])
-		mantissa <<= 8 * (3 - exponent)
-	} else {
-		// Use a copy to avoid modifying the caller's original number.
-		tn := new(big.Int).Set(n)
-		mantissa = uint32(tn.Rsh(tn, 8*(exponent-3)).Bits()[0])
-	}
-
-	// When the mantissa already has the sign bit set, the number is too
-	// large to fit into the available 23-bits, so divide the number by 256
-	// and increment the exponent accordingly.
-	if mantissa&0x00800000 != 0 {
-		mantissa >>= 8
-		exponent++
-	}
-
-	// Pack the exponent, sign bit, and mantissa into an unsigned 32-bit
-	// int and return it.
-	compact := uint32(exponent<<24) | mantissa
-	if n.Sign() < 0 {
-		compact |= 0x00800000
-	}
-	return compact
+	return workmath.BigToCompact(n)
 }
 
 // CalcWork calculates a work value from difficulty bits.  Bitcoin increases
@@ -140,17 +65,7 @@ func BigToCompact(n *big.Int) uint32 {
 // potential division by zero and really small floating point numbers, the
 // result adds 1 to the denominator and multiplies the numerator by 2^256.
 func CalcWork(bits uint32) *big.Int {
-	// Return a work value of zero if the passed difficulty bits represent
-	// a negative number. Note this should not happen in practice with valid
-	// blocks, but an invalid block could trigger it.
-	difficultyNum := CompactToBig(bits)
-	if difficultyNum.Sign() <= 0 {
-		return big.NewInt(0)
-	}
-
-	// (1 << 256) / (difficultyNum + 1)
-	denominator := new(big.Int).Add(difficultyNum, bigOne)
-	return new(big.Int).Div(oneLsh256, denominator)
+	return workmath.CalcWork(bits)
 }
 
 // calcEasiestDifficulty calculates the easiest possible difficulty that a block

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -224,26 +224,8 @@ func pushDataScript(items ...[]byte) []byte {
 // subsidy based on the passed block height.  The coinbase signature script
 // conforms to the requirements of version 2 blocks.
 func (g *testGenerator) createCoinbaseTx(blockHeight int32) *wire.MsgTx {
-	extraNonce := uint64(0)
-	coinbaseScript, err := testhelper.StandardCoinbaseScript(blockHeight, extraNonce)
-	if err != nil {
-		panic(err)
-	}
-
-	tx := wire.NewMsgTx(1)
-	tx.AddTxIn(&wire.TxIn{
-		// Coinbase transactions have no inputs, so previous outpoint is
-		// zero hash and max index.
-		PreviousOutPoint: *wire.NewOutPoint(&chainhash.Hash{},
-			wire.MaxPrevOutIndex),
-		Sequence:        wire.MaxTxInSequenceNum,
-		SignatureScript: coinbaseScript,
-	})
-	tx.AddTxOut(&wire.TxOut{
-		Value:    blockchain.CalcBlockSubsidy(blockHeight, g.params),
-		PkScript: testhelper.OpTrueScript,
-	})
-	return tx
+	return testhelper.CreateCoinbaseTx(
+		blockHeight, blockchain.CalcBlockSubsidy(blockHeight, g.params))
 }
 
 // calcMerkleRoot creates a merkle tree from the slice of transactions and

--- a/blockchain/fullblocktests/generate.go
+++ b/blockchain/fullblocktests/generate.go
@@ -220,20 +220,12 @@ func pushDataScript(items ...[]byte) []byte {
 	return script
 }
 
-// standardCoinbaseScript returns a standard script suitable for use as the
-// signature script of the coinbase transaction of a new block.  In particular,
-// it starts with the block height that is required by version 2 blocks.
-func standardCoinbaseScript(blockHeight int32, extraNonce uint64) ([]byte, error) {
-	return txscript.NewScriptBuilder().AddInt64(int64(blockHeight)).
-		AddInt64(int64(extraNonce)).Script()
-}
-
 // createCoinbaseTx returns a coinbase transaction paying an appropriate
 // subsidy based on the passed block height.  The coinbase signature script
 // conforms to the requirements of version 2 blocks.
 func (g *testGenerator) createCoinbaseTx(blockHeight int32) *wire.MsgTx {
 	extraNonce := uint64(0)
-	coinbaseScript, err := standardCoinbaseScript(blockHeight, extraNonce)
+	coinbaseScript, err := testhelper.StandardCoinbaseScript(blockHeight, extraNonce)
 	if err != nil {
 		panic(err)
 	}

--- a/blockchain/internal/testhelper/README.md
+++ b/blockchain/internal/testhelper/README.md
@@ -1,0 +1,16 @@
+testhelper
+==========
+
+[![Build Status](https://github.com/btcsuite/btcd/workflows/Build%20and%20Test/badge.svg)](https://github.com/btcsuite/btcd/actions)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://pkg.go.dev/github.com/btcsuite/btcd/blockchain/testhelper)
+
+Package testhelper provides functions that are used internally in the
+btcd/blockchain and btcd/blockchain/fullblocktests package to test consensus
+validation rules.  Mainly provided to avoid dependency cycles internally among
+the different packages in btcd.
+
+## License
+
+Package testhelper is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/blockchain/internal/testhelper/common.go
+++ b/blockchain/internal/testhelper/common.go
@@ -21,6 +21,14 @@ var (
 	LowFee = btcutil.Amount(1)
 )
 
+// StandardCoinbaseScript returns a standard script suitable for use as the
+// signature script of the coinbase transaction of a new block.  In particular,
+// it starts with the block height that is required by version 2 blocks.
+func StandardCoinbaseScript(blockHeight int32, extraNonce uint64) ([]byte, error) {
+	return txscript.NewScriptBuilder().AddInt64(int64(blockHeight)).
+		AddInt64(int64(extraNonce)).Script()
+}
+
 // OpReturnScript returns a provably-pruneable OP_RETURN script with the
 // provided data.
 func OpReturnScript(data []byte) ([]byte, error) {

--- a/blockchain/internal/testhelper/common.go
+++ b/blockchain/internal/testhelper/common.go
@@ -6,7 +6,18 @@ import (
 
 	"github.com/btcsuite/btcd/blockchain/internal/workmath"
 	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+)
+
+var (
+	// OpTrueScript is simply a public key script that contains the OP_TRUE
+	// opcode.  It is defined here to reduce garbage creation.
+	OpTrueScript = []byte{txscript.OP_TRUE}
+
+	// LowFee is a single satoshi and exists to make the test code more
+	// readable.
+	LowFee = btcutil.Amount(1)
 )
 
 // SpendableOut represents a transaction output that is spendable along with

--- a/blockchain/internal/testhelper/common.go
+++ b/blockchain/internal/testhelper/common.go
@@ -1,0 +1,31 @@
+package testhelper
+
+import (
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/wire"
+)
+
+// SpendableOut represents a transaction output that is spendable along with
+// additional metadata such as the block its in and how much it pays.
+type SpendableOut struct {
+	PrevOut wire.OutPoint
+	Amount  btcutil.Amount
+}
+
+// MakeSpendableOutForTx returns a spendable output for the given transaction
+// and transaction output index within the transaction.
+func MakeSpendableOutForTx(tx *wire.MsgTx, txOutIndex uint32) SpendableOut {
+	return SpendableOut{
+		PrevOut: wire.OutPoint{
+			Hash:  tx.TxHash(),
+			Index: txOutIndex,
+		},
+		Amount: btcutil.Amount(tx.TxOut[txOutIndex].Value),
+	}
+}
+
+// MakeSpendableOut returns a spendable output for the given block, transaction
+// index within the block, and transaction output index within the transaction.
+func MakeSpendableOut(block *wire.MsgBlock, txIndex, txOutIndex uint32) SpendableOut {
+	return MakeSpendableOutForTx(block.Transactions[txIndex], txOutIndex)
+}

--- a/blockchain/internal/testhelper/common.go
+++ b/blockchain/internal/testhelper/common.go
@@ -1,6 +1,10 @@
 package testhelper
 
 import (
+	"math"
+	"runtime"
+
+	"github.com/btcsuite/btcd/blockchain/internal/workmath"
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/wire"
 )
@@ -28,4 +32,69 @@ func MakeSpendableOutForTx(tx *wire.MsgTx, txOutIndex uint32) SpendableOut {
 // index within the block, and transaction output index within the transaction.
 func MakeSpendableOut(block *wire.MsgBlock, txIndex, txOutIndex uint32) SpendableOut {
 	return MakeSpendableOutForTx(block.Transactions[txIndex], txOutIndex)
+}
+
+// SolveBlock attempts to find a nonce which makes the passed block header hash
+// to a value less than the target difficulty.  When a successful solution is
+// found true is returned and the nonce field of the passed header is updated
+// with the solution.  False is returned if no solution exists.
+//
+// NOTE: This function will never solve blocks with a nonce of 0.  This is done
+// so the 'nextBlock' function can properly detect when a nonce was modified by
+// a munge function.
+func SolveBlock(header *wire.BlockHeader) bool {
+	// sbResult is used by the solver goroutines to send results.
+	type sbResult struct {
+		found bool
+		nonce uint32
+	}
+
+	// solver accepts a block header and a nonce range to test. It is
+	// intended to be run as a goroutine.
+	targetDifficulty := workmath.CompactToBig(header.Bits)
+	quit := make(chan bool)
+	results := make(chan sbResult)
+	solver := func(hdr wire.BlockHeader, startNonce, stopNonce uint32) {
+		// We need to modify the nonce field of the header, so make sure
+		// we work with a copy of the original header.
+		for i := startNonce; i >= startNonce && i <= stopNonce; i++ {
+			select {
+			case <-quit:
+				return
+			default:
+				hdr.Nonce = i
+				hash := hdr.BlockHash()
+				if workmath.HashToBig(&hash).Cmp(
+					targetDifficulty) <= 0 {
+
+					results <- sbResult{true, i}
+					return
+				}
+			}
+		}
+		results <- sbResult{false, 0}
+	}
+
+	startNonce := uint32(1)
+	stopNonce := uint32(math.MaxUint32)
+	numCores := uint32(runtime.NumCPU())
+	noncesPerCore := (stopNonce - startNonce) / numCores
+	for i := uint32(0); i < numCores; i++ {
+		rangeStart := startNonce + (noncesPerCore * i)
+		rangeStop := startNonce + (noncesPerCore * (i + 1)) - 1
+		if i == numCores-1 {
+			rangeStop = stopNonce
+		}
+		go solver(*header, rangeStart, rangeStop)
+	}
+	for i := uint32(0); i < numCores; i++ {
+		result := <-results
+		if result.found {
+			close(quit)
+			header.Nonce = result.nonce
+			return true
+		}
+	}
+
+	return false
 }

--- a/blockchain/internal/testhelper/common.go
+++ b/blockchain/internal/testhelper/common.go
@@ -1,6 +1,7 @@
 package testhelper
 
 import (
+	"encoding/binary"
 	"math"
 	"runtime"
 
@@ -19,6 +20,30 @@ var (
 	// readable.
 	LowFee = btcutil.Amount(1)
 )
+
+// OpReturnScript returns a provably-pruneable OP_RETURN script with the
+// provided data.
+func OpReturnScript(data []byte) ([]byte, error) {
+	builder := txscript.NewScriptBuilder()
+	script, err := builder.AddOp(txscript.OP_RETURN).AddData(data).Script()
+	if err != nil {
+		return nil, err
+	}
+	return script, nil
+}
+
+// UniqueOpReturnScript returns a standard provably-pruneable OP_RETURN script
+// with a random uint64 encoded as the data.
+func UniqueOpReturnScript() ([]byte, error) {
+	rand, err := wire.RandomUint64()
+	if err != nil {
+		return nil, err
+	}
+
+	data := make([]byte, 8)
+	binary.LittleEndian.PutUint64(data[0:8], rand)
+	return OpReturnScript(data)
+}
 
 // SpendableOut represents a transaction output that is spendable along with
 // additional metadata such as the block its in and how much it pays.

--- a/blockchain/internal/workmath/README.md
+++ b/blockchain/internal/workmath/README.md
@@ -1,0 +1,15 @@
+workmath
+==========
+
+[![Build Status](https://github.com/btcsuite/btcd/workflows/Build%20and%20Test/badge.svg)](https://github.com/btcsuite/btcd/actions)
+[![ISC License](http://img.shields.io/badge/license-ISC-blue.svg)](http://copyfree.org)
+[![GoDoc](https://img.shields.io/badge/godoc-reference-blue.svg)](https://pkg.go.dev/github.com/btcsuite/btcd/workmath)
+
+Package workmath provides utility functions that are related with calculating
+the work from difficulty bits.  This package was introduced to avoid import
+cycles in btcd.
+
+## License
+
+Package workmath is licensed under the [copyfree](http://copyfree.org) ISC
+License.

--- a/blockchain/internal/workmath/difficulty.go
+++ b/blockchain/internal/workmath/difficulty.go
@@ -1,0 +1,153 @@
+// Copyright (c) 2013-2017 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package workmath
+
+import (
+	"math/big"
+
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+)
+
+var (
+	// bigOne is 1 represented as a big.Int.  It is defined here to avoid
+	// the overhead of creating it multiple times.
+	bigOne = big.NewInt(1)
+
+	// oneLsh256 is 1 shifted left 256 bits.  It is defined here to avoid
+	// the overhead of creating it multiple times.
+	oneLsh256 = new(big.Int).Lsh(bigOne, 256)
+)
+
+// HashToBig converts a chainhash.Hash into a big.Int that can be used to
+// perform math comparisons.
+func HashToBig(hash *chainhash.Hash) *big.Int {
+	// A Hash is in little-endian, but the big package wants the bytes in
+	// big-endian, so reverse them.
+	buf := *hash
+	blen := len(buf)
+	for i := 0; i < blen/2; i++ {
+		buf[i], buf[blen-1-i] = buf[blen-1-i], buf[i]
+	}
+
+	return new(big.Int).SetBytes(buf[:])
+}
+
+// CompactToBig converts a compact representation of a whole number N to an
+// unsigned 32-bit number.  The representation is similar to IEEE754 floating
+// point numbers.
+//
+// Like IEEE754 floating point, there are three basic components: the sign,
+// the exponent, and the mantissa.  They are broken out as follows:
+//
+// - the most significant 8 bits represent the unsigned base 256 exponent
+// - bit 23 (the 24th bit) represents the sign bit
+// - the least significant 23 bits represent the mantissa
+//
+//	-------------------------------------------------
+//	|   Exponent     |    Sign    |    Mantissa     |
+//	-------------------------------------------------
+//	| 8 bits [31-24] | 1 bit [23] | 23 bits [22-00] |
+//	-------------------------------------------------
+//
+// The formula to calculate N is:
+//
+//	N = (-1^sign) * mantissa * 256^(exponent-3)
+//
+// This compact form is only used in bitcoin to encode unsigned 256-bit numbers
+// which represent difficulty targets, thus there really is not a need for a
+// sign bit, but it is implemented here to stay consistent with bitcoind.
+func CompactToBig(compact uint32) *big.Int {
+	// Extract the mantissa, sign bit, and exponent.
+	mantissa := compact & 0x007fffff
+	isNegative := compact&0x00800000 != 0
+	exponent := uint(compact >> 24)
+
+	// Since the base for the exponent is 256, the exponent can be treated
+	// as the number of bytes to represent the full 256-bit number.  So,
+	// treat the exponent as the number of bytes and shift the mantissa
+	// right or left accordingly.  This is equivalent to:
+	// N = mantissa * 256^(exponent-3)
+	var bn *big.Int
+	if exponent <= 3 {
+		mantissa >>= 8 * (3 - exponent)
+		bn = big.NewInt(int64(mantissa))
+	} else {
+		bn = big.NewInt(int64(mantissa))
+		bn.Lsh(bn, 8*(exponent-3))
+	}
+
+	// Make it negative if the sign bit is set.
+	if isNegative {
+		bn = bn.Neg(bn)
+	}
+
+	return bn
+}
+
+// BigToCompact converts a whole number N to a compact representation using
+// an unsigned 32-bit number.  The compact representation only provides 23 bits
+// of precision, so values larger than (2^23 - 1) only encode the most
+// significant digits of the number.  See CompactToBig for details.
+func BigToCompact(n *big.Int) uint32 {
+	// No need to do any work if it's zero.
+	if n.Sign() == 0 {
+		return 0
+	}
+
+	// Since the base for the exponent is 256, the exponent can be treated
+	// as the number of bytes.  So, shift the number right or left
+	// accordingly.  This is equivalent to:
+	// mantissa = mantissa / 256^(exponent-3)
+	var mantissa uint32
+	exponent := uint(len(n.Bytes()))
+	if exponent <= 3 {
+		mantissa = uint32(n.Bits()[0])
+		mantissa <<= 8 * (3 - exponent)
+	} else {
+		// Use a copy to avoid modifying the caller's original number.
+		tn := new(big.Int).Set(n)
+		mantissa = uint32(tn.Rsh(tn, 8*(exponent-3)).Bits()[0])
+	}
+
+	// When the mantissa already has the sign bit set, the number is too
+	// large to fit into the available 23-bits, so divide the number by 256
+	// and increment the exponent accordingly.
+	if mantissa&0x00800000 != 0 {
+		mantissa >>= 8
+		exponent++
+	}
+
+	// Pack the exponent, sign bit, and mantissa into an unsigned 32-bit
+	// int and return it.
+	compact := uint32(exponent<<24) | mantissa
+	if n.Sign() < 0 {
+		compact |= 0x00800000
+	}
+	return compact
+}
+
+// CalcWork calculates a work value from difficulty bits.  Bitcoin increases
+// the difficulty for generating a block by decreasing the value which the
+// generated hash must be less than.  This difficulty target is stored in each
+// block header using a compact representation as described in the documentation
+// for CompactToBig.  The main chain is selected by choosing the chain that has
+// the most proof of work (highest difficulty).  Since a lower target difficulty
+// value equates to higher actual difficulty, the work value which will be
+// accumulated must be the inverse of the difficulty.  Also, in order to avoid
+// potential division by zero and really small floating point numbers, the
+// result adds 1 to the denominator and multiplies the numerator by 2^256.
+func CalcWork(bits uint32) *big.Int {
+	// Return a work value of zero if the passed difficulty bits represent
+	// a negative number. Note this should not happen in practice with valid
+	// blocks, but an invalid block could trigger it.
+	difficultyNum := CompactToBig(bits)
+	if difficultyNum.Sign() <= 0 {
+		return big.NewInt(0)
+	}
+
+	// (1 << 256) / (difficultyNum + 1)
+	denominator := new(big.Int).Add(difficultyNum, bigOne)
+	return new(big.Int).Div(oneLsh256, denominator)
+}

--- a/blockchain/internal/workmath/difficulty_test.go
+++ b/blockchain/internal/workmath/difficulty_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-package blockchain
+package workmath
 
 import (
 	"math/big"


### PR DESCRIPTION
Adds `ReconsiderBlock()` on blockchain that will clear up any block validation statuses and re-validate the block. If the block is part of a longer chain, then the chain will reorganize to that chain.

Depends on #2155