### PR TITLE
mempool: check p2wsh standard

### DIFF
--- a/mempool/mempool.go
+++ b/mempool/mempool.go
@@ -1639,6 +1639,22 @@ func (mp *TxPool) validateStandardness(tx *btcutil.Tx, nextBlockHeight int32,
 		return txRuleError(rejectCode, str)
 	}
 
+	// Check the witness standard.
+	err = checkWitnessStandard(tx, utxoView)
+	if err != nil {
+		// Attempt to extract a reject code from the error so it can be
+		// retained. When not possible, fall back to a non-standard
+		// error.
+		rejectCode, found := extractRejectCode(err)
+		if !found {
+			rejectCode = wire.RejectNonstandard
+		}
+		str := fmt.Sprintf("transaction %v has a non-standard "+
+			"witness: %v", tx.Hash(), err)
+
+		return txRuleError(rejectCode, str)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Change Description

AFAIK, btcd curretly doesn't check standard rule for witness unlike [bitcoin core](https://github.com/bitcoin/bitcoin/blob/52ede28a8adb2c2d44d7f800bbfbef8aed86070e/src/policy/policy.cpp#L221). I add method `CheckWitnessStandard` to check standard rule for `p2wsh`, and execute it inside the method `validateStandardness` for mempool validation.

## Steps to Test
If this PR makes sense, I will add test vectors following the reviews.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
