### PR TITLE
Remove datacarriersize and op_return output count limit

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,10 +3,6 @@ User visible changes for btcd
   A full-node bitcoin implementation written in Go
 ============================================================================
 
-Changes in next version (TBD)
-  - Notable developer-related package changes:
-    - Remove the `MaxDataCarrierSize` limit for `OP_RETURN` transactions in the `txscript` package.
-
 Changes in 0.22.0 (Tue Jun 01 2021)
   - Protocol and network-related changes:
     - Add support for witness tx and block in notfound msg (#1625)

--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,10 @@ User visible changes for btcd
   A full-node bitcoin implementation written in Go
 ============================================================================
 
+Changes in next version (TBD)
+  - Notable developer-related package changes:
+    - Remove the `MaxDataCarrierSize` limit for `OP_RETURN` transactions in the `txscript` package.
+
 Changes in 0.22.0 (Tue Jun 01 2021)
   - Protocol and network-related changes:
     - Add support for witness tx and block in notfound msg (#1625)

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -365,13 +365,6 @@ func CheckTransactionStandard(tx *btcutil.Tx, height int32,
 		}
 	}
 
-	// A standard transaction must not have more than one output script that
-	// only carries data.
-	if numNullDataOutputs > 1 {
-		str := "more than one transaction output in a nulldata script"
-		return txRuleError(wire.RejectNonstandard, str)
-	}
-
 	return nil
 }
 

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -430,8 +430,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 				LockTime: 0,
 			},
 			height:     300000,
-			isStandard: false,
-			code:       wire.RejectNonstandard,
+			isStandard: true,
 		},
 		{
 			name: "Dust output",

--- a/rpcclient/errors.go
+++ b/rpcclient/errors.go
@@ -173,10 +173,6 @@ const (
 	// too small.
 	ErrDust
 
-	// ErrMultiOpReturn is returned when the transactions are not standard
-	// - muiltiple OP_RETURNs.
-	ErrMultiOpReturn
-
 	// ErrNonFinal is returned when spending a timelocked transaction that
 	// hasn't expired yet.
 	ErrNonFinal
@@ -319,9 +315,6 @@ func (r BitcoindRPCErr) Error() string {
 	case ErrDust:
 		return "dust"
 
-	case ErrMultiOpReturn:
-		return "multi op return"
-
 	case ErrNonFinal:
 		return "non final"
 
@@ -450,9 +443,6 @@ var BtcdErrMap = map[string]error{
 
 	// Some nonstandard transactions - output too small.
 	"payment is dust": ErrDust,
-
-	// Some nonstandard transactions - muiltiple OP_RETURNs.
-	"more than one transaction output in a nulldata script": ErrMultiOpReturn,
 
 	// A timelocked transaction.
 	"transaction is not finalized":               ErrNonFinal,

--- a/txscript/error.go
+++ b/txscript/error.go
@@ -44,8 +44,10 @@ const (
 	// provided public keys.
 	ErrTooManyRequiredSigs
 
-	// ErrTooMuchNullData is returned from NullDataScript when the length of
-	// the provided data exceeds MaxDataCarrierSize.
+	// ErrTooMuchNullData is returned when a script involving null data
+	// encounters an issue, for example, if the provided data is too large for a
+	// specific context (though standard OP_RETURN limits enforced by
+	// NullDataScript have been removed).
 	ErrTooMuchNullData
 
 	// ErrUnsupportedScriptVersion is returned when an unsupported script

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -13,10 +13,6 @@ import (
 )
 
 const (
-	// MaxDataCarrierSize is the maximum number of bytes allowed in pushed
-	// data to be considered a nulldata transaction
-	MaxDataCarrierSize = 80
-
 	// StandardVerifyFlags are the script flags which are used when
 	// executing transaction scripts to enforce additional checks which
 	// are required for the script to be considered standard.  These checks
@@ -518,11 +514,10 @@ func isNullDataScript(scriptVersion uint16, script []byte) bool {
 		return true
 	}
 
-	// OP_RETURN followed by data push up to MaxDataCarrierSize bytes.
+	// OP_RETURN followed by a data push.
 	tokenizer := MakeScriptTokenizer(scriptVersion, script[1:])
 	return tokenizer.Next() && tokenizer.Done() &&
-		(IsSmallInt(tokenizer.Opcode()) || tokenizer.Opcode() <= OP_PUSHDATA4) &&
-		len(tokenizer.Data()) <= MaxDataCarrierSize
+		(IsSmallInt(tokenizer.Opcode()) || tokenizer.Opcode() <= OP_PUSHDATA4)
 }
 
 // scriptType returns the type of the script being inspected from the known
@@ -883,15 +878,8 @@ func PayToAddrScript(addr btcutil.Address) ([]byte, error) {
 }
 
 // NullDataScript creates a provably-prunable script containing OP_RETURN
-// followed by the passed data.  An Error with the error code ErrTooMuchNullData
-// will be returned if the length of the passed data exceeds MaxDataCarrierSize.
+// followed by the passed data.
 func NullDataScript(data []byte) ([]byte, error) {
-	if len(data) > MaxDataCarrierSize {
-		str := fmt.Sprintf("data size %d is larger than max "+
-			"allowed size %d", len(data), MaxDataCarrierSize)
-		return nil, scriptError(ErrTooMuchNullData, str)
-	}
-
 	return NewScriptBuilder().AddOp(OP_RETURN).AddData(data).Script()
 }
 

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -1238,14 +1238,18 @@ func TestNullDataScript(t *testing.T) {
 			class: NullDataTy,
 		},
 		{
-			name: "too big",
+			name: "data push of 81 bytes (formerly too big)",
 			data: hexToBytes("000102030405060708090a0b0c0d0e0f101" +
 				"112131415161718191a1b1c1d1e1f202122232425262" +
 				"728292a2b2c2d2e2f303132333435363738393a3b3c3" +
 				"d3e3f404142434445464748494a4b4c4d4e4f50"),
-			expected: nil,
-			err:      scriptError(ErrTooMuchNullData, ""),
-			class:    NonStandardTy,
+			expected: mustParseShortForm("RETURN PUSHDATA1 0x51 0x" +
+				"000102030405060708090a0b0c0d0e0f101" +
+				"112131415161718191a1b1c1d1e1f202122232425262" +
+				"728292a2b2c2d2e2f303132333435363738393a3b3c3" +
+				"d3e3f404142434445464748494a4b4c4d4e4f50"),
+			err:   nil,
+			class: NullDataTy,
 		},
 	}
 

--- a/txscript/standard_test.go
+++ b/txscript/standard_test.go
@@ -1029,7 +1029,7 @@ var scriptClassTests = []struct {
 			"130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef3" +
 			"046708afdb0fe5548271967f1a67130b7105cd6a828e03909a67" +
 			"962e0ea1f61deb649f6bc3f4cef308",
-		class: NonStandardTy,
+		class: NullDataTy,
 	},
 	{
 		// Almost nulldata, but add an additional opcode after the data


### PR DESCRIPTION
## Change Description
This PR pretty much does the same changes as the instagibbs PR for bitcoin core.

https://github.com/bitcoin/bitcoin/pull/32406

- Removed datacarriersize limit
- Removed the restriction for max op_return output count

Though bitcoin core is marking datacarriersize as depracated, btcd never supported increasing the size with a flag hence I am getting rid of it altogether.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [X] Your PR passes all CI checks.
- [X] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [X] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [X] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [ ] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
