### PR TITLE
rpcclient: add bitcoind version dependent error matching

### DIFF
--- a/rpcclient/errors_test.go
+++ b/rpcclient/errors_test.go
@@ -61,6 +61,14 @@ func TestMatchErrStr(t *testing.T) {
 			matchStr:    "missingorspent",
 			matched:     false,
 		},
+		{
+			name: "new bitcoind v30 error",
+			bitcoindErr: errors.New(
+				"mempool-script-verify-flag-failed",
+			),
+			matchStr: "mempool script verify flag failed",
+			matched:  true,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Fixes #2404.
If different versions of bitcoind return different error strings, we need a way to match those as well.
