### PR TITLE
Testcases: Fix an obvious typo / bug

### DIFF
--- a/btcjson/help.go
+++ b/btcjson/help.go
@@ -269,7 +269,7 @@ func resultTypeHelp(xT descLookupFunc, rt reflect.Type, fieldDescKey string) str
 	w.Init(&formatted, 0, 4, 1, ' ', 0)
 	for i, text := range results {
 		if i == len(results)-1 {
-			fmt.Fprintf(w, text)
+			fmt.Fprint(w, text)
 		} else {
 			fmt.Fprintln(w, text)
 		}


### PR DESCRIPTION
This is a compile time error on newer compilers, caused testcases to fail

## Change Description
The issue was that help.go testcase was failing to compile.
Whoever wrote this didn't intend to utilize the first arg w as format string, as evidenced by the else branch.

## Steps to Test
go test ./...

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
