### PR TITLE
main: add flag to write execution traces

### DIFF
--- a/btcd.go
+++ b/btcd.go
@@ -14,6 +14,7 @@ import (
 	"runtime"
 	"runtime/debug"
 	"runtime/pprof"
+	"runtime/trace"
 
 	"github.com/btcsuite/btcd/blockchain/indexers"
 	"github.com/btcsuite/btcd/database"
@@ -98,6 +99,18 @@ func btcdMain(serverChan chan<- *server) error {
 		defer f.Close()
 		defer pprof.WriteHeapProfile(f)
 		defer runtime.GC()
+	}
+
+	// Write execution trace if requested.
+	if cfg.TraceProfile != "" {
+		f, err := os.Create(cfg.TraceProfile)
+		if err != nil {
+			btcdLog.Errorf("Unable to create execution trace: %v", err)
+			return err
+		}
+		trace.Start(f)
+		defer f.Close()
+		defer trace.Stop()
 	}
 
 	// Perform upgrades to btcd as new versions require it.

--- a/config.go
+++ b/config.go
@@ -114,6 +114,7 @@ type config struct {
 	ConnectPeers         []string      `long:"connect" description:"Connect only to the specified peers at startup"`
 	CPUProfile           string        `long:"cpuprofile" description:"Write CPU profile to the specified file"`
 	MemoryProfile        string        `long:"memprofile" description:"Write memory profile to the specified file"`
+	TraceProfile         string        `long:"traceprofile" description:"Write execution trace to the specified file"`
 	DataDir              string        `short:"b" long:"datadir" description:"Directory to store data"`
 	DbType               string        `long:"dbtype" description:"Database backend to use for the Block Chain"`
 	DebugLevel           string        `short:"d" long:"debuglevel" description:"Logging level for all subsystems {trace, debug, info, warn, error, critical} -- You may also specify <subsystem>=<level>,<subsystem2>=<level>,... to set the log level for individual subsystems -- Use show to list available subsystems"`


### PR DESCRIPTION
Execution traces are part of the go runtime tooling and is useful to check what is slowing down the ibd.  For example, a slow ibd because of slow block downloads from peers won't show up on cpu profiling but will on a trace.

Also execution tracing has [gotten a lot better](https://go.dev/blog/execution-traces-2024) with go 1.22