### PR TITLE
wire: check TXID length before creating outpoint

### DIFF
--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -229,6 +229,11 @@ func NewOutPointFromString(outpoint string) (*OutPoint, error) {
 	if len(parts) != 2 {
 		return nil, errors.New("outpoint should be of the form txid:index")
 	}
+
+	if len(parts[0]) != chainhash.MaxHashStringSize {
+		return nil, errors.New("outpoint txid should be 64 hex chars")
+	}
+
 	hash, err := chainhash.NewHashFromStr(parts[0])
 	if err != nil {
 		return nil, err

--- a/wire/msgtx_test.go
+++ b/wire/msgtx_test.go
@@ -850,6 +850,15 @@ func TestTxOutPointFromString(t *testing.T) {
 			err: false,
 		},
 		{
+			name:  "normal outpoint 2 with 31-byte txid",
+			input: "c7762a68ff164352bd31fd95fa875204e811c09acef40ba781787eb28e3b55:42",
+			result: &OutPoint{
+				Hash:  hashFromStr("c7762a68ff164352bd31fd95fa875204e811c09acef40ba781787eb28e3b55"),
+				Index: 42,
+			},
+			err: true,
+		},
+		{
 			name:   "bad string",
 			input:  "not_outpoint_not_outpoint_not_outpoint",
 			result: nil,


### PR DESCRIPTION
`chainhash.NewHashFromStr` will zero-pad the given string if it's smaller than 32 bytes / 64 hex chars.

That's fine, but when creating an OutPoint from a string, the TXID part of the string must be exactly 64 hex chars to (possibly) be a valid TXID. Right now, `NewOutPointFromString` accepts a TXID of less than 64 chars, and will end up padding the end with 0's.

This PR rejects incorrectly-sized TXID strings in `NewOutPointFromString`.

