### PR TITLE
rpcclient: remove the 'for' variable "tc"

### DIFF
--- a/rpcclient/backend_version_test.go
+++ b/rpcclient/backend_version_test.go
@@ -59,8 +59,6 @@ func TestParseBitcoindVersion(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			version := parseBitcoindVersion(tc.rpcVersion)
 			require.Equal(t, tc.parsedVersion, version)
@@ -96,8 +94,6 @@ func TestParseBtcdVersion(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			version := parseBtcdVersion(tc.rpcVersion)
 			require.Equal(t, tc.parsedVersion, version)

--- a/rpcclient/infrastructure_test.go
+++ b/rpcclient/infrastructure_test.go
@@ -93,8 +93,6 @@ func TestParseAddressString(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
-
 		t.Run(tc.name, func(t *testing.T) {
 			addr, err := ParseAddressString(tc.addressString)
 			if tc.expErrStr != "" {


### PR DESCRIPTION
## Change Description
Description of change / link to associated issue.


```
rpcclient/backend_version_test.go:62:3: The copy of the 'for' variable "tc" can be deleted (Go 1.22+) (copyloopvar)
                tc := tc
                ^
rpcclient/backend_version_test.go:99:3: The copy of the 'for' variable "tc" can be deleted (Go 1.22+) (copyloopvar)
                tc := tc
                ^
rpcclient/infrastructure_test.go:96:3: The copy of the 'for' variable "tc" can be deleted (Go 1.22+) (copyloopvar)
```

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/btcsuite/btcd/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [ ] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
