### PR TITLE
peer: catch `MsgWTxIdRelay` during handshake

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -2190,11 +2190,18 @@ func (p *Peer) waitToFinishNegotiation(pver uint32) error {
 					p.cfg.Listeners.OnSendAddrV2(p, m)
 				}
 			}
+
+		// Receiving a verack means we are done with the handshake.
 		case *wire.MsgVerAck:
-			// Receiving a verack means we are done with the
-			// handshake.
 			p.processRemoteVerAckMsg(m)
 			return nil
+
+		// Received an optional wtxidrelay message.
+		//
+		// TODO(yy): We ignore it atm, but should figure out how to
+		// process it?
+		case *wire.MsgWTxIdRelay:
+
 		default:
 			// This is triggered if the peer sends, for example, a
 			// GETDATA message during this negotiation.


### PR DESCRIPTION
When initializing a connection, `bitcoind` will send three msgs, `version`, `wtxidrelay`, and `sendaddrv2`, as shown in the logs,
```
2024-11-27T08:20:50Z [net] Added connection peer=1
2024-11-27T08:20:50Z [net] sending version (102 bytes) peer=1
2024-11-27T08:20:50Z [net] send version message: version 70016, blocks=0, txrelay=1, peer=1
2024-11-27T08:20:50Z [net] received: version (113 bytes) peer=1
2024-11-27T08:20:50Z [net] sending wtxidrelay (0 bytes) peer=1
2024-11-27T08:20:50Z [net] sending sendaddrv2 (0 bytes) peer=1
2024-11-27T08:20:50Z [net] socket recv error for peer=1: Connection reset by peer (54)
```

Prior to #2272, upon receiving `wtxidrelay` msg, `btcd` will consider it as unknown and ignore it during the handshake,
https://github.com/btcsuite/btcd/blob/e9d95eed43d2c7e8afb2c3b7d1165dffe713e132/peer/peer.go#L2174-L2180

However, since `btcd` is now aware of `MsgWTxIdRelay`, it will cause the handshake to fail. It looks like we don't update the peer's state based on this msg, so we can ignore it during the handshake.