### PR TITLE
ffldb: close block files

### DIFF
--- a/database/ffldb/blockio.go
+++ b/database/ffldb/blockio.go
@@ -307,6 +307,11 @@ func (s *blockStore) openFile(fileNum uint32) (*lockableFile, error) {
 // other state cleanup necessary.
 func (s *blockStore) deleteFile(fileNum uint32) error {
 	filePath := blockFilePath(s.basePath, fileNum)
+	blockFile := s.openBlockFiles[fileNum]
+	if blockFile != nil {
+		err := fmt.Errorf("attempted to delete open file at %v", filePath)
+		return makeDbErr(database.ErrDriverSpecific, err.Error(), err)
+	}
 	if err := os.Remove(filePath); err != nil {
 		return makeDbErr(database.ErrDriverSpecific, err.Error(), err)
 	}

--- a/database/ffldb/db.go
+++ b/database/ffldb/db.go
@@ -1630,6 +1630,9 @@ func (tx *transaction) writePendingAndCommit() error {
 	// We do this first before doing any of the writes as we can't undo
 	// deletions of files.
 	for _, fileNum := range tx.pendingDelFileNums {
+		// Make sure the file is closed before attempting to delete it.
+		tx.db.store.closeFile(fileNum)
+
 		err := tx.db.store.deleteFileFunc(fileNum)
 		if err != nil {
 			// Nothing we can do if we fail to delete blocks besides

--- a/database/ffldb/driver_test.go
+++ b/database/ffldb/driver_test.go
@@ -335,6 +335,20 @@ func TestPrune(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// Open the first block file before the pruning happens in the
+		// code snippet below.  This let's us test that block files are
+		// properly closed before attempting to delete them.
+		err = db.View(func(tx database.Tx) error {
+			_, err := tx.FetchBlock(blocks[0].Hash())
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
 		var deletedBlocks []chainhash.Hash
 
 		// This should leave 3 files on disk.


### PR DESCRIPTION
On methods readBlock and readBlockRegion, the opened files were never closed which resulted in errors when attempting to delete these files on pruning on windows.  Properly closing the files avoids this error.

Doing a full block sync on windows to make sure. Definitely seems to be the fix as I'm not having any issues so far (few hours into ibd).