### PR TITLE
Print a readable error before os.Exit(1) in btcctl

### DIFF
--- a/cmd/btcctl/btcctl.go
+++ b/cmd/btcctl/btcctl.go
@@ -49,6 +49,7 @@ func usage(errorMessage string) {
 func main() {
 	cfg, args, err := loadConfig()
 	if err != nil {
+		fmt.Fprintln(os.Stderr, "Failed to load config:", err)
 		os.Exit(1)
 	}
 	if len(args) < 1 {


### PR DESCRIPTION
## Change Description
Prints a readable error in btcctl if there's an error in reading the config.
Solves https://github.com/btcsuite/btcd/issues/2392

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [ ] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
