### PR TITLE
txscript: add more detail to invalid tapscript merkle proof error

### DIFF
--- a/txscript/taproot.go
+++ b/txscript/taproot.go
@@ -353,7 +353,10 @@ func VerifyTaprootLeafCommitment(controlBlock *ControlBlock,
 	expectedWitnessProgram := schnorr.SerializePubKey(taprootKey)
 	if !bytes.Equal(expectedWitnessProgram, taprootWitnessProgram) {
 
-		return scriptError(ErrTaprootMerkleProofInvalid, "")
+		str := fmt.Sprintf("derived witness program: %x, expected: "+
+			"%x, using tapscript_root: %x", expectedWitnessProgram,
+			taprootWitnessProgram, rootHash)
+		return scriptError(ErrTaprootMerkleProofInvalid, str)
 	}
 
 	// Finally, we'll verify that the parity of the y coordinate of the


### PR DESCRIPTION
In this commit, we add more detail to the invalid tapscript merkle proof error. Before this commit, the error was blank, making such a case hard to debug. We'll now log the expected witness program, what we derived, and also the passed in tapscript root.