### PR TITLE
typo-Update register_test.go

### DIFF
--- a/btcjson/register_test.go
+++ b/btcjson/register_test.go
@@ -231,7 +231,7 @@ func TestMustRegisterCmdPanic(t *testing.T) {
 	t.Parallel()
 
 	// Setup a defer to catch the expected panic to ensure it actually
-	// paniced.
+	// panicked.
 	defer func() {
 		if err := recover(); err == nil {
 			t.Error("MustRegisterCmd did not panic as expected")


### PR DESCRIPTION
# Fix: Corrected typo in source file

## Changes
1. **File**: `btcjson/register_test.go`
   - Corrected "paniced" to "panicked".

## Purpose
- Improved code comments by fixing the typographical error.
- Enhanced the clarity and professionalism of the codebase.
