### PR TITLE
net: replace deprecated math/rand.Read with crypto/rand.Read

### DIFF
--- a/addrmgr/addrmanager_internal_test.go
+++ b/addrmgr/addrmanager_internal_test.go
@@ -1,7 +1,8 @@
 package addrmgr
 
 import (
-	"math/rand"
+	crand "crypto/rand"
+	mrand "math/rand"
 	"net"
 	"testing"
 	"time"
@@ -14,24 +15,24 @@ import (
 func randAddr(t *testing.T) *wire.NetAddressV2 {
 	t.Helper()
 
-	ipv4 := rand.Intn(2) == 0
+	ipv4 := mrand.Intn(2) == 0
 	var ip net.IP
 	if ipv4 {
 		var b [4]byte
-		if _, err := rand.Read(b[:]); err != nil {
+		if _, err := crand.Read(b[:]); err != nil { //replaced with crypto/rand.Read (math.rand.Read is deprecated)
 			t.Fatal(err)
 		}
 		ip = b[:]
 	} else {
 		var b [16]byte
-		if _, err := rand.Read(b[:]); err != nil {
+		if _, err := crand.Read(b[:]); err != nil { //replaced with crypto/rand.Read (math.rand.Read is deprecated)
 			t.Fatal(err)
 		}
 		ip = b[:]
 	}
 
-	services := wire.ServiceFlag(rand.Uint64())
-	port := uint16(rand.Uint32())
+	services := wire.ServiceFlag(mrand.Uint64())
+	port := uint16(mrand.Uint32())
 
 	return wire.NetAddressV2FromBytes(
 		time.Now(), services, ip, port,


### PR DESCRIPTION
This pull request replaces deprecated usage of `math/rand.Read` with the recommended `crypto/rand.Read` for secure random byte generation, in compliance with Go 1.22 standards.

### Summary of Changes:
- Replaced `math/rand.Read` with `crypto/rand.Read` in two locations.
- on file addrmgr/addrmanager_internal_test.go
- Applied import aliasing to avoid name collisions between `math/rand` and `crypto/rand`.
- Updated the corresponding test file to ensure compatibility and test coverage remains intact.
- All tests pass (`go test ./...`) and static analysis tools (`go vet ./...`) report no issues.
- Code is formatted using `go fmt` and adheres to btcd's code formatting and contribution standards.

### Notes:
- This is a focused PR addressing only the deprecation fixes.
- Additional deprecation and cleanup tasks will be submitted in future pull requests to keep reviews manageable.