### PR TITLE
log: pull in logrotator, switch to ZSTD compressor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/decred/dcrd/lru v1.0.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/jessevdk/go-flags v1.4.0
-	github.com/jrick/logrotate v1.0.0
+	github.com/klauspost/compress v1.17.9
 	github.com/stretchr/testify v1.8.4
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	golang.org/x/crypto v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -59,10 +59,11 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGARJA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
-github.com/jrick/logrotate v1.0.0 h1:lQ1bL/n9mBNeIXoTUoYRlK4dHuNJVofX9oWqBtPnSzI=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23 h1:FOOIBWrEkLgmlgGfMuZT83xIwfPDxEI2OHu6xUmJMFE=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
+github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
+github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/log.go
+++ b/log.go
@@ -23,7 +23,6 @@ import (
 	"github.com/btcsuite/btcd/txscript"
 
 	"github.com/btcsuite/btclog"
-	"github.com/jrick/logrotate/rotator"
 )
 
 // logWriter implements an io.Writer that outputs to both standard output and
@@ -52,7 +51,7 @@ var (
 
 	// logRotator is one of the logging outputs.  It should be closed on
 	// application shutdown.
-	logRotator *rotator.Rotator
+	logRotator *Rotator
 
 	adxrLog = backendLog.Logger("ADXR")
 	amgrLog = backendLog.Logger("AMGR")
@@ -115,7 +114,7 @@ func initLogRotator(logFile string) {
 		fmt.Fprintf(os.Stderr, "failed to create log directory: %v\n", err)
 		os.Exit(1)
 	}
-	r, err := rotator.New(logFile, 10*1024, false, 3)
+	r, err := NewRotatorWithCompressor(logFile, 10*1024, false, 3, Zstd)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create file rotator: %v\n", err)
 		os.Exit(1)

--- a/logrotator.go
+++ b/logrotator.go
@@ -1,0 +1,313 @@
+// Copyright (c) 2017, moshee
+// Copyright (c) 2017, Josh Rickmar <jrick@devio.us>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// * Redistributions of source code must retain the above copyright notice, this
+//   list of conditions and the following disclaimer.
+//
+// * Redistributions in binary form must reproduce the above copyright notice,
+//   this list of conditions and the following disclaimer in the documentation
+//   and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+// Package rotator implements a simple logfile rotator. Logs are read from an
+// io.Reader and are written to a file until they reach a specified size. The
+// log is then gzipped to another file and truncated.
+package main
+
+import (
+	"bufio"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/klauspost/compress/zstd"
+)
+
+// nl is a byte slice containing a newline byte.  It is used to avoid creating
+// additional allocations when writing newlines to the log file.
+var nl = []byte{'\n'}
+
+// Compressor represents the supported compression algorithms.
+type Compressor uint8
+
+const (
+	// Gzip is the gzip compression algorithm, implemented in the stdlib.
+	Gzip Compressor = 0
+
+	// Zstd is the zstd compression algorithm.
+	Zstd Compressor = 1
+)
+
+// Validate checks that the Compressor is valid, and returns the appropriate
+// file suffix for the compressed file.
+func (c Compressor) Validate() (string, error) {
+	switch c {
+	case Gzip:
+		return ".gz", nil
+	case Zstd:
+		return ".zst", nil
+
+	default:
+		return "", fmt.Errorf("unknown compression algorithm: %d", c)
+	}
+}
+
+// Init creates a new writer to use for compression.
+func (c Compressor) Init(w io.Writer) (io.WriteCloser, error) {
+	switch c {
+	case Gzip:
+		dst := gzip.NewWriter(w)
+		return dst, nil
+
+	case Zstd:
+		return zstd.NewWriter(w)
+
+	default:
+		return nil, fmt.Errorf("unknown compression algorithm: %d", c)
+	}
+}
+
+// A Rotator writes input to a file, splitting it up into gzipped chunks once
+// the filesize reaches a certain threshold.
+type Rotator struct {
+	size      int64
+	threshold int64
+	maxRolls  int
+	filename  string
+	out       *os.File
+	tee       bool
+	wg        sync.WaitGroup
+	comp      Compressor
+}
+
+// NewRotator returns a new Rotator. The rotator can be used either by reading
+// input from an io.Reader by calling Run, or writing directly to the Rotator
+// with Write. The default compression algorithm is Gzip.
+func NewRotator(filename string, thresholdKB int64, tee bool,
+	maxRolls int) (*Rotator, error) {
+
+	f, err := os.OpenFile(filename, os.O_CREATE|os.O_APPEND|os.O_RDWR, 0644)
+	if err != nil {
+		return nil, err
+	}
+
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	return &Rotator{
+		size:      stat.Size(),
+		threshold: 1000 * thresholdKB,
+		maxRolls:  maxRolls,
+		filename:  filename,
+		out:       f,
+		tee:       tee,
+		comp:      Gzip,
+	}, nil
+}
+
+// NewRotatorWithCompressor returns a new Rotator that will use a specific
+// compression algorithm.
+func NewRotatorWithCompressor(filename string, thresholdKB int64, tee bool,
+	maxRolls int, comp Compressor) (*Rotator, error) {
+
+	_, err := comp.Validate()
+	if err != nil {
+		return nil, err
+	}
+
+	rotator, err := NewRotator(filename, thresholdKB, tee, maxRolls)
+	if err != nil {
+		return nil, err
+	}
+
+	rotator.comp = comp
+
+	return rotator, nil
+}
+
+// Run begins reading lines from the reader and rotating logs as necessary.  Run
+// should not be called concurrently with Write.
+//
+// Prefer to use Rotator as a writer instead to avoid unnecessary scanning of
+// input, as this job is better handled using io.Pipe.
+func (r *Rotator) Run(reader io.Reader) error {
+	in := bufio.NewReader(reader)
+
+	// Rotate file immediately if it is already over the size limit.
+	if r.size >= r.threshold {
+		if err := r.rotate(); err != nil {
+			return err
+		}
+		r.size = 0
+	}
+
+	for {
+		line, isPrefix, err := in.ReadLine()
+		if err != nil {
+			return err
+		}
+
+		n, _ := r.out.Write(line)
+		r.size += int64(n)
+		if r.tee {
+			os.Stdout.Write(line)
+		}
+		if isPrefix {
+			continue
+		}
+
+		m, _ := r.out.Write(nl)
+		if r.tee {
+			os.Stdout.Write(nl)
+		}
+		r.size += int64(m)
+
+		if r.size >= r.threshold {
+			err := r.rotate()
+			if err != nil {
+				return err
+			}
+			r.size = 0
+		}
+	}
+}
+
+// Write implements the io.Writer interface for Rotator.  If p ends in a newline
+// and the file has exceeded the threshold size, the file is rotated.
+func (r *Rotator) Write(p []byte) (n int, err error) {
+	n, _ = r.out.Write(p)
+	r.size += int64(n)
+
+	if r.size >= r.threshold && len(p) > 0 && p[len(p)-1] == '\n' {
+		err := r.rotate()
+		if err != nil {
+			return 0, err
+		}
+		r.size = 0
+	}
+
+	return n, nil
+}
+
+// Close closes the output logfile.
+func (r *Rotator) Close() error {
+	err := r.out.Close()
+	r.wg.Wait()
+	return err
+}
+
+func (r *Rotator) rotate() error {
+	dir := filepath.Dir(r.filename)
+	glob := filepath.Join(dir, filepath.Base(r.filename)+".*")
+	existing, err := filepath.Glob(glob)
+	if err != nil {
+		return err
+	}
+
+	maxNum := 0
+	for _, name := range existing {
+		parts := strings.Split(name, ".")
+		if len(parts) < 2 {
+			continue
+		}
+		numIdx := len(parts) - 1
+		if parts[numIdx] == "gz" {
+			numIdx--
+		}
+		num, err := strconv.Atoi(parts[numIdx])
+		if err != nil {
+			continue
+		}
+		if num > maxNum {
+			maxNum = num
+		}
+	}
+
+	err = r.out.Close()
+	if err != nil {
+		return err
+	}
+	rotname := fmt.Sprintf("%s.%d", r.filename, maxNum+1)
+	err = os.Rename(r.filename, rotname)
+	if err != nil {
+		return err
+	}
+	if r.maxRolls > 0 {
+		for n := maxNum + 1 - r.maxRolls; ; n-- {
+			err := os.Remove(fmt.Sprintf("%s.%d.gz", r.filename, n))
+			if err != nil {
+				break
+			}
+		}
+	}
+	r.out, err = os.OpenFile(r.filename, os.O_CREATE|os.O_RDWR, 0644)
+	if err != nil {
+		return err
+	}
+
+	r.wg.Add(1)
+	go func() {
+		err := compress(rotname, r.comp)
+		if err == nil {
+			os.Remove(rotname)
+		}
+		r.wg.Done()
+	}()
+
+	return nil
+}
+
+func compress(name string, comp Compressor) (err error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	suffix, err := comp.Validate()
+	if err != nil {
+		return err
+	}
+
+	arc, err := os.OpenFile(
+		name+suffix, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0644,
+	)
+	if err != nil {
+		return err
+	}
+
+	z, err := comp.Init(arc)
+	if err != nil {
+		return err
+	}
+
+	if _, err = io.Copy(z, f); err != nil {
+		return err
+	}
+	if err = z.Close(); err != nil {
+		return err
+	}
+	return arc.Close()
+}


### PR DESCRIPTION
The log rotator we currently use is from a now-unmaintained repo: https://github.com/jrick/logrotate/tree/master

Which is fine, it works. But this issue https://github.com/lightninglabs/taproot-assets/issues/1084 prompted me to look at how we could switch from gzip to zstd for log compression (better compression at the default level: https://pkg.go.dev/github.com/klauspost/compress/zstd#readme-performance).

Since the log rotator is one short file, it seems easiest to just pull it into this repo directly vs. fork the `logrotate` package and release this updated version with ZSTD support, and then pull that in as a dependency.

If this gets merged to `btcd`, we could do the same `lnd` and then drop the `logrotate` dependency there as well. Once it's in the lnd `build` package, it could be used from the `taproot-assets` project.

The diff from upstream `logrotate` is quite small, and can be checked easily:

```bash
wget https://github.com/jrick/logrotate/raw/master/rotator/rotator.go
wget https://github.com/jharveyb/btcd/raw/logrotator_vendor_zstd/logrotator.go
diff -y --suppress-common-lines rotator.go logrotator.go
```

This is a more minimal diff from difftastic (https://difftastic.wilfred.me.uk/) with upstream on the left, and my version on the right:

<details>

```go
logrotator.go --- 1/6 --- Go
14 //                                                      14 //
15 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS A 15 // THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS A
.. ND CONTRIBUTORS "AS IS"                                 .. ND CONTRIBUTORS "AS IS"
16 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BU 16 // AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BU
.. T NOT LIMITED TO, THE                                   .. T NOT LIMITED TO, THE
17 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FO 17 // IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FO
.. R A PARTICULAR PURPOSE ARE                              .. R A PARTICULAR PURPOSE
18 // DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER O 18 // ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLD
.. R CONTRIBUTORS BE LIABLE                                .. ER OR CONTRIBUTORS BE
19 // FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMP 19 // LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL
.. LARY, OR CONSEQUENTIAL                                  .. , EXEMPLARY, OR
20 // DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT  20 // CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO
.. OF SUBSTITUTE GOODS OR                                  .. , PROCUREMENT OF
21 // SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 21 // SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
..  INTERRUPTION) HOWEVER                                  .. PROFITS; OR BUSINESS
22 // CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CO 22 // INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LI
.. NTRACT, STRICT LIABILITY,                               .. ABILITY, WHETHER IN
23 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING  23 // CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLI
.. IN ANY WAY OUT OF THE USE                               .. GENCE OR OTHERWISE)
24 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 24 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, 
..  OF SUCH DAMAGE.                                        .. EVEN IF ADVISED OF THE
..                                                         25 // POSSIBILITY OF SUCH DAMAGE.
25                                                         26 
26 // Package rotator implements a simple logfile rotator. 27 // Package rotator implements a simple logfile rotator.
..  Logs are read from an                                  ..  Logs are read from an
27 // io.Reader and are written to a file until they reach 28 // io.Reader and are written to a file until they reach
..  a specified size. The                                  ..  a specified size. The
28 // log is then gzipped to another file and truncated.   29 // log is then gzipped to another file and truncated.
29 package rotator                                         30 package main
30                                                         31 
31 import (                                                32 import (
32     "bufio"                                             33     "bufio"

logrotator.go --- 2/6 --- Go
39 40     "strings"
40 41     "sync"
.. 42 
.. 43     "github.com/klauspost/compress/zstd"
41 44 )
42 45 
43 46 // nl is a byte slice containing a newline byte.  It is used to avoid creating
44 47 // additional allocations when writing newlines to the log file.
45 48 var nl = []byte{'\n'}
.. 49 
.. 50 // Compressor represents the supported compression algorithms.
.. 51 type Compressor uint8
.. 52 
.. 53 const (
.. 54     // Gzip is the gzip compression algorithm, implemented in the stdlib.
.. 55     Gzip Compressor = 0
.. 56 
.. 57     // Zstd is the zstd compression algorithm.
.. 58     Zstd Compressor = 1
.. 59 )
.. 60 
.. 61 // Validate checks that the Compressor is valid, and returns the appropriate
.. 62 // file suffix for the compressed file.
.. 63 func (c Compressor) Validate() (string, error) {
.. 64     switch c {
.. 65     case Gzip:
.. 66         return ".gz", nil
.. 67     case Zstd:
.. 68         return ".zst", nil
.. 69 
.. 70     default:
.. 71         return "", fmt.Errorf("unknown compression algorithm: %d", c)
.. 72     }
.. 73 }
.. 74 
.. 75 // Init creates a new writer to use for compression.
.. 76 func (c Compressor) Init(w io.Writer) (io.WriteCloser, error) {
.. 77     switch c {
.. 78     case Gzip:
.. 79         dst := gzip.NewWriter(w)
.. 80         return dst, nil
.. 81 
.. 82     case Zstd:
.. 83         return zstd.NewWriter(w)
.. 84 
.. 85     default:
.. 86         return nil, fmt.Errorf("unknown compression algorithm: %d", c)
.. 87     }
.. 88 }
46 89 
47 90 // A Rotator writes input to a file, splitting it up into gzipped chunks once
48 91 // the filesize reaches a certain threshold.

logrotator.go --- 3/6 --- Go
54     out       *os.File                                  97     out       *os.File
55     tee       bool                                      98     tee       bool
56     wg        sync.WaitGroup                            99     wg        sync.WaitGroup
..                                                        100     comp      Compressor
57 }                                                      101 }
58                                                        102 
59 // New returns a new Rotator.  The rotator can be used 103 // NewRotator returns a new Rotator. The rotator can b
..  either by reading input                               ... e used either by reading
60 // from an io.Reader by calling Run, or writing direct 104 // input from an io.Reader by calling Run, or writing 
.. ly to the Rotator with                                 ... directly to the Rotator
61 // Write.                                              105 // with Write. The default compression algorithm is Gz
..                                                        ... ip.
62 func New(filename string, thresholdKB int64, tee bool, 106 func NewRotator(filename string, thresholdKB int64, te
..  maxRolls int) (*Rotator, error) {                     ... e bool,
..                                                        107     maxRolls int) (*Rotator, error) {
..                                                        108 
63     f, err := os.OpenFile(filename, os.O_CREATE|os.O_A 109     f, err := os.OpenFile(filename, os.O_CREATE|os.O_A
   PPEND|os.O_RDWR, 0644)                                     PPEND|os.O_RDWR, 0644)

logrotator.go --- 4/6 --- Go
77 123         filename:  filename,
78 124         out:       f,
79 125         tee:       tee,
.. 126         comp:      Gzip,
80 127     }, nil
81 128 }
.. 129 
.. 130 // NewRotatorWithCompressor returns a new Rotator that will use a specific
.. 131 // compression algorithm.
.. 132 func NewRotatorWithCompressor(filename string, thresholdKB int64, tee bool,
.. 133     maxRolls int, comp Compressor) (*Rotator, error) {
.. 134 
.. 135     _, err := comp.Validate()
.. 136     if err != nil {
.. 137         return nil, err
.. 138     }
.. 139 
.. 140     rotator, err := NewRotator(filename, thresholdKB, tee, maxRolls)
.. 141     if err != nil {
.. 142         return nil, err
.. 143     }
.. 144 
.. 145     rotator.comp = comp
.. 146 
.. 147     return rotator, nil
.. 148 }
82 149 
83 150 // Run begins reading lines from the reader and rotating logs as necessary.  Run
84 151 // should not be called concurrently with Write.

logrotator.go --- 5/6 --- Go
202 269 
203 270     r.wg.Add(1)
204 271     go func() {
205 272         err := compress(rotname, r.comp)
206 273         if err == nil {
207 274             os.Remove(rotname)
208 275         }

logrotator.go --- 6/6 --- Go
212     return nil                                         279     return nil
213 }                                                      280 }
214                                                        281 
215 func compress(name string) (err error) {               282 func compress(name string, comp Compressor) (err error
...                                                        ... ) {
216     f, err := os.Open(name)                            283     f, err := os.Open(name)
217     if err != nil {                                    284     if err != nil {
218         return err                                     285         return err
219     }                                                  286     }
220     defer f.Close()                                    287     defer f.Close()
...                                                        288 
...                                                        289     suffix, err := comp.Validate()
...                                                        290     if err != nil {
...                                                        291         return err
...                                                        292     }
221                                                        293 
222     arc, err := os.OpenFile(name+".gz", os.O_CREATE|os 294     arc, err := os.OpenFile(
... .O_EXCL|os.O_WRONLY, 0644)                             ... 
...                                                        295         name+suffix, os.O_CREATE|os.O_EXCL|os.O_WRONLY
...                                                        ... , 0644,
...                                                        296     )
223     if err != nil {                                    297     if err != nil {
224         return err                                     298         return err
225     }                                                  299     }
226                                                        300 
227     z := gzip.NewWriter(arc)                           301     z, err := comp.Init(arc)
...                                                        302     if err != nil {
...                                                        303         return err
...                                                        304     }
...                                                        305 
228     if _, err = io.Copy(z, f); err != nil {            306     if _, err = io.Copy(z, f); err != nil {
229         return err                                     307         return err
```

</details>