### PR TITLE
utxocache: replace mapslice with concurrent-swiss-map

### DIFF
--- a/blockchain/utxocache.go
+++ b/blockchain/utxocache.go
@@ -7,7 +7,6 @@ package blockchain
 import (
 	"container/list"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil"
@@ -15,167 +14,57 @@ import (
 	"github.com/btcsuite/btcd/database"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
+
+	csm "github.com/mhmtszr/concurrent-swiss-map"
 )
 
-// mapSlice is a slice of maps for utxo entries.  The slice of maps are needed to
-// guarantee that the map will only take up N amount of bytes.  As of v1.20, the
-// go runtime will allocate 2^N + few extra buckets, meaning that for large N, we'll
-// allocate a lot of extra memory if the amount of entries goes over the previously
-// allocated buckets.  A slice of maps allows us to have a better control of how much
-// total memory gets allocated by all the maps.
-type mapSlice struct {
-	// mtx protects against concurrent access for the map slice.
-	mtx sync.Mutex
-
-	// maps are the underlying maps in the slice of maps.
-	maps []map[wire.OutPoint]*UtxoEntry
-
-	// maxEntries is the maximum amount of elements that the map is allocated for.
-	maxEntries []int
-
-	// maxTotalMemoryUsage is the maximum memory usage in bytes that the state
-	// should contain in normal circumstances.
-	maxTotalMemoryUsage uint64
+func NewCsMap(numMaxElements int) *csMap {
+	return &csMap{
+		maps: csm.Create(csm.WithSize[wire.OutPoint, *UtxoEntry](uint64(numMaxElements))),
+	}
 }
 
-// length returns the length of all the maps in the map slice added together.
+// csmap is a concurrent-swiss-map for UTXO entries.
+// csmap provides better control over memory allocation while ensuring efficient concurrent access.
+type csMap struct {
+	maps *csm.CsMap[wire.OutPoint, *UtxoEntry]
+}
+
+// length returns the length of csmap.
 //
 // This function is safe for concurrent access.
-func (ms *mapSlice) length() int {
-	ms.mtx.Lock()
-	defer ms.mtx.Unlock()
-
-	var l int
-	for _, m := range ms.maps {
-		l += len(m)
-	}
-
-	return l
+func (ms *csMap) length() int {
+	return ms.maps.Count()
 }
 
-// size returns the size of all the maps in the map slice added together.
+// size returns the size of csmap.
 //
 // This function is safe for concurrent access.
-func (ms *mapSlice) size() int {
-	ms.mtx.Lock()
-	defer ms.mtx.Unlock()
-
-	var size int
-	for _, num := range ms.maxEntries {
-		size += calculateRoughMapSize(num, bucketSize)
-	}
-
-	return size
+func (ms *csMap) size() int {
+	return calculateRoughMapSize(ms.length(), bucketSize)
 }
 
-// get looks for the outpoint in all the maps in the map slice and returns
-// the entry.  nil and false is returned if the outpoint is not found.
+// get looks for the outpoint in csmap and returns the entry if it exists.
+// nil and false is returned if the outpoint is not found.
 //
 // This function is safe for concurrent access.
-func (ms *mapSlice) get(op wire.OutPoint) (*UtxoEntry, bool) {
-	ms.mtx.Lock()
-	defer ms.mtx.Unlock()
-
-	var entry *UtxoEntry
-	var found bool
-
-	for _, m := range ms.maps {
-		entry, found = m[op]
-		if found {
-			return entry, found
-		}
-	}
-
-	return nil, false
+func (ms *csMap) get(op wire.OutPoint) (*UtxoEntry, bool) {
+	return ms.maps.Load(op)
 }
 
-// put puts the outpoint and the entry into one of the maps in the map slice.  If the
-// existing maps are all full, it will allocate a new map based on how much memory we
-// have left over.  Leftover memory is calculated as:
-// maxTotalMemoryUsage - (totalEntryMemory + mapSlice.size())
+// put puts the outpoint and the entry into csmap.
 //
 // This function is safe for concurrent access.
-func (ms *mapSlice) put(op wire.OutPoint, entry *UtxoEntry, totalEntryMemory uint64) {
-	ms.mtx.Lock()
-	defer ms.mtx.Unlock()
-
-	// Look for the key in the maps.
-	for i := range ms.maxEntries {
-		m := ms.maps[i]
-		_, found := m[op]
-		if found {
-			// If the key is found, overwrite it.
-			m[op] = entry
-			return // Return as we were successful in adding the entry.
-		}
-	}
-
-	for i, maxNum := range ms.maxEntries {
-		m := ms.maps[i]
-		if len(m) >= maxNum {
-			// Don't try to insert if the map already at max since
-			// that'll force the map to allocate double the memory it's
-			// currently taking up.
-			continue
-		}
-
-		m[op] = entry
-		return // Return as we were successful in adding the entry.
-	}
-
-	// We only reach this code if we've failed to insert into the map above as
-	// all the current maps were full.  We thus make a new map and insert into
-	// it.
-	m := ms.makeNewMap(totalEntryMemory)
-	m[op] = entry
+func (ms *csMap) put(op wire.OutPoint, entry *UtxoEntry) {
+	ms.maps.Store(op, entry)
 }
 
-// delete attempts to delete the given outpoint in all of the maps. No-op if the
+// delete attempts to delete the given outpoint in csmap. No-op if the
 // outpoint doesn't exist.
 //
 // This function is safe for concurrent access.
-func (ms *mapSlice) delete(op wire.OutPoint) {
-	ms.mtx.Lock()
-	defer ms.mtx.Unlock()
-
-	for i := 0; i < len(ms.maps); i++ {
-		delete(ms.maps[i], op)
-	}
-}
-
-// makeNewMap makes and appends the new map into the map slice.
-//
-// This function is NOT safe for concurrent access and must be called with the
-// lock held.
-func (ms *mapSlice) makeNewMap(totalEntryMemory uint64) map[wire.OutPoint]*UtxoEntry {
-	// Get the size of the leftover memory.
-	memSize := ms.maxTotalMemoryUsage - totalEntryMemory
-	for _, maxNum := range ms.maxEntries {
-		memSize -= uint64(calculateRoughMapSize(maxNum, bucketSize))
-	}
-
-	// Get a new map that's sized to house inside the leftover memory.
-	// -1 on the returned value will make the map allocate half as much total
-	// bytes.  This is done to make sure there's still room left for utxo
-	// entries to take up.
-	numMaxElements := calculateMinEntries(int(memSize), bucketSize+avgEntrySize)
-	numMaxElements -= 1
-	ms.maxEntries = append(ms.maxEntries, numMaxElements)
-	ms.maps = append(ms.maps, make(map[wire.OutPoint]*UtxoEntry, numMaxElements))
-
-	return ms.maps[len(ms.maps)-1]
-}
-
-// deleteMaps deletes all maps except for the first one which should be the biggest.
-//
-// This function is safe for concurrent access.
-func (ms *mapSlice) deleteMaps() {
-	ms.mtx.Lock()
-	defer ms.mtx.Unlock()
-
-	size := ms.maxEntries[0]
-	ms.maxEntries = []int{size}
-	ms.maps = ms.maps[:1]
+func (ms *csMap) delete(op wire.OutPoint) {
+	ms.maps.Delete(op)
 }
 
 const (
@@ -218,7 +107,7 @@ type utxoCache struct {
 	// flag indicates that the state of the entry (potentially) deviates from the
 	// state in the database.  Explicit nil values in the map are used to
 	// indicate that the database does not contain the entry.
-	cachedEntries    mapSlice
+	cachedEntries    *csMap
 	totalEntryMemory uint64 // Total memory usage in bytes.
 
 	// Below fields are used to indicate when the last flush happened.
@@ -236,16 +125,10 @@ func newUtxoCache(db database.DB, maxTotalMemoryUsage uint64) *utxoCache {
 
 	log.Infof("Pre-alloacting for %d MiB", maxTotalMemoryUsage/(1024*1024)+1)
 
-	m := make(map[wire.OutPoint]*UtxoEntry, numMaxElements)
-
 	return &utxoCache{
 		db:                  db,
 		maxTotalMemoryUsage: maxTotalMemoryUsage,
-		cachedEntries: mapSlice{
-			maps:                []map[wire.OutPoint]*UtxoEntry{m},
-			maxEntries:          []int{numMaxElements},
-			maxTotalMemoryUsage: maxTotalMemoryUsage,
-		},
+		cachedEntries:       NewCsMap(numMaxElements),
 	}
 }
 
@@ -321,7 +204,7 @@ func (s *utxoCache) fetchEntries(outpoints []wire.OutPoint) ([]*UtxoEntry, error
 	// as a miss; this prevents future lookups to perform the same database
 	// fetch.
 	for i := range dbEntries {
-		s.cachedEntries.put(missingOps[i], dbEntries[i], s.totalEntryMemory)
+		s.cachedEntries.put(missingOps[i], dbEntries[i])
 		s.totalEntryMemory += dbEntries[i].memoryUsage()
 	}
 
@@ -363,7 +246,7 @@ func (s *utxoCache) addTxOut(outpoint wire.OutPoint, txOut *wire.TxOut, isCoinBa
 		entry.packedFlags |= tfCoinBase
 	}
 
-	s.cachedEntries.put(outpoint, entry, s.totalEntryMemory)
+	s.cachedEntries.put(outpoint, entry)
 	s.totalEntryMemory += entry.memoryUsage()
 
 	return nil
@@ -504,36 +387,38 @@ func (s *utxoCache) writeCache(dbTx database.Tx, bestState *BestState) error {
 	// NOTE: The database has its own cache which gets atomically written
 	// to leveldb.
 	utxoBucket := dbTx.Metadata().Bucket(utxoSetBucketName)
-	for i := range s.cachedEntries.maps {
-		for outpoint, entry := range s.cachedEntries.maps[i] {
-			switch {
-			// If the entry is nil or spent, remove the entry from the database
-			// and the cache.
-			case entry == nil || entry.IsSpent():
-				err := dbDeleteUtxoEntry(utxoBucket, outpoint)
-				if err != nil {
-					return err
-				}
 
-			// No need to update the cache if the entry was not modified.
-			case !entry.isModified():
-			default:
-				// Entry is fresh and needs to be put into the database.
-				err := dbPutUtxoEntry(utxoBucket, outpoint, entry)
-				if err != nil {
-					return err
-				}
+	var err error
+	s.cachedEntries.maps.Range(func(outpoint wire.OutPoint, entry *UtxoEntry) bool {
+		switch {
+		// If the entry is nil or spent, remove the entry from the database
+		// and the cache.
+		case entry == nil || entry.IsSpent():
+			err = dbDeleteUtxoEntry(utxoBucket, outpoint)
+			if err != nil {
+				return true
 			}
 
-			delete(s.cachedEntries.maps[i], outpoint)
+		// No need to update the cache if the entry was not modified.
+		case !entry.isModified():
+		default:
+			// Entry is fresh and needs to be put into the database.
+			err = dbPutUtxoEntry(utxoBucket, outpoint, entry)
+			if err != nil {
+				return true
+			}
 		}
+		s.cachedEntries.maps.Delete(outpoint)
+		return false
+	})
+	if err != nil {
+		return err
 	}
-	s.cachedEntries.deleteMaps()
 	s.totalEntryMemory = 0
 
 	// When done, store the best state hash in the database to indicate the state
 	// is consistent until that hash.
-	err := dbPutUtxoStateConsistency(dbTx, &bestState.Hash)
+	err = dbPutUtxoStateConsistency(dbTx, &bestState.Hash)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/jrick/logrotate v1.0.0
+	github.com/mhmtszr/concurrent-swiss-map v1.0.8
 	github.com/stretchr/testify v1.8.4
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	golang.org/x/crypto v0.22.0

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ github.com/jrick/logrotate v1.0.0 h1:lQ1bL/n9mBNeIXoTUoYRlK4dHuNJVofX9oWqBtPnSzI
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23 h1:FOOIBWrEkLgmlgGfMuZT83xIwfPDxEI2OHu6xUmJMFE=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
+github.com/mhmtszr/concurrent-swiss-map v1.0.8 h1:GDSxgVrXsPFsraUJaPMm7ptYulj8qnWPgnwXcWbJNxo=
+github.com/mhmtszr/concurrent-swiss-map v1.0.8/go.mod h1:F6QETL48Qn7jEJ3ZPt7EqRZjAAZu7lRQeQGIzXuUIDc=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=


### PR DESCRIPTION
## Change Description
Currently, `utxocache` uses `mapslice` instead of a single large `map`. This seems to be necessary because Go's built-in `map` can consume a significant amount of memory when scaled.
However, I suggest using [ConcurrentSwissMap](https://github.com/mhmtszr/concurrent-swiss-map) as an alternative, which offers simple implementation and better performance in concurrent reads.

## Benchmark

**Environment**  
`GOOS`: linux  
`GOARCH`: amd64  
`CPU`: AMD EPYC 7571  
`PKG`: github.com/btcsuite/btcd/blockchain  

| Type              | Put                                  | Get                              | Delete                             |
|-------------------|------------------------|-------------------------|-----------------------------|
| MapSlice          | 209.5 ns/op      | 153.8 ns/op      | 99.15 ns/op      |
| Csmap             | 197.7 ns/op      | 252.5 ns/op      | 249.4 ns/op     |
| MapSlice (8 Core) | 539.7 ns/op      | 428.0 ns/op   | 287.6 ns/op     |
| Csmap (8 Core)    | 430.9 ns/op      | 70.30 ns/op  | 482.8 ns/op       |

Csmap outperforms the lock-based mapslice by over 6x in concurrent reads.
You can verify the performance using the [mapslice](https://github.com/rabbitprincess/btcd/blob/45313e138363c200938be118890bde4d79cf9c39/blockchain/utxocache_test.go#L198) and [concurrentSwissMap](https://github.com/rabbitprincess/btcd/blob/12c43509f38da3d41662a0da4cf5801beff5a7c2/blockchain/utxocache_test.go#L184) benchmarks.


## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/btcsuite/btcd/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [ ] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
