### PR TITLE
refactor: use errors.New to replace fmt.Errorf with no parameters & fix typo

### DIFF
--- a/btcec/schnorr/musig2/context.go
+++ b/btcec/schnorr/musig2/context.go
@@ -3,8 +3,7 @@
 package musig2
 
 import (
-	"fmt"
-
+	"errors"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
 )
@@ -13,52 +12,52 @@ var (
 	// ErrSignersNotSpecified is returned when a caller attempts to create
 	// a context without specifying either the total number of signers, or
 	// the complete set of singers.
-	ErrSignersNotSpecified = fmt.Errorf("total number of signers or all " +
+	ErrSignersNotSpecified = errors.New("total number of signers or all " +
 		"signers must be known")
 
 	// ErrSignerNotInKeySet is returned when a the private key for a signer
 	// isn't included in the set of signing public keys.
-	ErrSignerNotInKeySet = fmt.Errorf("signing key is not found in key" +
+	ErrSignerNotInKeySet = errors.New("signing key is not found in key" +
 		" set")
 
 	// ErrAlredyHaveAllNonces is called when RegisterPubNonce is called too
 	// many times for a given signing session.
-	ErrAlredyHaveAllNonces = fmt.Errorf("already have all nonces")
+	ErrAlredyHaveAllNonces = errors.New("already have all nonces")
 
 	// ErrNotEnoughSigners is returned when a caller attempts to create a
 	// session from a context, but before all the required signers are
 	// known.
-	ErrNotEnoughSigners = fmt.Errorf("not enough signers")
+	ErrNotEnoughSigners = errors.New("not enough signers")
 
 	// ErrAlredyHaveAllNonces is returned when a caller attempts to
 	// register a signer, once we already have the total set of known
 	// signers.
-	ErrAlreadyHaveAllSigners = fmt.Errorf("all signers registered")
+	ErrAlreadyHaveAllSigners = errors.New("all signers registered")
 
 	// ErrAlredyHaveAllSigs is called when CombineSig is called too many
 	// times for a given signing session.
-	ErrAlredyHaveAllSigs = fmt.Errorf("already have all sigs")
+	ErrAlredyHaveAllSigs = errors.New("already have all sigs")
 
 	// ErrSigningContextReuse is returned if a user attempts to sign using
 	// the same signing context more than once.
-	ErrSigningContextReuse = fmt.Errorf("nonce already used")
+	ErrSigningContextReuse = errors.New("nonce already used")
 
 	// ErrFinalSigInvalid is returned when the combined signature turns out
 	// to be invalid.
-	ErrFinalSigInvalid = fmt.Errorf("final signature is invalid")
+	ErrFinalSigInvalid = errors.New("final signature is invalid")
 
 	// ErrCombinedNonceUnavailable is returned when a caller attempts to
 	// sign a partial signature, without first having collected all the
 	// required combined nonces.
-	ErrCombinedNonceUnavailable = fmt.Errorf("missing combined nonce")
+	ErrCombinedNonceUnavailable = errors.New("missing combined nonce")
 
 	// ErrTaprootInternalKeyUnavailable is returned when a user attempts to
 	// obtain the
-	ErrTaprootInternalKeyUnavailable = fmt.Errorf("taproot tweak not used")
+	ErrTaprootInternalKeyUnavailable = errors.New("taproot tweak not used")
 
 	// ErrNotEnoughSigners is returned if a caller attempts to obtain an
 	// early nonce when it wasn't specified
-	ErrNoEarlyNonce = fmt.Errorf("no early nonce available")
+	ErrNoEarlyNonce = errors.New("no early nonce available")
 )
 
 // Context is a managed signing context for musig2. It takes care of things

--- a/btcec/schnorr/musig2/keys.go
+++ b/btcec/schnorr/musig2/keys.go
@@ -4,7 +4,7 @@ package musig2
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"sort"
 
 	secp "github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -25,11 +25,11 @@ var (
 
 	// ErrTweakedKeyIsInfinity is returned if while tweaking a key, we end
 	// up with the point at infinity.
-	ErrTweakedKeyIsInfinity = fmt.Errorf("tweaked key is infinity point")
+	ErrTweakedKeyIsInfinity = errors.New("tweaked key is infinity point")
 
 	// ErrTweakedKeyOverflows is returned if a tweaking key is larger than
 	// 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141.
-	ErrTweakedKeyOverflows = fmt.Errorf("tweaked key is too large")
+	ErrTweakedKeyOverflows = errors.New("tweaked key is too large")
 )
 
 // sortableKeys defines a type of slice of public keys that implements the sort

--- a/btcec/schnorr/musig2/sign.go
+++ b/btcec/schnorr/musig2/sign.go
@@ -4,7 +4,7 @@ package musig2
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io"
 
 	secp "github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -24,28 +24,28 @@ var (
 
 	// ErrNoncePointAtInfinity is returned if during signing, the fully
 	// combined public nonce is the point at infinity.
-	ErrNoncePointAtInfinity = fmt.Errorf("signing nonce is the infinity " +
+	ErrNoncePointAtInfinity = errors.New("signing nonce is the infinity " +
 		"point")
 
 	// ErrPrivKeyZero is returned when the private key for signing is
 	// actually zero.
-	ErrPrivKeyZero = fmt.Errorf("priv key is zero")
+	ErrPrivKeyZero = errors.New("priv key is zero")
 
 	// ErrPartialSigInvalid is returned when a partial is found to be
 	// invalid.
-	ErrPartialSigInvalid = fmt.Errorf("partial signature is invalid")
+	ErrPartialSigInvalid = errors.New("partial signature is invalid")
 
 	// ErrSecretNonceZero is returned when a secret nonce is passed in a
 	// zero.
-	ErrSecretNonceZero = fmt.Errorf("secret nonce is blank")
+	ErrSecretNonceZero = errors.New("secret nonce is blank")
 
 	// ErrSecNoncePubkey is returned when the signing key does not match the
 	// sec nonce pubkey
-	ErrSecNoncePubkey = fmt.Errorf("public key does not match secnonce")
+	ErrSecNoncePubkey = errors.New("public key does not match secnonce")
 
 	// ErrPubkeyNotIncluded is returned when the signers pubkey is not included
 	// in the list of pubkeys.
-	ErrPubkeyNotIncluded = fmt.Errorf("signer's pubkey must be included" +
+	ErrPubkeyNotIncluded = errors.New("signer's pubkey must be included" +
 		" in the list of pubkeys")
 )
 
@@ -397,7 +397,7 @@ func Sign(secNonce [SecNonceSize]byte, privKey *btcec.PrivateKey,
 			signOpts...,
 		)
 		if !sigValid {
-			return nil, fmt.Errorf("sig is invalid!")
+			return nil, errors.New("sig is invalid!")
 		}
 	}
 

--- a/btcec/schnorr/pubkey.go
+++ b/btcec/schnorr/pubkey.go
@@ -6,6 +6,7 @@
 package schnorr
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2"
@@ -22,7 +23,7 @@ const (
 // the BIP-340 32-byte format.
 func ParsePubKey(pubKeyStr []byte) (*btcec.PublicKey, error) {
 	if pubKeyStr == nil {
-		err := fmt.Errorf("nil pubkey byte string")
+		err := errors.New("nil pubkey byte string")
 		return nil, err
 	}
 	if len(pubKeyStr) != PubKeyBytesLen {

--- a/btcutil/gcs/builder/builder.go
+++ b/btcutil/gcs/builder/builder.go
@@ -7,7 +7,7 @@ package builder
 
 import (
 	"crypto/rand"
-	"fmt"
+	"errors"
 	"io"
 	"math"
 
@@ -210,10 +210,10 @@ func (b *GCSBuilder) Build() (*gcs.Filter, error) {
 	// We'll ensure that all the parameters we need to actually build the
 	// filter properly are set.
 	if b.p == 0 {
-		return nil, fmt.Errorf("p value is not set, cannot build")
+		return nil, errors.New("p value is not set, cannot build")
 	}
 	if b.m == 0 {
-		return nil, fmt.Errorf("m value is not set, cannot build")
+		return nil, errors.New("m value is not set, cannot build")
 	}
 
 	dataSlice := make([][]byte, 0, len(b.data))

--- a/btcutil/gcs/gcs.go
+++ b/btcutil/gcs/gcs.go
@@ -7,7 +7,7 @@ package gcs
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io"
 	"sort"
 
@@ -20,11 +20,11 @@ import (
 
 var (
 	// ErrNTooBig signifies that the filter can't handle N items.
-	ErrNTooBig = fmt.Errorf("N is too big to fit in uint32")
+	ErrNTooBig = errors.New("N is too big to fit in uint32")
 
 	// ErrPTooBig signifies that the filter can't handle `1/2**P`
 	// collision probability.
-	ErrPTooBig = fmt.Errorf("P is too big to fit in uint32")
+	ErrPTooBig = errors.New("P is too big to fit in uint32")
 )
 
 const (

--- a/btcutil/psbt/finalizer.go
+++ b/btcutil/psbt/finalizer.go
@@ -13,6 +13,7 @@ package psbt
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 
 	"github.com/btcsuite/btcd/btcec/v2/schnorr"
@@ -547,7 +548,7 @@ func finalizeTaprootInput(p *Packet, inIndex int) error {
 		targetLeafHash := pInput.TaprootScriptSpendSig[0].LeafHash
 		leafScript, err := FindLeafScript(pInput, targetLeafHash)
 		if err != nil {
-			return fmt.Errorf("control block for script spend " +
+			return errors.New("control block for script spend " +
 				"signature not found")
 		}
 

--- a/cmd/btcctl/config.go
+++ b/cmd/btcctl/config.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net"
@@ -134,7 +135,7 @@ func normalizeAddress(addr string, chain *chaincfg.Params, useWallet bool) (stri
 		case &chaincfg.RegressionNetParams:
 			if useWallet {
 				// TODO: add port once regtest is supported in btcwallet
-				paramErr := fmt.Errorf("cannot use -wallet with -regtest, btcwallet not yet compatible with regtest")
+				paramErr := errors.New("cannot use -wallet with -regtest, btcwallet not yet compatible with regtest")
 				return "", paramErr
 			} else {
 				defaultPort = "18334"

--- a/cmd/btcctl/httpclient.go
+++ b/cmd/btcctl/httpclient.go
@@ -104,7 +104,7 @@ func sendPostRequest(marshalledJSON []byte, cfg *config) ([]byte, error) {
 	}
 
 	// Handle unsuccessful HTTP responses
-	if httpResponse.StatusCode < 200 || httpResponse.StatusCode >= 300 {
+	if httpResponse.StatusCode < http.StatusOK || httpResponse.StatusCode >= http.StatusMultipleChoices {
 		// Generate a standard error to return if the server body is
 		// empty.  This should not happen very often, but it's better
 		// than showing nothing in case the target server has a poor

--- a/upnp.go
+++ b/upnp.go
@@ -229,7 +229,7 @@ func getServiceURL(rootURL string) (url string, err error) {
 		return
 	}
 	defer r.Body.Close()
-	if r.StatusCode >= 400 {
+	if r.StatusCode >= http.StatusBadRequest {
 		err = errors.New(fmt.Sprint(r.StatusCode))
 		return
 	}
@@ -312,7 +312,7 @@ func soapRequest(url, function, message string) (replyXML []byte, err error) {
 		defer r.Body.Close()
 	}
 
-	if r.StatusCode >= 400 {
+	if r.StatusCode >= http.StatusBadRequest {
 		err = errors.New("Error " + strconv.Itoa(r.StatusCode) + " for " + function)
 		r = nil
 		return

--- a/wire/message.go
+++ b/wire/message.go
@@ -6,6 +6,7 @@ package wire
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"unicode/utf8"
@@ -81,11 +82,11 @@ const (
 var LatestEncoding = WitnessEncoding
 
 // ErrUnknownMessage is the error returned when decoding an unknown message.
-var ErrUnknownMessage = fmt.Errorf("received unknown message")
+var ErrUnknownMessage = errors.New("received unknown message")
 
 // ErrInvalidHandshake is the error returned when a peer sends us a known
 // message that does not belong in the version-verack handshake.
-var ErrInvalidHandshake = fmt.Errorf("invalid message during handshake")
+var ErrInvalidHandshake = errors.New("invalid message during handshake")
 
 // Message is an interface that describes a bitcoin message.  A type that
 // implements Message has complete control over the representation of its data

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -115,7 +115,7 @@ const (
 var (
 	// errSuperfluousWitnessRecord is returned during tx deserialization when
 	// a tx has the witness marker flag set but has no witnesses.
-	errSuperfluousWitnessRecord = fmt.Errorf(
+	errSuperfluousWitnessRecord = errors.New(
 		"witness flag set but tx has no witnesses",
 	)
 )

--- a/wire/msgversion.go
+++ b/wire/msgversion.go
@@ -6,6 +6,7 @@ package wire
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -79,7 +80,7 @@ func (msg *MsgVersion) AddService(service ServiceFlag) {
 func (msg *MsgVersion) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) error {
 	buf, ok := r.(*bytes.Buffer)
 	if !ok {
-		return fmt.Errorf("MsgVersion.BtcDecode reader is not a " +
+		return errors.New("MsgVersion.BtcDecode reader is not a " +
 			"*bytes.Buffer")
 	}
 

--- a/wire/netaddressv2.go
+++ b/wire/netaddressv2.go
@@ -3,7 +3,7 @@ package wire
 import (
 	"encoding/base32"
 	"encoding/binary"
-	"fmt"
+	"errors"
 	"io"
 	"net"
 	"strings"
@@ -22,7 +22,7 @@ var (
 	// ErrInvalidAddressSize is an error that means an incorrect address
 	// size was decoded for a networkID or that the address exceeded the
 	// maximum size for an unknown networkID.
-	ErrInvalidAddressSize = fmt.Errorf("invalid address size")
+	ErrInvalidAddressSize = errors.New("invalid address size")
 
 	// ErrSkippedNetworkID is returned when the cjdns, i2p, or unknown
 	// networks are encountered during decoding. btcd does not support i2p
@@ -32,7 +32,7 @@ var (
 	// addresses. This error can also be returned when an OnionCat-encoded
 	// torv2 address is received with the ipv6 networkID. This error
 	// signals to the caller to continue reading.
-	ErrSkippedNetworkID = fmt.Errorf("skipped networkID")
+	ErrSkippedNetworkID = errors.New("skipped networkID")
 )
 
 // maxNetAddressV2Payload returns the max payload size for an address used in
@@ -225,7 +225,7 @@ func writeNetAddressV2(w io.Writer, pver uint32, na *NetAddressV2) error {
 		address = a.addr[:]
 	default:
 		// This should not occur.
-		return fmt.Errorf("unexpected address type")
+		return errors.New("unexpected address type")
 	}
 
 	if err := writeElement(w, netID); err != nil {


### PR DESCRIPTION
1. use errors.New to replace fmt.Errorf with no parameters.
2. fix typo.