### PR TITLE
Increase dust threshold multiplier

### DIFF
--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -173,8 +173,8 @@ func checkPkScriptStandard(pkScript []byte, scriptClass txscript.ScriptClass) er
 }
 
 // GetDustThreshold calculates the dust limit for a *wire.TxOut by taking the
-// size of a typical spending transaction and multiplying it by 3 to account
-// for the minimum dust relay fee of 3000sat/kvb.
+// size of a typical spending transaction and multiplying it by 9 to account
+// for the minimum dust relay fee of 9000sat/kvb.
 func GetDustThreshold(txOut *wire.TxOut) int64 {
 	// The total serialized size consists of the output and the associated
 	// input script to redeem it.  Since there is no input script
@@ -246,13 +246,13 @@ func GetDustThreshold(txOut *wire.TxOut) int64 {
 		totalSize += 107
 	}
 
-	return 3 * int64(totalSize)
+	return 9 * int64(totalSize)
 }
 
 // IsDust returns whether or not the passed transaction output amount is
 // considered dust or not based on the passed minimum transaction relay fee.
 // Dust is defined in terms of the minimum transaction relay fee.  In
-// particular, if the cost to the network to spend coins is more than 1/3 of the
+// particular, if the cost to the network to spend coins is more than 1/9 of the
 // minimum transaction relay fee, it is considered dust.
 func IsDust(txOut *wire.TxOut, minRelayTxFee btcutil.Amount) bool {
 	// Unspendable outputs are considered dust.
@@ -261,7 +261,7 @@ func IsDust(txOut *wire.TxOut, minRelayTxFee btcutil.Amount) bool {
 	}
 
 	// The output is considered dust if the cost to the network to spend the
-	// coins is more than 1/3 of the minimum free transaction relay fee.
+	// coins is more than 1/9 of the minimum free transaction relay fee.
 	// minFreeTxRelayFee is in Satoshi/KB, so multiply by 1000 to
 	// convert to bytes.
 	//
@@ -270,7 +270,7 @@ func IsDust(txOut *wire.TxOut, minRelayTxFee btcutil.Amount) bool {
 	// fee of 1000, this equates to values less than 546 satoshi being
 	// considered dust.
 	//
-	// The following is equivalent to (value/totalSize) * (1/3) * 1000
+	// The following is equivalent to (value/totalSize) * (1/9) * 1000
 	// without needing to do floating point math.
 	return txOut.Value*1000/GetDustThreshold(txOut) < int64(minRelayTxFee)
 }
@@ -387,3 +387,4 @@ func GetTxVirtualSize(tx *btcutil.Tx) int64 {
 	return (blockchain.GetTransactionWeight(tx) + (blockchain.WitnessScaleFactor - 1)) /
 		blockchain.WitnessScaleFactor
 }
+


### PR DESCRIPTION
## Change Description
The purpose of this PR is to filter out more dust / nonmonetary transactions. The dust would be defined for outputs for which the cost to the network to spend coins is more than 1/9 of the minimum transaction relay fee.
