### PR TITLE
treap, ffldb: add treapNodePool

### DIFF
--- a/database/ffldb/dbcache.go
+++ b/database/ffldb/dbcache.go
@@ -611,19 +611,27 @@ func (c *dbCache) commitTx(tx *transaction) error {
 	c.cacheLock.RUnlock()
 
 	// Apply every key to add in the database transaction to the cache.
+	pendingKeys := make([][]byte, 0, tx.pendingKeys.Len())
+	pendingKeyValues := make([][]byte, 0, tx.pendingKeys.Len())
 	tx.pendingKeys.ForEach(func(k, v []byte) bool {
+		pendingKeys = append(pendingKeys, k)
+		pendingKeyValues = append(pendingKeyValues, v)
+
 		newCachedRemove = newCachedRemove.Delete(k)
-		newCachedKeys = newCachedKeys.Put(k, v)
 		return true
 	})
+	newCachedKeys = newCachedKeys.Put(pendingKeys, pendingKeyValues)
 	tx.pendingKeys = nil
 
 	// Apply every key to remove in the database transaction to the cache.
+	pendingRemoveKeys := make([][]byte, 0, tx.pendingRemove.Len())
 	tx.pendingRemove.ForEach(func(k, v []byte) bool {
+		pendingRemoveKeys = append(pendingRemoveKeys, k)
+
 		newCachedKeys = newCachedKeys.Delete(k)
-		newCachedRemove = newCachedRemove.Put(k, nil)
 		return true
 	})
+	newCachedRemove = newCachedRemove.Put(pendingRemoveKeys, nil)
 	tx.pendingRemove = nil
 
 	// Atomically replace the immutable treaps which hold the cached keys to

--- a/database/internal/treap/common.go
+++ b/database/internal/treap/common.go
@@ -6,6 +6,7 @@ package treap
 
 import (
 	"math/rand"
+	"sync"
 	"time"
 )
 
@@ -33,6 +34,14 @@ var (
 	emptySlice = make([]byte, 0)
 )
 
+// treapNodePool defines a concurrent safe free list of treapNode used to
+// provide temporary buffers.
+var treapNodePool = sync.Pool{
+	New: func() any {
+		return &treapNode{}
+	},
+}
+
 // treapNode represents a node in the treap.
 type treapNode struct {
 	key      []byte
@@ -51,7 +60,14 @@ func nodeSize(node *treapNode) uint64 {
 // newTreapNode returns a new node from the given key, value, and priority.  The
 // node is not initially linked to any others.
 func newTreapNode(key, value []byte, priority int) *treapNode {
-	return &treapNode{key: key, value: value, priority: priority}
+	n := treapNodePool.Get().(*treapNode)
+	n.key = key
+	n.value = value
+	n.priority = priority
+	n.left = nil
+	n.right = nil
+
+	return n
 }
 
 // parentStack represents a stack of parent treap nodes that are used during

--- a/database/internal/treap/immutable.go
+++ b/database/internal/treap/immutable.go
@@ -106,6 +106,11 @@ func (t *Immutable) Get(key []byte) []byte {
 
 // Put inserts the passed key/value pair.
 func (t *Immutable) Put(key, value []byte) *Immutable {
+	return t.put(key, value)
+}
+
+// put inserts the passed key/value pair.
+func (t *Immutable) put(key, value []byte) *Immutable {
 	// Use an empty byte slice for the value when none was provided.  This
 	// ultimately allows key existence to be determined from the value since
 	// an empty byte slice is distinguishable from nil.

--- a/database/internal/treap/immutable.go
+++ b/database/internal/treap/immutable.go
@@ -11,13 +11,14 @@ import (
 
 // cloneTreapNode returns a shallow copy of the passed node.
 func cloneTreapNode(node *treapNode) *treapNode {
-	return &treapNode{
-		key:      node.key,
-		value:    node.value,
-		priority: node.priority,
-		left:     node.left,
-		right:    node.right,
-	}
+	n := treapNodePool.Get().(*treapNode)
+	n.key = node.key
+	n.value = node.value
+	n.priority = node.priority
+	n.left = node.left
+	n.right = node.right
+
+	return n
 }
 
 // Immutable represents a treap data structure which is used to hold ordered

--- a/database/internal/treap/immutable.go
+++ b/database/internal/treap/immutable.go
@@ -110,8 +110,11 @@ func (t *Immutable) Put(key, value []byte) *Immutable {
 	return t.put(key, value)
 }
 
-// put inserts the passed key/value pair.
-func (t *Immutable) put(key, value []byte) *Immutable {
+// put inserts the passed key/value pair and returns all the newly created
+// treapNodes that were created during this put operation.  The returned
+// treapNodes can then be put into data structures like sync.Pool to reduce the
+// memory overhead of allocating new treapNodes during multiple put calls.
+func (t *Immutable) put(key, value []byte) (*Immutable, [staticDepth]*treapNode) {
 	// Use an empty byte slice for the value when none was provided.  This
 	// ultimately allows key existence to be determined from the value since
 	// an empty byte slice is distinguishable from nil.
@@ -119,10 +122,17 @@ func (t *Immutable) put(key, value []byte) *Immutable {
 		value = emptySlice
 	}
 
+	// recycle is the treapNodes that are created during this put operation.
+	// We keep track of the nodes as the caller may be choose to recycle
+	// them to keep memory allocation low.
+	var recycle [staticDepth]*treapNode
+	var rIdx int
+
 	// The node is the root of the tree if there isn't already one.
 	if t.root == nil {
 		root := newTreapNode(key, value, rand.Int())
-		return newImmutable(root, 1, nodeSize(root))
+		recycle[rIdx] = root
+		return newImmutable(root, 1, nodeSize(root)), recycle
 	}
 
 	// Find the binary tree insertion point and construct a replaced list of
@@ -138,6 +148,16 @@ func (t *Immutable) put(key, value []byte) *Immutable {
 	for node := t.root; node != nil; {
 		// Clone the node and link its parent to it if needed.
 		nodeCopy := cloneTreapNode(node)
+
+		// Check if we still have space in the recycle for this node.
+		// It's ok if we don't put every single new node to be recycled
+		// as there's no guarantee in the sync.Pool that every recycled
+		// treapNode will be re-utilized.
+		if rIdx < staticDepth {
+			recycle[rIdx] = nodeCopy
+			rIdx++
+		}
+
 		if oldParent := parents.At(0); oldParent != nil {
 			if oldParent.left == node {
 				oldParent.left = nodeCopy
@@ -167,11 +187,20 @@ func (t *Immutable) put(key, value []byte) *Immutable {
 		newRoot := parents.At(parents.Len() - 1)
 		newTotalSize := t.totalSize - uint64(len(node.value)) +
 			uint64(len(value))
-		return newImmutable(newRoot, t.count, newTotalSize)
+		return newImmutable(newRoot, t.count, newTotalSize), recycle
+	}
+
+	// Check if we still have space in the recycle for this node.
+	// It's ok if we don't put every single new node to be recycled
+	// as there's no guarantee in the sync.Pool that every recycled
+	// treapNode will be re-utilized.
+	node := newTreapNode(key, value, rand.Int())
+	if rIdx < staticDepth {
+		recycle[rIdx] = node
+		rIdx++
 	}
 
 	// Link the new node into the binary tree in the correct position.
-	node := newTreapNode(key, value, rand.Int())
 	parent := parents.At(0)
 	if compareResult < 0 {
 		parent.left = node
@@ -211,7 +240,7 @@ func (t *Immutable) put(key, value []byte) *Immutable {
 		}
 	}
 
-	return newImmutable(newRoot, t.count+1, t.totalSize+nodeSize(node))
+	return newImmutable(newRoot, t.count+1, t.totalSize+nodeSize(node)), recycle
 }
 
 // Delete removes the passed key from the treap and returns the resulting treap

--- a/database/internal/treap/immutable.go
+++ b/database/internal/treap/immutable.go
@@ -105,9 +105,62 @@ func (t *Immutable) Get(key []byte) []byte {
 	return nil
 }
 
-// Put inserts the passed key/value pair.
-func (t *Immutable) Put(key, value []byte) *Immutable {
-	return t.put(key, value)
+// Put puts the passed in key/value pairs into the treap.  For operations
+// requiring many insertions at once, Put is memory efficient as the
+// intermediary treap nodes created between each put operation is recycled
+// through an internal sync.Pool, reducing overall memory allocation.
+//
+// If the passed in length of values is less than keys, the keys with no
+// matching values will have nil values.  If the passed in values are nil, all
+// keys will be saved will nil values.
+func (t *Immutable) Put(keys, values [][]byte) *Immutable {
+	treap := t
+	var prevTreapNodes [staticDepth]*treapNode
+
+	for i, key := range keys {
+		// Use an empty byte slice for the value when none was provided.
+		// This ultimately allows key existence to be determined from
+		// the value since an empty byte slice is distinguishable from nil.
+		value := emptySlice
+		if values != nil && i < len(values) {
+			value = values[i]
+		}
+
+		newTreap, newTreapNodes := treap.put(key, value)
+
+		// Loop through the prevTreapNodes and check for treapNodes that
+		// are no longer being utilized.  These will be garbaged collected
+		// and they're better off being recycled in the treapNodePool.
+		for _, node := range prevTreapNodes {
+			if node == nil {
+				break
+			}
+
+			// Make sure that the node we're going to recycle isn't
+			// being used by the latest immutable treap by checking
+			// if the pointer value of the node is the same.
+			got := newTreap.get(node.key)
+			if got == node {
+				continue
+			}
+
+			// This node is only being used by the previous immutable
+			// copy and can safely be put into the treapNodePool to be
+			// recycled.
+			node.key = nil
+			node.value = nil
+			node.priority = 0
+			node.left = nil
+			node.right = nil
+			treapNodePool.Put(node)
+		}
+
+		// Replace with the latest treap and treap nodes.
+		treap = newTreap
+		prevTreapNodes = newTreapNodes
+	}
+
+	return treap
 }
 
 // put inserts the passed key/value pair and returns all the newly created

--- a/database/internal/treap/immutable_test.go
+++ b/database/internal/treap/immutable_test.go
@@ -61,31 +61,41 @@ func TestImmutableSequential(t *testing.T) {
 	// functions work as expected.
 	expectedSize := uint64(0)
 	numItems := 1000
+	keyCount := 100
 	testTreap := NewImmutable()
-	for i := 0; i < numItems; i++ {
-		key := serializeUint32(uint32(i))
-		testTreap = testTreap.Put(key, key)
+	for i := 0; i < numItems/keyCount; i++ {
+		keys := make([][]byte, 0, keyCount)
+		for j := 0; j < keyCount; j++ {
+			n := i*keyCount + j
+			key := serializeUint32(uint32(n))
+			keys = append(keys, key)
+		}
+
+		testTreap = testTreap.Put(keys, keys)
 
 		// Ensure the treap length is the expected value.
-		if gotLen := testTreap.Len(); gotLen != i+1 {
+		if gotLen := testTreap.Len(); gotLen != (i+1)*keyCount {
 			t.Fatalf("Len #%d: unexpected length - got %d, want %d",
 				i, gotLen, i+1)
 		}
 
-		// Ensure the treap has the key.
-		if !testTreap.Has(key) {
-			t.Fatalf("Has #%d: key %q is not in treap", i, key)
-		}
+		for j, key := range keys {
+			// Ensure the treap has the key.
+			if !testTreap.Has(key) {
+				t.Fatalf("Has #%d#%d: key %q is not in treap", i, j, key)
+			}
 
-		// Get the key from the treap and ensure it is the expected
-		// value.
-		if gotVal := testTreap.Get(key); !bytes.Equal(gotVal, key) {
-			t.Fatalf("Get #%d: unexpected value - got %x, want %x",
-				i, gotVal, key)
+			// Get the key from the treap and ensure it is the expected
+			// value.
+			if gotVal := testTreap.Get(key); !bytes.Equal(gotVal, key) {
+				t.Fatalf("Get #%d#%d: unexpected value - got %x, want %x",
+					i, j, gotVal, key)
+			}
+
+			expectedSize += (nodeFieldsSize + 8)
 		}
 
 		// Ensure the expected size is reported.
-		expectedSize += (nodeFieldsSize + 8)
 		if gotSize := testTreap.Size(); gotSize != expectedSize {
 			t.Fatalf("Size #%d: unexpected byte size - got %d, "+
 				"want %d", i, gotSize, expectedSize)
@@ -161,31 +171,41 @@ func TestImmutableReverseSequential(t *testing.T) {
 	// functions work as expected.
 	expectedSize := uint64(0)
 	numItems := 1000
+	keyCount := 100
 	testTreap := NewImmutable()
-	for i := 0; i < numItems; i++ {
-		key := serializeUint32(uint32(numItems - i - 1))
-		testTreap = testTreap.Put(key, key)
+	for i := 0; i < numItems/keyCount; i++ {
+		keys := make([][]byte, 0, keyCount)
+		for j := 0; j < keyCount; j++ {
+			n := numItems - (i * keyCount) - j - 1
+			key := serializeUint32(uint32(n))
+			keys = append(keys, key)
+		}
+
+		testTreap = testTreap.Put(keys, keys)
 
 		// Ensure the treap length is the expected value.
-		if gotLen := testTreap.Len(); gotLen != i+1 {
+		if gotLen := testTreap.Len(); gotLen != (i+1)*keyCount {
 			t.Fatalf("Len #%d: unexpected length - got %d, want %d",
 				i, gotLen, i+1)
 		}
 
-		// Ensure the treap has the key.
-		if !testTreap.Has(key) {
-			t.Fatalf("Has #%d: key %q is not in treap", i, key)
-		}
+		for j, key := range keys {
+			// Ensure the treap has the key.
+			if !testTreap.Has(key) {
+				t.Fatalf("Has #%d#%d: key %q is not in treap", i, j, key)
+			}
 
-		// Get the key from the treap and ensure it is the expected
-		// value.
-		if gotVal := testTreap.Get(key); !bytes.Equal(gotVal, key) {
-			t.Fatalf("Get #%d: unexpected value - got %x, want %x",
-				i, gotVal, key)
+			// Get the key from the treap and ensure it is the expected
+			// value.
+			if gotVal := testTreap.Get(key); !bytes.Equal(gotVal, key) {
+				t.Fatalf("Get #%d#%d: unexpected value - got %x, want %x",
+					i, j, gotVal, key)
+			}
+
+			expectedSize += (nodeFieldsSize + 8)
 		}
 
 		// Ensure the expected size is reported.
-		expectedSize += (nodeFieldsSize + 8)
 		if gotSize := testTreap.Size(); gotSize != expectedSize {
 			t.Fatalf("Size #%d: unexpected byte size - got %d, "+
 				"want %d", i, gotSize, expectedSize)
@@ -262,33 +282,43 @@ func TestImmutableUnordered(t *testing.T) {
 	// treap functions work as expected.
 	expectedSize := uint64(0)
 	numItems := 1000
+	keyCount := 100
 	testTreap := NewImmutable()
-	for i := 0; i < numItems; i++ {
+	for i := 0; i < numItems/keyCount; i++ {
 		// Hash the serialized int to generate out-of-order keys.
-		hash := sha256.Sum256(serializeUint32(uint32(i)))
-		key := hash[:]
-		testTreap = testTreap.Put(key, key)
+		keys := make([][]byte, 0, keyCount)
+		for j := 0; j < keyCount; j++ {
+			n := i*keyCount + j
+			hash := sha256.Sum256(serializeUint32(uint32(n)))
+			key := hash[:]
+			keys = append(keys, key)
+		}
+
+		testTreap = testTreap.Put(keys, keys)
 
 		// Ensure the treap length is the expected value.
-		if gotLen := testTreap.Len(); gotLen != i+1 {
+		if gotLen := testTreap.Len(); gotLen != (i+1)*keyCount {
 			t.Fatalf("Len #%d: unexpected length - got %d, want %d",
 				i, gotLen, i+1)
 		}
 
-		// Ensure the treap has the key.
-		if !testTreap.Has(key) {
-			t.Fatalf("Has #%d: key %q is not in treap", i, key)
-		}
+		for j, key := range keys {
+			// Ensure the treap has the key.
+			if !testTreap.Has(key) {
+				t.Fatalf("Has #%d#%d: key %q is not in treap", i, j, key)
+			}
 
-		// Get the key from the treap and ensure it is the expected
-		// value.
-		if gotVal := testTreap.Get(key); !bytes.Equal(gotVal, key) {
-			t.Fatalf("Get #%d: unexpected value - got %x, want %x",
-				i, gotVal, key)
+			// Get the key from the treap and ensure it is the expected
+			// value.
+			if gotVal := testTreap.Get(key); !bytes.Equal(gotVal, key) {
+				t.Fatalf("Get #%d#%d: unexpected value - got %x, want %x",
+					i, j, gotVal, key)
+			}
+
+			expectedSize += nodeFieldsSize + uint64(len(key)+len(key))
 		}
 
 		// Ensure the expected size is reported.
-		expectedSize += nodeFieldsSize + uint64(len(key)+len(key))
 		if gotSize := testTreap.Size(); gotSize != expectedSize {
 			t.Fatalf("Size #%d: unexpected byte size - got %d, "+
 				"want %d", i, gotSize, expectedSize)
@@ -335,31 +365,50 @@ func TestImmutableUnordered(t *testing.T) {
 func TestImmutableDuplicatePut(t *testing.T) {
 	t.Parallel()
 
+	keyCount := 100
 	expectedVal := []byte("testval")
+	expectedVals := make([][]byte, keyCount)
+	for i := range expectedVals {
+		expectedVals[i] = expectedVal
+	}
+
 	expectedSize := uint64(0)
 	numItems := 1000
 	testTreap := NewImmutable()
-	for i := 0; i < numItems; i++ {
-		key := serializeUint32(uint32(i))
-		testTreap = testTreap.Put(key, key)
-		expectedSize += nodeFieldsSize + uint64(len(key)+len(key))
-
-		// Put a duplicate key with the expected final value.
-		testTreap = testTreap.Put(key, expectedVal)
-
-		// Ensure the key still exists and is the new value.
-		if gotVal := testTreap.Has(key); !gotVal {
-			t.Fatalf("Has: unexpected result - got %v, want true",
-				gotVal)
+	for i := 0; i < numItems/keyCount; i++ {
+		keys := make([][]byte, 0, keyCount)
+		for j := 0; j < keyCount; j++ {
+			n := i*keyCount + j
+			key := serializeUint32(uint32(n))
+			keys = append(keys, key)
 		}
-		if gotVal := testTreap.Get(key); !bytes.Equal(gotVal, expectedVal) {
-			t.Fatalf("Get: unexpected result - got %x, want %x",
-				gotVal, expectedVal)
+
+		testTreap = testTreap.Put(keys, keys)
+
+		// Get expectedSize.
+		for _, key := range keys {
+			expectedSize += nodeFieldsSize + uint64(len(key)+len(key))
+		}
+
+		// Put duplicate keys with the expected final values.
+		testTreap = testTreap.Put(keys, expectedVals)
+
+		// Ensure the keys still exist and is the new value.
+		for _, key := range keys {
+			if gotVal := testTreap.Has(key); !gotVal {
+				t.Fatalf("Has: unexpected result - got %v, want true",
+					gotVal)
+			}
+			if gotVal := testTreap.Get(key); !bytes.Equal(gotVal, expectedVal) {
+				t.Fatalf("Get: unexpected result - got %x, want %x",
+					gotVal, expectedVal)
+			}
+
+			expectedSize -= uint64(len(key))
+			expectedSize += uint64(len(expectedVal))
 		}
 
 		// Ensure the expected size is reported.
-		expectedSize -= uint64(len(key))
-		expectedSize += uint64(len(expectedVal))
 		if gotSize := testTreap.Size(); gotSize != expectedSize {
 			t.Fatalf("Size: unexpected byte size - got %d, want %d",
 				gotSize, expectedSize)
@@ -376,7 +425,7 @@ func TestImmutableNilValue(t *testing.T) {
 
 	// Put the key with a nil value.
 	testTreap := NewImmutable()
-	testTreap = testTreap.Put(key, nil)
+	testTreap = testTreap.Put([][]byte{key}, nil)
 
 	// Ensure the key exists and is an empty byte slice.
 	if gotVal := testTreap.Has(key); !gotVal {
@@ -399,10 +448,12 @@ func TestImmutableForEachStopIterator(t *testing.T) {
 	// Insert a few keys.
 	numItems := 10
 	testTreap := NewImmutable()
+	keys := make([][]byte, 0, numItems)
 	for i := 0; i < numItems; i++ {
 		key := serializeUint32(uint32(i))
-		testTreap = testTreap.Put(key, key)
+		keys = append(keys, key)
 	}
+	testTreap = testTreap.Put(keys, keys)
 
 	// Ensure ForEach exits early on false return by caller.
 	var numIterated int
@@ -426,38 +477,48 @@ func TestImmutableSnapshot(t *testing.T) {
 	// functions work as expected.
 	expectedSize := uint64(0)
 	numItems := 1000
+	keyCount := 100
 	testTreap := NewImmutable()
-	for i := 0; i < numItems; i++ {
+	for i := 0; i < numItems/keyCount; i++ {
 		treapSnap := testTreap
 
-		key := serializeUint32(uint32(i))
-		testTreap = testTreap.Put(key, key)
+		keys := make([][]byte, 0, keyCount)
+		for j := 0; j < keyCount; j++ {
+			n := i*keyCount + j
+			key := serializeUint32(uint32(n))
+			keys = append(keys, key)
+		}
+
+		testTreap = testTreap.Put(keys, keys)
 
 		// Ensure the length of the treap snapshot is the expected
 		// value.
-		if gotLen := treapSnap.Len(); gotLen != i {
+		if gotLen := treapSnap.Len(); gotLen != i*keyCount {
 			t.Fatalf("Len #%d: unexpected length - got %d, want %d",
 				i, gotLen, i)
 		}
 
-		// Ensure the treap snapshot does not have the key.
-		if treapSnap.Has(key) {
-			t.Fatalf("Has #%d: key %q is in treap", i, key)
+		for j, key := range keys {
+			// Ensure the treap snapshot does not have the key.
+			if treapSnap.Has(key) {
+				t.Fatalf("Has #%d#%d: key %q is in treap", i, j, key)
+			}
+
+			// Get the key that doesn't exist in the treap snapshot and
+			// ensure it is nil.
+			if gotVal := treapSnap.Get(key); gotVal != nil {
+				t.Fatalf("Get #%d#%d: unexpected value - got %x, want nil",
+					i, j, gotVal)
+			}
+
+			// Ensure the expected size is reported.
+			if gotSize := treapSnap.Size(); gotSize != expectedSize {
+				t.Fatalf("Size #%d#%d: unexpected byte size - got %d, "+
+					"want %d", i, j, gotSize, expectedSize)
+			}
 		}
 
-		// Get the key that doesn't exist in the treap snapshot and
-		// ensure it is nil.
-		if gotVal := treapSnap.Get(key); gotVal != nil {
-			t.Fatalf("Get #%d: unexpected value - got %x, want nil",
-				i, gotVal)
-		}
-
-		// Ensure the expected size is reported.
-		if gotSize := treapSnap.Size(); gotSize != expectedSize {
-			t.Fatalf("Size #%d: unexpected byte size - got %d, "+
-				"want %d", i, gotSize, expectedSize)
-		}
-		expectedSize += (nodeFieldsSize + 8)
+		expectedSize += (nodeFieldsSize + 8) * uint64(keyCount)
 	}
 
 	// Delete the keys one-by-one while checking several of the treap

--- a/database/internal/treap/treapiter_test.go
+++ b/database/internal/treap/treapiter_test.go
@@ -496,10 +496,12 @@ testLoop:
 	for i, test := range tests {
 		// Insert a bunch of keys.
 		testTreap := NewImmutable()
+		keys := make([][]byte, 0, test.numKeys)
 		for i := 0; i < test.numKeys; i += test.step {
 			key := serializeUint32(uint32(i))
-			testTreap = testTreap.Put(key, key)
+			keys = append(keys, key)
 		}
+		testTreap = testTreap.Put(keys, keys)
 
 		// Create new iterator limited by the test params.
 		iter := testTreap.Iterator(test.startKey, test.limitKey)


### PR DESCRIPTION
## Change Description
During the initial-block download, one of the biggest culprits of excessive memory allocation was the [immutable treap](https://github.com/btcsuite/btcd/blob/e8097a1b044c3c0b3843b2aba377e87eb5fc4f9f/database/internal/treap/immutable.go#L23-L46).
The immutable treap guarantees immutability by cloning all shared nodes that'll be modified inside the treap during deletion and put operations.

For the insertions of 3 keys:

key 1: 50
key 2: 10
key 3: 4
     
The insertion is like so:
```   
    1: allocate 50.
     
            50
     
    2: clone 50, allocate 10.
     
            50
           /  \
          10
     
    3: clone 50, clone 10, allocate 4
     
            50
           /  \
          10
         /
        4
```

In the above example, only the nodes allocated during insertion of (3) is going to be used. 
The rest is going to be garbage collected immediately which results in memory being allocated too much.

The memory allocation savings in this PR comes from putting the nodes that'll be garbage collected in the sync.Pool.

We're able to safely recycle the intermediary nodes as we now require the `Put()` operation to take in multiple key-value pairs.
Since there's a guarantee that the previous copies are not being accessed as they're *only* accessible within the `Put()` operation, it's safe to recycle them.

I tested both the `master` and `b3bf17cd0f924c82634271babb2e312f44b7a314` with the following command.
I used the `connect` flag to reduce the differences that would happen a random selection of peers.
I added a checkpoint just to speed up things on signet since there aren't checkpoints by default for signet.

```
btcd --datadir=. --logdir=. --signet --addcheckpoint=260000:0000000b2d5533cb361cab243eb2034986c579efceb2fe266baa057104537bf5 --memprofile=memprof-with-master --connect=100.115.246.54
```

On master, the pprof flamegraph for syncing on signet looks like so:

We can see that the `cloneTreapNode` function is taking up a lot of space in the flamegraph.
The total memory allocation is also 511GB.
![IMG_0418](https://github.com/user-attachments/assets/728c3bb3-3450-432d-b3c1-adbf7026c66a)

With this PR, the flamegraph looks like so:

We can see a dramatic reduction in the total memory allocated as it's now just 359GB.
The problematic `cloneTreapNode` is also significantly reduced in the flamegraph.
![IMG_0419](https://github.com/user-attachments/assets/f78f919c-2f85-446b-80aa-4c186cf76499)

I added the profiles that I took in this zip file:
[2025-09-20-treappool-pprof.zip](https://github.com/user-attachments/files/22441189/2025-09-20-treappool-pprof.zip)

## Steps to Test

To test that there is a memory reduction, run the following command on `master` and on this PR.
Compare that there's less memory allocation with this PR.

```
# Make sure to edit the output name for the flag `memprofile`!
btcd --datadir=. --logdir=. --signet --addcheckpoint=260000:0000000b2d5533cb361cab243eb2034986c579efceb2fe266baa057104537bf5 --memprofile=memprof-with-master
```

To test that the `Put()` function still guarantees immutability, check that the tests in `immutable_test.go` are correctly
modified to account for the function prototype change.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
