### PR TITLE
bugfix: check if both begin and end are numbers in `UnmarshalJSON`

### DIFF
--- a/btcjson/walletsvrcmds.go
+++ b/btcjson/walletsvrcmds.go
@@ -903,9 +903,14 @@ func (r *DescriptorRange) UnmarshalJSON(data []byte) error {
 		if len(v) != 2 {
 			return fmt.Errorf("expected [begin,end] integer range, got: %v", unmarshalled)
 		}
+		begin, ok1 := v[0].(float64)
+		end, ok2 := v[1].(float64)
+		if !ok1 || !ok2 {
+			return fmt.Errorf("expected both begin and end to be numbers, got: %v", v)
+		}
 		r.Value = []int{
-			int(v[0].(float64)),
-			int(v[1].(float64)),
+			int(begin),
+			int(end),
 		}
 	default:
 		return fmt.Errorf("invalid descriptor range value: %v", unmarshalled)


### PR DESCRIPTION
In the current code, if we provide a non-number value (e.g. `"method":"deriveaddresses","params":["A",["A","B"]]`), it might cause a panic. This PR fixes it.