### PR TITLE
rpcclient: update `ErrTxAlreadyConfirmed` to match both versions

### DIFF
--- a/rpcclient/errors.go
+++ b/rpcclient/errors.go
@@ -406,9 +406,14 @@ var BtcdErrMap = map[string]error{
 	// A transaction with too many sigops.
 	"sigop cost is too hight": ErrTooManySigOps,
 
-	// A transaction already in the blockchain.
+	// A transaction already in the database.
 	"database contains entry for spent tx output": ErrTxAlreadyKnown,
-	"transaction already exists in blockchain":    ErrTxAlreadyConfirmed,
+
+	// A transaction already in the blockchain.
+	//
+	// NOTE: For btcd v0.24.2 and beyond, the error message is "transaction
+	// already exists in blockchain".
+	"transaction already exists": ErrTxAlreadyConfirmed,
 
 	// A transaction in the mempool.
 	//


### PR DESCRIPTION
This commit updates the error str to match the same error `ErrTxAlreadyConfirmed` returned from `btcd` for both pre-0.24.2 and post-0.24.2.