### PR TITLE
Update GPG key URL in installation instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,7 +14,7 @@ has not been tampered with and is coming from the btcsuite developers.  To
 verify the signature perform the following:
 
 * Download the Conformal public key:
-  https://raw.githubusercontent.com/btcsuite/btcd/master/release/GIT-GPG-KEY-conformal.txt
+  https://opensource.conformal.com/GIT-GPG-KEY-conformal.txt
 
 * Import the public key into your GPG keyring:
 


### PR DESCRIPTION
The file GIT-GPG-KEY-conformal.txt no longer exists in the btcd repository and is not accessible via the old link. According to the documentation and other btcsuite projects, it is now recommended to download this key from the Conformal website:
https://opensource.conformal.com/GIT-GPG-KEY-conformal.txt