### PR TITLE
rpcserver: fix `SignCompact`

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3595,14 +3595,7 @@ func handleSignMessageWithPrivKey(s *rpcServer, cmd interface{}, closeChan <-cha
 	wire.WriteVarString(&buf, 0, c.Message)
 	messageHash := chainhash.DoubleHashB(buf.Bytes())
 
-	sig, err := ecdsa.SignCompact(wif.PrivKey,
-		messageHash, wif.CompressPubKey)
-	if err != nil {
-		return nil, &btcjson.RPCError{
-			Code:    btcjson.ErrRPCInvalidAddressOrKey,
-			Message: "Sign failed",
-		}
-	}
+	sig := ecdsa.SignCompact(wif.PrivKey, messageHash, wif.CompressPubKey)
 
 	return base64.StdEncoding.EncodeToString(sig), nil
 }


### PR DESCRIPTION
Introduced in #2211, we need to update the `rpcserver.go` to use this method. In addition we need to tag a new version for `btcec`. We also need to update `lnd` when the version is tagged. Will update the relevant packages once it's tagged.