### PR TITLE
v2transport: fix module path

### DIFF
--- a/v2transport/go.mod
+++ b/v2transport/go.mod
@@ -1,4 +1,4 @@
-module v2transport
+module github.com/btcsuite/btcd/v2transport
 
 go 1.23.2
 


### PR DESCRIPTION
In this commit, we fix the module path for the new `v2transport` package. It needs the repo prefix (btcsuite/btcd).

