### PR TITLE
integration: implement port reservation and release functionality in rpc tests

### DIFF
--- a/integration/rpctest/port.go
+++ b/integration/rpctest/port.go
@@ -1,0 +1,48 @@
+package rpctest
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+)
+
+var (
+	portRangeStart = 30000
+	portRangeEnd   = 40000
+	portLockDir    = filepath.Join(os.TempDir(), "test_port_locks")
+)
+
+func ReservePort() (int, error) {
+	// Always attempt to create the lock directory
+	if err := os.MkdirAll(portLockDir, 0755); err != nil {
+		return 0, err
+	}
+
+	for port := portRangeStart; port <= portRangeEnd; port++ {
+		lockFile := filepath.Join(portLockDir, fmt.Sprintf("port_%d.lock", port))
+
+		// Attempt to atomically create the lock file
+		f, err := os.OpenFile(lockFile, os.O_CREATE|os.O_EXCL, 0600)
+		if err == nil {
+			// Successfully reserved the port
+			defer f.Close()
+
+			// Verify the port is actually usable
+			l, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+			if err != nil {
+				// Port is reserved but unusable, release the lock
+				os.Remove(lockFile)
+				continue
+			}
+			l.Close()
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("no available ports in range %d–%d", portRangeStart, portRangeEnd)
+}
+
+func ReleasePort(port int) error {
+	lockFile := filepath.Join(portLockDir, fmt.Sprintf("port_%d.lock", port))
+	return os.Remove(lockFile)
+}


### PR DESCRIPTION
## Change Description
This commit introduces a new file, `port.go`, which provides functions to reserve and release TCP ports within a specified range. The `ReservePort` function attempts to create a lock file for each port and verifies its usability by attempting to listen on it. If successful, it returns the port number; otherwise, it continues searching until the range is exhausted. The `ReleasePort` function allows for the removal of the lock file associated with a reserved port. Additionally, the `rpc_harness.go` file has been updated to utilize these new functions for managing port allocation in test cases, resolving a race condition between tests running in parallel.

## Steps to Test
On master branch (perhaps needed more than once to replicate the race).
```
cd integration
go test -tags=rpctest -v -count=1 ./...
```
Then run the same test on this branch.


## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
