### PR TITLE
multi:use t.TempDir replace os.MkdirTemp to simplify test temp dir manager

### DIFF
--- a/addrmgr/addrmanager_internal_test.go
+++ b/addrmgr/addrmanager_internal_test.go
@@ -3,7 +3,6 @@ package addrmgr
 import (
 	"math/rand"
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -107,11 +106,7 @@ func TestAddrManagerSerialization(t *testing.T) {
 
 	// We'll start by creating our address manager backed by a temporary
 	// directory.
-	tempDir, err := os.MkdirTemp("", "addrmgr")
-	if err != nil {
-		t.Fatalf("unable to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	addrMgr := New(tempDir, nil)
 
@@ -147,11 +142,7 @@ func TestAddrManagerV1ToV2(t *testing.T) {
 
 	// We'll start by creating our address manager backed by a temporary
 	// directory.
-	tempDir, err := os.MkdirTemp("", "addrmgr")
-	if err != nil {
-		t.Fatalf("unable to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	addrMgr := New(tempDir, nil)
 

--- a/cmd/findcheckpoint/config.go
+++ b/cmd/findcheckpoint/config.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	
+
 	"github.com/btcsuite/btcd/btcutil"
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcd/database"

--- a/config_test.go
+++ b/config_test.go
@@ -22,10 +22,7 @@ func TestCreateDefaultConfigFile(t *testing.T) {
 	sampleConfigFile := filepath.Join(filepath.Dir(path), "sample-btcd.conf")
 
 	// Setup a temporary directory
-	tmpDir, err := os.MkdirTemp("", "btcd")
-	if err != nil {
-		t.Fatalf("Failed creating a temporary directory: %v", err)
-	}
+	tmpDir := t.TempDir()
 	testpath := filepath.Join(tmpDir, "test.conf")
 
 	// copy config file to location of btcd binary
@@ -42,13 +39,6 @@ func TestCreateDefaultConfigFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed copying sample config file: %v", err)
 	}
-
-	// Clean-up
-	defer func() {
-		os.Remove(testpath)
-		os.Remove(tmpConfigFile)
-		os.Remove(tmpDir)
-	}()
 
 	err = createDefaultConfigFile(testpath)
 

--- a/database/ffldb/driver_test.go
+++ b/database/ffldb/driver_test.go
@@ -103,14 +103,13 @@ func TestCreateOpenFail(t *testing.T) {
 
 	// Ensure operations against a closed database return the expected
 	// error.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-createfail")
+	dbPath := filepath.Join(t.TempDir(), "ffldb-createfail")
 	_ = os.RemoveAll(dbPath)
 	db, err := database.Create(dbType, dbPath, blockDataNet)
 	if err != nil {
 		t.Errorf("Create: unexpected error: %v", err)
 		return
 	}
-	defer os.RemoveAll(dbPath)
 	db.Close()
 
 	wantErrCode = database.ErrDbNotOpen
@@ -154,14 +153,13 @@ func TestPersistence(t *testing.T) {
 	t.Parallel()
 
 	// Create a new database to run tests against.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-persistencetest")
+	dbPath := filepath.Join(t.TempDir(), "ffldb-persistencetest")
 	_ = os.RemoveAll(dbPath)
 	db, err := database.Create(dbType, dbPath, blockDataNet)
 	if err != nil {
 		t.Errorf("Failed to create test database (%s) %v", dbType, err)
 		return
 	}
-	defer os.RemoveAll(dbPath)
 	defer db.Close()
 
 	// Create a bucket, put some values into it, and store a block so they
@@ -447,14 +445,13 @@ func TestInterface(t *testing.T) {
 	t.Parallel()
 
 	// Create a new database to run tests against.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-interfacetest")
+	dbPath := filepath.Join(t.TempDir(), "ffldb-interfacetest")
 	_ = os.RemoveAll(dbPath)
 	db, err := database.Create(dbType, dbPath, blockDataNet)
 	if err != nil {
 		t.Errorf("Failed to create test database (%s) %v", dbType, err)
 		return
 	}
-	defer os.RemoveAll(dbPath)
 	defer db.Close()
 
 	// Ensure the driver type is the expected value.

--- a/database/ffldb/whitebox_test.go
+++ b/database/ffldb/whitebox_test.go
@@ -165,8 +165,8 @@ func TestConvertErr(t *testing.T) {
 func TestCornerCases(t *testing.T) {
 	t.Parallel()
 
-	// Create a file at the datapase path to force the open below to fail.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-errors")
+	// Create a file at the database path to force the open below to fail.
+	dbPath := filepath.Join(t.TempDir(), "ffldb-errors")
 	_ = os.RemoveAll(dbPath)
 	fi, err := os.Create(dbPath)
 	if err != nil {
@@ -603,14 +603,13 @@ func testCorruption(tc *testContext) bool {
 // correctly.
 func TestFailureScenarios(t *testing.T) {
 	// Create a new database to run tests against.
-	dbPath := filepath.Join(os.TempDir(), "ffldb-failurescenarios")
+	dbPath := filepath.Join(t.TempDir(), "ffldb-failurescenarios")
 	_ = os.RemoveAll(dbPath)
 	idb, err := database.Create(dbType, dbPath, blockDataNet)
 	if err != nil {
 		t.Errorf("Failed to create test database (%s) %v", dbType, err)
 		return
 	}
-	defer os.RemoveAll(dbPath)
 	defer idb.Close()
 
 	// Create a test context to pass around.


### PR DESCRIPTION
## Change Description
>TempDir returns a temporary directory for the test to use.The directory is automatically removed when the test and
all its subtests complete.

## Steps to Test
Steps for reviewers to follow to test the change.

tested:
```
Running tool: /opt/homebrew/bin/go test -timeout 30s -run ^TestAddrManagerV1ToV2$ github.com/btcsuite/btcd/addrmgr

=== RUN   TestAddrManagerV1ToV2
=== PAUSE TestAddrManagerV1ToV2
=== CONT  TestAddrManagerV1ToV2
--- PASS: TestAddrManagerV1ToV2 (0.00s)
PASS
ok      github.com/btcsuite/btcd/addrmgr        0.005s
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md#ideal-git-commit-structure).
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/lightningnetwork/lnd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
