### PR TITLE
remove `error` return value for `SignCompact`

### DIFF
--- a/btcec/ecdsa/bench_test.go
+++ b/btcec/ecdsa/bench_test.go
@@ -170,7 +170,7 @@ func BenchmarkSignCompact(b *testing.B) {
 	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _ = SignCompact(privKey, msgHash, true)
+		_ = SignCompact(privKey, msgHash, true)
 	}
 }
 

--- a/btcec/ecdsa/signature.go
+++ b/btcec/ecdsa/signature.go
@@ -233,9 +233,9 @@ func ParseDERSignature(sigStr []byte) (*Signature, error) {
 // <(byte of 27+public key solution)+4 if compressed >< padded bytes for signature R><padded bytes for signature S>
 // where the R and S parameters are padde up to the bitlengh of the curve.
 func SignCompact(key *btcec.PrivateKey, hash []byte,
-	isCompressedKey bool) ([]byte, error) {
+	isCompressedKey bool) []byte {
 
-	return secp_ecdsa.SignCompact(key, hash, isCompressedKey), nil
+	return secp_ecdsa.SignCompact(key, hash, isCompressedKey)
 }
 
 // RecoverCompact verifies the compact signature "signature" of "hash" for the

--- a/btcec/ecdsa/signature_test.go
+++ b/btcec/ecdsa/signature_test.go
@@ -479,11 +479,7 @@ func testSignCompact(t *testing.T, tag string, curve *btcec.KoblitzCurve,
 	priv, _ := btcec.NewPrivateKey()
 
 	hashed := []byte("testing")
-	sig, err := SignCompact(priv, hashed, isCompressed)
-	if err != nil {
-		t.Errorf("%s: error signing: %s", tag, err)
-		return
-	}
+	sig := SignCompact(priv, hashed, isCompressed)
 
 	pk, wasCompressed, err := RecoverCompact(sig, hashed)
 	if err != nil {


### PR DESCRIPTION
There's no need for `error` since it's always `nil`.