### PR TITLE
blockchain, main: add and fix logs

### DIFF
--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -234,7 +234,7 @@ func newUtxoCache(db database.DB, maxTotalMemoryUsage uint64) *utxoCache {
 	numMaxElements := calculateMinEntries(int(maxTotalMemoryUsage), bucketSize+avgEntrySize)
 	numMaxElements -= 1
 
-	log.Infof("Pre-alloacting for %d MiB: ", maxTotalMemoryUsage/(1024*1024)+1)
+	log.Infof("Pre-alloacting for %d MiB", maxTotalMemoryUsage/(1024*1024)+1)
 
 	m := make(map[wire.OutPoint]*UtxoEntry, numMaxElements)
 

--- a/server.go
+++ b/server.go
@@ -2823,6 +2823,11 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 		checkpoints = mergeCheckpoints(s.chainParams.Checkpoints, cfg.addCheckpoints)
 	}
 
+	// Log that the node is pruned.
+	if cfg.Prune != 0 {
+		btcdLog.Infof("Prune set to %d MiB", cfg.Prune)
+	}
+
 	// Create a new block chain instance with the appropriate configuration.
 	var err error
 	s.chain, err = blockchain.New(&blockchain.Config{


### PR DESCRIPTION
The trailing `: ` is removed from the utxocache log. It just looks better.

If the node is pruned, we now log what MiB it's pruned to. Logging alerts the user that the node is pruned and it helps for debugging purposes as well since we can now see from the logging whether or not the node is pruned.