### PR TITLE
rpcclient: clarify GetBlockCount description

### DIFF
--- a/rpcclient/chain.go
+++ b/rpcclient/chain.go
@@ -275,8 +275,8 @@ func (c *Client) GetBlockVerboseTx(blockHash *chainhash.Hash) (*btcjson.GetBlock
 // GetBlockCountAsync RPC invocation (or an applicable error).
 type FutureGetBlockCountResult chan *Response
 
-// Receive waits for the Response promised by the future and returns the number
-// of blocks in the longest block chain.
+// Receive waits for the Response promised by the future and returns the height
+// of the most-work fully-validated chain. The genesis block has height 0.
 func (r FutureGetBlockCountResult) Receive() (int64, error) {
 	res, err := ReceiveFuture(r)
 	if err != nil {
@@ -302,7 +302,8 @@ func (c *Client) GetBlockCountAsync() FutureGetBlockCountResult {
 	return c.SendCmd(cmd)
 }
 
-// GetBlockCount returns the number of blocks in the longest block chain.
+// GetBlockCount returns the height of the most-work fully-validated chain.
+// The genesis block has height 0.
 func (c *Client) GetBlockCount() (int64, error) {
 	return c.GetBlockCountAsync().Receive()
 }


### PR DESCRIPTION
`GetBlockCount` returns the height of the latest block, not the total number of blocks. The genesis block has a height of 0.

The previous description could lead to an off-by-one error for anyone relying on it.