### PR TITLE
refactor: fix Dockerfile to use go 1.23 for build container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,9 @@ ARG ARCH=amd64
 # https://github.com/opencontainers/image-spec/blob/main/descriptor.md#digests
 # https://cloud.google.com/architecture/using-container-images
 # https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md
-# ➜  ~ crane digest golang:1.22.11-alpine3.21
-# sha256:161858498a61ce093c8e2bd704299bfb23e5bff79aef99b6c40bb9c6a43acf0f
-FROM golang@sha256:161858498a61ce093c8e2bd704299bfb23e5bff79aef99b6c40bb9c6a43acf0f AS build-container
+# ➜  ~ crane digest golang:1.23.10-alpine3.22
+# sha256:9a425d78a8257fc92d41ad979d38cb54005bac3fdefbdadde868e004eccbb898
+FROM golang@sha256:9a425d78a8257fc92d41ad979d38cb54005bac3fdefbdadde868e004eccbb898 AS build-container
 
 ARG ARCH
 

--- a/docs/using_docker.md
+++ b/docs/using_docker.md
@@ -87,13 +87,13 @@ With the following commands you can control *docker-compose*:
 Let's start with an easy example. If you just want to create a full node without the need of using the RPC port, you can use the following example. This example will launch *btcd* and exposes only the default p2p port 8333 to the outside world:
 
 ```yaml
-version: "2"
-
 services:
   btcd:
     container_name: btcd
     hostname: btcd
-    build: https://github.com/btcsuite/btcd.git#master
+    build:
+      context: https://github.com/btcsuite/btcd.git#master
+      dockerfile: Dockerfile
     restart: unless-stopped
     volumes:
       - btcd-data:/root/.btcd
@@ -109,13 +109,13 @@ volumes:
 To use the RPC port of *btcd* you need to specify a *username* and a very strong *password*. If you want to connect to the RPC port from the internet, you need to expose port 8334(RPC) as well.
 
 ```yaml
-version: "2"
-
 services:
   btcd:
     container_name: btcd
     hostname: btcd
-    build: https://github.com/btcsuite/btcd.git#master
+    build:
+      context: https://github.com/btcsuite/btcd.git#master
+      dockerfile: Dockerfile
     restart: unless-stopped
     volumes:
       - btcd-data:/root/.btcd
@@ -136,13 +136,13 @@ volumes:
 To run a node on testnet, you need to provide the *--testnet* argument. The ports for testnet are 18333 (p2p) and 18334 (RPC):
 
 ```yaml
-version: "2"
-
 services:
   btcd:
     container_name: btcd
     hostname: btcd
-    build: https://github.com/btcsuite/btcd.git#master
+    build:
+      context: https://github.com/btcsuite/btcd.git#master
+      dockerfile: Dockerfile
     restart: unless-stopped
     volumes:
       - btcd-data:/root/.btcd

--- a/docs/using_docker.md
+++ b/docs/using_docker.md
@@ -12,7 +12,7 @@
 
 ## Introduction
 
-With Docker you can easily set up *btcd* to run your Bitcoin full node. You can find the official *btcd* Docker images on Docker Hub [btcsuite/btcd](https://hub.docker.com/r/btcsuite/btcd). The Docker source file of this image is located at [Dockerfile](https://github.com/btcsuite/btcd/blob/master/Dockerfile).
+With Docker you can easily set up *btcd* to run your Bitcoin full node. You can find the official *btcd* Docker images on Docker Hub [btcsuite/btcd](https://github.com/btcsuite/btcd/pkgs/container/btcd). The Docker source file of this image is located at [Dockerfile](https://github.com/btcsuite/btcd/blob/master/Dockerfile).
 
 This documentation focuses on running Docker container with *docker-compose.yml* files. These files are better to read and you can use them as a template for your own use. For more information about Docker and Docker compose visit the official [Docker documentation](https://docs.docker.com/).
 


### PR DESCRIPTION
## Change Description
Fixes Dockerfile to use updated GO version as required by update `go.mod` and addresses #2268. Updates docker compose references in documentation to reflect new docker compose depcrecations and changes.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
