### PR TITLE
musig2: Add adaptor signature support to MuSig2 protocol

### DIFF
--- a/btcec/schnorr/musig2/context.go
+++ b/btcec/schnorr/musig2/context.go
@@ -620,7 +620,7 @@ func (s *Session) SetAdaptorSecret(msg [32]byte,
 		return ErrAlreadySigned
 	}
 
-	nonce, _, err := computeSigningNonce(
+	nonce, _, err := ComputeSigningNonce(
 		*s.combinedNonce, s.ctx.combinedKey.FinalKey, msg,
 	)
 	if err != nil {
@@ -663,7 +663,7 @@ func (s *Session) SetAdaptorPoint(msg [32]byte,
 
 	// Verify that the adaptor point added to the combined nonce will result in
 	// a point with even y-coordinate.
-	nonce, _, err := computeSigningNonce(
+	nonce, _, err := ComputeSigningNonce(
 		*s.combinedNonce, s.ctx.combinedKey.FinalKey, msg,
 	)
 	if err != nil {
@@ -811,7 +811,7 @@ func (s *Session) FinalSig() *schnorr.Signature {
 
 // AdaptFinalSig adapts the final signature with the provided adaptor secret
 // key, and returns a valid signature.
-func (s *Session) AdaptFinalSig(adaptorSecret *btcec.ModNScalar) (
+func (s *Session) AdaptFinalSig() (
 	*schnorr.Signature, error) {
 
 	if s.finalSig == nil {
@@ -827,7 +827,7 @@ func (s *Session) AdaptFinalSig(adaptorSecret *btcec.ModNScalar) (
 	sigS := new(btcec.ModNScalar)
 	sigS.SetByteSlice(sigB[32:64])
 
-	sigS.Add(adaptorSecret)
+	sigS.Add(s.adaptorSecret)
 	adaptedSig := schnorr.NewSignature(r, sigS)
 
 	if !adaptedSig.Verify(s.msg[:], s.ctx.combinedKey.FinalKey) {

--- a/btcec/schnorr/musig2/sign.go
+++ b/btcec/schnorr/musig2/sign.go
@@ -207,9 +207,9 @@ func WithBip86SignTweak() SignOption {
 	}
 }
 
-// computeSigningNonce calculates the final nonce used for signing. This will
+// ComputeSigningNonce calculates the final nonce used for signing. This will
 // be the R value used in the final signature.
-func computeSigningNonce(combinedNonce [PubNonceSize]byte,
+func ComputeSigningNonce(combinedNonce [PubNonceSize]byte,
 	combinedKey *btcec.PublicKey, msg [32]byte) (
 	*btcec.JacobianPoint, *btcec.ModNScalar, error) {
 
@@ -325,7 +325,7 @@ func Sign(secNonce [SecNonceSize]byte, privKey *btcec.PrivateKey,
 	// We'll now combine both the public nonces, using the blinding factor
 	// to tweak the second nonce:
 	//  * R = R_1 + b*R_2
-	nonce, nonceBlinder, err := computeSigningNonce(
+	nonce, nonceBlinder, err := ComputeSigningNonce(
 		combinedNonce, combinedKey.FinalKey, msg,
 	)
 	if err != nil {

--- a/btcec/schnorr/musig2/sign_test.go
+++ b/btcec/schnorr/musig2/sign_test.go
@@ -371,7 +371,7 @@ func TestMusig2SignCombine(t *testing.T) {
 			combinedNonce, err := AggregateNonces(pubNonces)
 			require.NoError(t, err)
 
-			finalNonceJ, _, err := computeSigningNonce(
+			finalNonceJ, _, err := ComputeSigningNonce(
 				combinedNonce, combinedKey.FinalKey, msg,
 			)
 
@@ -474,7 +474,7 @@ func TestMusig2SignCombineAdaptor(t *testing.T) {
 
 		// Signer 0, the one that knows the adaptor secret, adapts the
 		// final signature.
-		validSig, err := sessions[0].AdaptFinalSig(adaptorSecret)
+		validSig, err := sessions[0].AdaptFinalSig()
 		require.NoError(t, err)
 
 		// Verify the final signature is valid under the combined key.


### PR DESCRIPTION
This commit adds comprehensive support for adaptor signatures in the MuSig2 protocol, including:

- New methods for generating and setting adaptor points
- Support for creating partial adaptor signatures
- Methods to adapt final signatures and recover adaptor secrets
- Updated signature verification and combination logic
- Added test cases for adaptor signature functionality across different signer configurations