### PR TITLE
Chains 6377

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ btcutil/psbt/coverage.txt
 /btcd
 /findcheckpoint
 /gencerts
+
+#Goland
+.idea


### PR DESCRIPTION
 ## Change Description
  Add support for capturing HTTP response headers in RPC client when running in HTTP POST mode.

  This change introduces a new `HeaderCapturingTransport` that wraps the existing HTTP transport to intercept and capture response headers. Users can now provide an optional `OnCaptureHeader` callback
  function in the `ConnConfig` to receive all response headers from RPC calls.

  ### Key Changes:
  - Added `OnCaptureHeader func(header http.Header)` field to `ConnConfig`
  - Created `HeaderCapturingTransport` struct that implements `http.RoundTripper`
  - Modified `newHTTPClient` to wrap the transport with header capturing when callback is provided

  ### Use Case:
  This feature is useful for capturing server-provided headers like request IDs (e.g., `zp-rid`), trace IDs, or other metadata that can be used for debugging, logging, or request correlation.

  ## Steps to Test
  1. Create an RPC client with HTTP POST mode enabled
  2. Provide an `OnCaptureHeader` callback in the `ConnConfig`
  3. Make RPC calls and verify the callback receives response headers
  4. Verify that the feature doesn't affect existing functionality when callback is not provided

  Example usage:
  ```go
  config := &rpcclient.ConnConfig{
      Host:         "localhost:8332",
      HTTPPostMode: true,
      OnCaptureHeader: func(headers http.Header) {
          if rid := headers.Get("zp-rid"); rid != "" {
              log.Printf("Request ID: %s", rid)
          }
      },
  }
  client, _ := rpcclient.New(config, nil)

  Pull Request Checklist

  Testing

  - Your PR passes all CI checks.
  - Tests covering the positive and negative (error paths) are included.
  - Bug fixes contain tests triggering the bug to prevent regressions.

  Code Style and Documentation

  - The change is not https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only. Typo fixes are not accepted to fight bot spam.
  - The change obeys the https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting guidelines, and lines wrap at 80.
  - Commits follow the https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages.
  - Any new logging statements use an appropriate subsystem and logging level.