### PR TITLE
chore: fix some function names in comment

### DIFF
--- a/wire/msgfilterload_test.go
+++ b/wire/msgfilterload_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-// TestFilterCLearLatest tests the MsgFilterLoad API against the latest protocol
+// TestFilterLoadLatest tests the MsgFilterLoad API against the latest protocol
 // version.
 func TestFilterLoadLatest(t *testing.T) {
 	pver := ProtocolVersion

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -1008,7 +1008,7 @@ func writeOutPointBuf(w io.Writer, pver uint32, version int32, op *OutPoint,
 	return err
 }
 
-// readScript reads a variable length byte array that represents a transaction
+// readScriptBuf reads a variable length byte array that represents a transaction
 // script.  It is encoded as a varInt containing the length of the array
 // followed by the bytes themselves.  An error is returned if the length is
 // greater than the passed maxAllowed parameter which helps protect against

--- a/wire/msgtx_test.go
+++ b/wire/msgtx_test.go
@@ -184,7 +184,7 @@ func TestTxHash(t *testing.T) {
 	}
 }
 
-// TestTxSha tests the ability to generate the wtxid, and txid of a transaction
+// TestWTxSha tests the ability to generate the wtxid, and txid of a transaction
 // with witness inputs accurately.
 func TestWTxSha(t *testing.T) {
 	hashStrTxid := "0f167d1385a84d1518cfee208b653fc9163b605ccf1b75347e2850b3e2eb19f3"


### PR DESCRIPTION
 fix some function names in comment