### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/dimagespub.yml
+++ b/.github/workflows/dimagespub.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Docker Setup Buildx
         id: buildx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Build
         run: make build
@@ -33,7 +33,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Test
         run: make unit-cover
@@ -90,7 +90,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Check out source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Test
         run: make unit-race


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0