### PR TITLE
mempool: Correctly identify all OP_RETURN outputs as NulldataTy

### DIFF
--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -353,6 +353,12 @@ func CheckTransactionStandard(tx *btcutil.Tx, height int32,
 			return txRuleError(rejectCode, str)
 		}
 
+		// If we have a null data script, ensure it is not larger than the
+		// maximum allowed size, plus 1 byte for the OP_RETURN and 2 for the push ops.
+		if scriptClass == txscript.NullDataTy && len(txOut.PkScript) > txscript.MaxDataCarrierSize+3 {
+			return txRuleError(wire.RejectNonstandard, "non-standard script form")
+		}
+
 		// Accumulate the number of outputs which only carry data.  For
 		// all other script types, ensure the output value is not
 		// "dust".

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -505,7 +505,7 @@ func isNullDataScript(scriptVersion uint16, script []byte) bool {
 	//  OP_RETURN <optional data>
 	//
 	// Thus, it can either be a single OP_RETURN or an OP_RETURN followed by a
-	// data push up to MaxDataCarrierSize bytes.
+	// data push.
 
 	// The script can't possibly be a null data script if it doesn't start
 	// with OP_RETURN.  Fail fast to avoid more work below.
@@ -521,8 +521,7 @@ func isNullDataScript(scriptVersion uint16, script []byte) bool {
 	// OP_RETURN followed by data push up to MaxDataCarrierSize bytes.
 	tokenizer := MakeScriptTokenizer(scriptVersion, script[1:])
 	return tokenizer.Next() && tokenizer.Done() &&
-		(IsSmallInt(tokenizer.Opcode()) || tokenizer.Opcode() <= OP_PUSHDATA4) &&
-		len(tokenizer.Data()) <= MaxDataCarrierSize
+		(IsSmallInt(tokenizer.Opcode()) || tokenizer.Opcode() <= OP_PUSHDATA4)
 }
 
 // scriptType returns the type of the script being inspected from the known

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -1023,13 +1023,13 @@ var scriptClassTests = []struct {
 	},
 	{
 		// Nulldata with more than max allowed data to be considered
-		// standard (so therefore nonstandard)
+		// standard is still marked as nulldata.
 		name: "nulldata exceed max standard push",
 		script: "RETURN PUSHDATA1 0x51 0x046708afdb0fe5548271967f1a67" +
 			"130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3" +
 			"046708afdb0fe5548271967f1a67130b7105cd6a828e03909a67" +
 			"962e0ea1f61deb649f6bc3f4cef308",
-		class: NonStandardTy,
+		class: NullDataTy,
 	},
 	{
 		// Almost nulldata, but add an additional opcode after the data


### PR DESCRIPTION
## Change Description

Previously OP_RETURN outputs could be identified as `NonStandardTy` if they were over the `MaxDataCarrierSize`. This would cause in other parts of the code where OP_RETURN outputs would be handled weirdly (as dust and other things).

This changes it so it is correctly identified but still marks a transaction non-standard if the output violates `MaxDataCarrierSize`

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
