### PR TITLE
Minor Documentation and Comment Improvements

### DIFF
--- a/rpcclient/errors.go
+++ b/rpcclient/errors.go
@@ -174,7 +174,7 @@ const (
 	ErrDust
 
 	// ErrMultiOpReturn is returned when the transactions are not standard
-	// - muiltiple OP_RETURNs.
+	// - multiple OP_RETURNs.
 	ErrMultiOpReturn
 
 	// ErrNonFinal is returned when spending a timelocked transaction that
@@ -451,7 +451,7 @@ var BtcdErrMap = map[string]error{
 	// Some nonstandard transactions - output too small.
 	"payment is dust": ErrDust,
 
-	// Some nonstandard transactions - muiltiple OP_RETURNs.
+	// Some nonstandard transactions - multiple OP_RETURNs.
 	"more than one transaction output in a nulldata script": ErrMultiOpReturn,
 
 	// A timelocked transaction.

--- a/wire/message.go
+++ b/wire/message.go
@@ -598,7 +598,7 @@ func ReadPartialMessageWithEncodingN(r io.Reader, pver uint32,
 
 // readMessageWithEncodingNInternal is used to deduplicate the code because we
 // typically parse messages and headers all at once except in the case of a
-// downgraded v2->v1 conncection.
+// downgraded v2->v1 connection.
 func readMessageWithEncodingNInternal(r io.Reader, pver uint32,
 	hdr *messageHeader, btcnet BitcoinNet, enc MessageEncoding,
 	totalBytes int) (int, Message, []byte, error) {


### PR DESCRIPTION


---

## Description
- Standardized phrasing for "multiple OP_RETURNs" in comments and error mappings within `rpcclient/errors.go`.


---