### PR TITLE
v2transport: update to btcec v2.3.5, reduce module deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/btcsuite/btcd
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.4
+	github.com/btcsuite/btcd/btcec/v2 v2.3.5
 	github.com/btcsuite/btcd/btcutil v1.1.5
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/btcsuite/btcd/v2transport v1.0.0

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -2279,7 +2279,8 @@ func (p *Peer) negotiateInboundProtocol() error {
 	if p.cfg.UsingV2Conn {
 		garbageLen := rand.Intn(v2transport.MaxGarbageLen + 1)
 		err := p.V2Transport.RespondV2Handshake(
-			garbageLen, p.cfg.ChainParams.Net,
+			garbageLen,
+			v2transport.BitcoinNet(p.cfg.ChainParams.Net),
 		)
 		switch {
 		case errors.Is(err, v2transport.ErrUseV1Protocol):
@@ -2295,7 +2296,8 @@ func (p *Peer) negotiateInboundProtocol() error {
 
 		default:
 			err = p.V2Transport.CompleteHandshake(
-				false, nil, p.cfg.ChainParams.Net,
+				false, nil,
+				v2transport.BitcoinNet(p.cfg.ChainParams.Net),
 			)
 			if err != nil {
 				return err
@@ -2356,7 +2358,8 @@ func (p *Peer) negotiateOutboundProtocol() error {
 		}
 
 		err = p.V2Transport.CompleteHandshake(
-			true, nil, p.cfg.ChainParams.Net,
+			true, nil,
+			v2transport.BitcoinNet(p.cfg.ChainParams.Net),
 		)
 		if errors.Is(err, v2transport.ErrShouldDowngradeToV1) {
 			log.Infof("Outbound v2 connection attempt to %s "+

--- a/v2transport/go.mod
+++ b/v2transport/go.mod
@@ -3,7 +3,7 @@ module v2transport
 go 1.23.2
 
 require (
-	github.com/btcsuite/btcd/btcec/v2 v2.3.4
+	github.com/btcsuite/btcd/btcec/v2 v2.3.5
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	golang.org/x/crypto v0.25.0
 )
@@ -13,5 +13,3 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	golang.org/x/sys v0.22.0 // indirect
 )
-
-replace github.com/btcsuite/btcd/btcec/v2 => ./../btcec

--- a/v2transport/go.mod
+++ b/v2transport/go.mod
@@ -3,7 +3,6 @@ module v2transport
 go 1.23.2
 
 require (
-	github.com/btcsuite/btcd v0.24.2
 	github.com/btcsuite/btcd/btcec/v2 v2.3.4
 	github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f
 	golang.org/x/crypto v0.25.0

--- a/v2transport/go.sum
+++ b/v2transport/go.sum
@@ -1,3 +1,5 @@
+github.com/btcsuite/btcd/btcec/v2 v2.3.5 h1:dpAlnAwmT1yIBm3exhT1/8iUSD98RDJM5vqJVQDQLiU=
+github.com/btcsuite/btcd/btcec/v2 v2.3.5/go.mod h1:m22FrOAiuxl/tht9wIqAoGHcbnCCaPWyauO8y2LGGtQ=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 h1:59Kx4K6lzOW5w6nFlA0v5+lk/6sjybR934QNHSJZPTQ=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=

--- a/v2transport/go.sum
+++ b/v2transport/go.sum
@@ -1,5 +1,3 @@
-github.com/btcsuite/btcd v0.24.2 h1:aLmxPguqxza+4ag8R1I2nnJjSu2iFn/kqtHTIImswcY=
-github.com/btcsuite/btcd v0.24.2/go.mod h1:5C8ChTkl5ejr3WHj8tkQSCmydiMEPB0ZhQhehpq7Dgg=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 h1:59Kx4K6lzOW5w6nFlA0v5+lk/6sjybR934QNHSJZPTQ=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
@@ -9,13 +7,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.25.0 h1:ypSNr+bnYL2YhwoMt2zPxHFmbAN1KZs/njMG3hxUp30=
 golang.org/x/crypto v0.25.0/go.mod h1:T+wALwcMOSE0kXgUAnPAHqTLW+XHgcELELW8VaDgm/M=
 golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
 golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/v2transport/transport.go
+++ b/v2transport/transport.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ellswift"
-	"github.com/btcsuite/btcd/wire"
 )
 
 // packetBit is a type used to represent the bits in the packet's header.
@@ -24,6 +23,13 @@ const (
 	// header.
 	ignoreBitPos packetBit = 7
 )
+
+// BitcoinNet is a type used to represent the Bitcoin network that we're
+// connecting to.
+//
+// NOTE: This is identical to the wire.BitcoinNet type, but allows us to shed a
+// large module dependency.
+type BitcoinNet uint32
 
 const (
 	// garbageSize is the length in bytes of the garbage terminator that
@@ -179,7 +185,7 @@ func NewPeer() *Peer {
 
 // createV2Ciphers constructs the packet-length and packet encryption ciphers.
 func (p *Peer) createV2Ciphers(ecdhSecret []byte, initiating bool,
-	net wire.BitcoinNet) error {
+	net BitcoinNet) error {
 
 	log.Debugf("Creating v2 ciphers (initiating=%v, net=%v)", initiating,
 		net)
@@ -376,7 +382,7 @@ func (p *Peer) InitiateV2Handshake(garbageLen int) error {
 // wants to use the v2 protocol and if so returns our ElligatorSwift-encoded
 // public key followed by our garbage data over. If the initiator does not want
 // to use the v2 protocol, we'll instead revert to the v1 protocol.
-func (p *Peer) RespondV2Handshake(garbageLen int, net wire.BitcoinNet) error {
+func (p *Peer) RespondV2Handshake(garbageLen int, net BitcoinNet) error {
 	v1Prefix := createV1Prefix(net)
 
 	log.Debugf("Responding to v2 handshake (garbageLen=%d, net=%v)",
@@ -474,7 +480,7 @@ func (p *Peer) generateKeyAndGarbage(garbageLen int) ([]byte, error) {
 
 // createV1Prefix is a helper function that returns the first 16 bytes of the
 // version message's header.
-func createV1Prefix(net wire.BitcoinNet) []byte {
+func createV1Prefix(net BitcoinNet) []byte {
 	v1Prefix := make([]byte, 0, 4+12)
 
 	// The v1 transport protocol uses the network's 4 magic bytes followed by
@@ -493,7 +499,7 @@ func createV1Prefix(net wire.BitcoinNet) []byte {
 // CompleteHandshake finishes the v2 protocol negotiation and optionally sends
 // decoy packets after sending the garbage terminator.
 func (p *Peer) CompleteHandshake(initiating bool, decoyContentLens []int,
-	btcnet wire.BitcoinNet) error {
+	btcnet BitcoinNet) error {
 
 	log.Debugf("Completing v2 handshake (initiating=%v, "+
 		"num_decoys=%d, net=%v)", initiating, len(decoyContentLens),

--- a/v2transport/transport_test.go
+++ b/v2transport/transport_test.go
@@ -221,8 +221,8 @@ func TestPacketEncodingVectors(t *testing.T) {
 	for _, test := range tests {
 		inInitiating := test.inInitiating
 
-		// We need to convert the FieldVal into a ModNScalar so that we can use
-		// the ScalarBaseMultNonConst.
+		// We need to convert the FieldVal into a ModNScalar so that we
+		// can use the ScalarBaseMultNonConst.
 		inPrivOurs := setHex(test.inPrivOurs)
 		inPrivOursBytes := inPrivOurs.Bytes()
 
@@ -274,10 +274,13 @@ func TestPacketEncodingVectors(t *testing.T) {
 		}
 
 		if !midXOurs.Equals(xEllswiftOurs) {
-			t.Fatalf("expected mid-state to match decoded ellswift key")
+			t.Fatalf("expected mid-state to match decoded " +
+				"ellswift key")
 		}
 
-		bytesEllswiftTheirs, err := hex.DecodeString(test.inEllswiftTheirs)
+		bytesEllswiftTheirs, err := hex.DecodeString(
+			test.inEllswiftTheirs,
+		)
 		if err != nil {
 			t.Fatalf("unexpected error decoding string")
 		}
@@ -309,7 +312,8 @@ func TestPacketEncodingVectors(t *testing.T) {
 
 		midXTheirs := setHex(test.midXTheirs)
 		if !midXTheirs.Equals(xEllswiftTheirs) {
-			t.Fatalf("expected mid-state to match decoded ellswift key")
+			t.Fatalf("expected mid-state to match decoded " +
+				"ellswift key")
 		}
 
 		privKeyOurs, _ := btcec.PrivKeyFromBytes((*inPrivOursBytes)[:])
@@ -340,10 +344,12 @@ func TestPacketEncodingVectors(t *testing.T) {
 		copy(bytesEllswiftOurs64[:], bytesEllswiftOurs)
 
 		sharedSecret, err := ellswift.V2Ecdh(
-			privKeyOurs, bytesEllswiftTheirs64, bytesEllswiftOurs64, inInitiating,
+			privKeyOurs, bytesEllswiftTheirs64,
+			bytesEllswiftOurs64, inInitiating,
 		)
 		if err != nil {
-			t.Fatalf("unexpected error when calculating shared secret")
+			t.Fatalf("unexpected error when calculating " +
+				"shared secret")
 		}
 
 		midShared, err := hex.DecodeString(test.midSharedSecret)
@@ -371,7 +377,8 @@ func TestPacketEncodingVectors(t *testing.T) {
 		}
 
 		if !bytes.Equal(midInitiatorL, p.initiatorL) {
-			t.Fatalf("expected mid-state initiatorL to match computed value")
+			t.Fatalf("expected mid-state initiatorL to " +
+				"match computed value")
 		}
 
 		midInitiatorP, err := hex.DecodeString(test.midInitiatorP)
@@ -380,7 +387,8 @@ func TestPacketEncodingVectors(t *testing.T) {
 		}
 
 		if !bytes.Equal(midInitiatorP, p.initiatorP) {
-			t.Fatalf("expected mid-state initiatorP to match computed value")
+			t.Fatalf("expected mid-state initiatorP to " +
+				"match computed value")
 		}
 
 		midResponderL, err := hex.DecodeString(test.midResponderL)
@@ -389,7 +397,8 @@ func TestPacketEncodingVectors(t *testing.T) {
 		}
 
 		if !bytes.Equal(midResponderL, p.responderL) {
-			t.Fatalf("expected mid-state responderL to match computed value")
+			t.Fatalf("expected mid-state responderL to " +
+				"match computed value")
 		}
 
 		midResponderP, err := hex.DecodeString(test.midResponderP)
@@ -398,25 +407,32 @@ func TestPacketEncodingVectors(t *testing.T) {
 		}
 
 		if !bytes.Equal(midResponderP, p.responderP) {
-			t.Fatalf("expected mid-state responderP to match computed value")
+			t.Fatalf("expected mid-state responderP to " +
+				"match computed value")
 		}
 
-		midSendGarbageTerm, err := hex.DecodeString(test.midSendGarbageTerm)
+		midSendGarbageTerm, err := hex.DecodeString(
+			test.midSendGarbageTerm,
+		)
 		if err != nil {
 			t.Fatalf("unexpected error decoding midSendGarbageTerm")
 		}
 
 		if !bytes.Equal(midSendGarbageTerm, p.sendGarbageTerm[:]) {
-			t.Fatalf("expected mid-state sendGarbageTerm to match computed value")
+			t.Fatalf("expected mid-state sendGarbageTerm " +
+				"to match computed value")
 		}
 
-		midRecvGarbageTerm, err := hex.DecodeString(test.midRecvGarbageTerm)
+		midRecvGarbageTerm, err := hex.DecodeString(
+			test.midRecvGarbageTerm,
+		)
 		if err != nil {
 			t.Fatalf("unexpected error decoding midRecvGarbageTerm")
 		}
 
 		if !bytes.Equal(midRecvGarbageTerm, p.recvGarbageTerm) {
-			t.Fatalf("expected mid-state recvGarbageTerm to match computed value")
+			t.Fatalf("expected mid-state recvGarbageTerm to " +
+				"match computed value")
 		}
 
 		outSessionID, err := hex.DecodeString(test.outSessionID)

--- a/v2transport/transport_test.go
+++ b/v2transport/transport_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ellswift"
-	"github.com/btcsuite/btcd/wire"
 )
 
 func setHex(hexString string) *btcec.FieldVal {
@@ -22,6 +21,10 @@ func setHex(hexString string) *btcec.FieldVal {
 
 	return &f
 }
+
+const (
+	mainNet = 0xd9b4bef9
+)
 
 func TestPacketEncodingVectors(t *testing.T) {
 	tests := []struct {
@@ -366,7 +369,7 @@ func TestPacketEncodingVectors(t *testing.T) {
 		buf := bytes.NewBuffer(nil)
 		p.UseReadWriter(buf)
 
-		err = p.createV2Ciphers(midShared, inInitiating, wire.MainNet)
+		err = p.createV2Ciphers(midShared, inInitiating, mainNet)
 		if err != nil {
 			t.Fatalf("error initiating v2 transport")
 		}


### PR DESCRIPTION
In this PR, we first reduce the size of the new `v2transport` module by reducing eliminating the dep on the `wire` package, which causes the entire `btcd` repo to be brought in. As a follow up, we then update the `btcec` dep so we can eliminate the newly added replace directives. 

Once this PR is merged, we can tag the `v2transport` module, then remove the top level replace. 