### PR TITLE
chore(ci): bump Go to 1.22.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ env:
   # go needs absolute directories, using the $HOME variable doesn't work here.
   GOCACHE: /home/runner/work/go/pkg/build
   GOPATH: /home/runner/work/go
-  GO_VERSION: 1.22.11
+  GO_VERSION: 1.22.12
 
 jobs:
   build:


### PR DESCRIPTION
## Change Description
Go 1.22.12 (2025-02-04) fixes CVE-2025-22866—a timing side-channel in
`crypto/elliptic` (P-256 on ppc64le)—and includes miscellaneous compiler and
`go` command bug fixes. Updating keeps CI on the latest security patch.

[Reference](https://go.dev/doc/devel/release#go1.22.12)