### PR TITLE
rpcclient: update error str to match both versions

### DIFF
--- a/rpcclient/errors.go
+++ b/rpcclient/errors.go
@@ -411,7 +411,10 @@ var BtcdErrMap = map[string]error{
 	"transaction already exists in blockchain":    ErrTxAlreadyConfirmed,
 
 	// A transaction in the mempool.
-	"already have transaction in mempool": ErrTxAlreadyInMempool,
+	//
+	// NOTE: For btcd v0.24.2 and beyond, the error message is "already
+	// have transaction in mempool".
+	"already have transaction": ErrTxAlreadyInMempool,
 
 	// A transaction with missing inputs, that never existed or only
 	// existed once in the past.


### PR DESCRIPTION
This commit updates the error str to match the same error returned from `btcd` for both pre-0.24.2 and post-0.24.2.