### PR TITLE
fix: correct typo in comments

### DIFF
--- a/btcutil/psbt/psbt_test.go
+++ b/btcutil/psbt/psbt_test.go
@@ -1546,7 +1546,7 @@ func TestWitnessForNonWitnessUtxo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to sign with pubkey 1: %v", err)
 	}
-	if res != SignSuccessful {
+	if res != SignSuccesful {
 		t.Fatalf("signing was not successful, got result %v", res)
 	}
 
@@ -1567,7 +1567,7 @@ func TestWitnessForNonWitnessUtxo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to sign with pubkey 2: %v", err)
 	}
-	if res != SignSuccessful {
+	if res != SignSuccesful {
 		t.Fatalf("signing was not successful, got result %v", res)
 	}
 

--- a/btcutil/psbt/psbt_test.go
+++ b/btcutil/psbt/psbt_test.go
@@ -1546,7 +1546,7 @@ func TestWitnessForNonWitnessUtxo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to sign with pubkey 1: %v", err)
 	}
-	if res != SignSuccesful {
+	if res != SignSuccessful {
 		t.Fatalf("signing was not successful, got result %v", res)
 	}
 
@@ -1567,7 +1567,7 @@ func TestWitnessForNonWitnessUtxo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to sign with pubkey 2: %v", err)
 	}
-	if res != SignSuccesful {
+	if res != SignSuccessful {
 		t.Fatalf("signing was not successful, got result %v", res)
 	}
 

--- a/rpcclient/errors.go
+++ b/rpcclient/errors.go
@@ -174,7 +174,7 @@ const (
 	ErrDust
 
 	// ErrMultiOpReturn is returned when the transactions are not standard
-	// - muiltiple OP_RETURNs.
+	// - multiple OP_RETURNs.
 	ErrMultiOpReturn
 
 	// ErrNonFinal is returned when spending a timelocked transaction that
@@ -451,7 +451,7 @@ var BtcdErrMap = map[string]error{
 	// Some nonstandard transactions - output too small.
 	"payment is dust": ErrDust,
 
-	// Some nonstandard transactions - muiltiple OP_RETURNs.
+	// Some nonstandard transactions - multiple OP_RETURNs.
 	"more than one transaction output in a nulldata script": ErrMultiOpReturn,
 
 	// A timelocked transaction.


### PR DESCRIPTION
Fixed typos in comments where the words were incorrectly written in several places

