### PR TITLE
txscript: increase OP_RETURN data limit to 100KB

### DIFF
--- a/integration/rawtx_test.go
+++ b/integration/rawtx_test.go
@@ -221,10 +221,11 @@ func TestLargeOPReturnMempool(t *testing.T) {
 	})
 
 	testCases := []struct {
-		name          string
-		dataSize      int
-		shouldSucceed bool
-		failureReason string
+		name                string
+		dataSize            int
+		shouldSucceed       bool
+		failureReason       string
+		failsScriptCreation bool
 	}{
 		{
 			name:          "75KB OP_RETURN (well over old 80 byte/520 byte limits)",
@@ -237,52 +238,140 @@ func TestLargeOPReturnMempool(t *testing.T) {
 			shouldSucceed: false,
 			failureReason: "transaction size exceeds maxStandardTxWeight (100,000 vbytes)",
 		},
+		{
+			name:                "101KB OP_RETURN (exceeds MaxDataCarrierSize)",
+			dataSize:            101000,
+			shouldSucceed:       false,
+			failureReason:       "data exceeds MaxDataCarrierSize",
+			failsScriptCreation: true,
+		},
 	}
 
+	// Run single OP_RETURN tests
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			// Create large OP_RETURN script.
-			largeData := make([]byte, tc.dataSize)
-			for i := range largeData {
-				largeData[i] = byte(i % 256)
-			}
-
-			opReturnScript, err := txscript.NullDataScript(largeData)
-			require.NoError(t, err)
-
-			// Create a transaction with OP_RETURN output using the harness wallet.
-			// The wallet will handle signing and input selection.
-			opReturnOutput := &wire.TxOut{
-				Value:    0,
-				PkScript: opReturnScript,
-			}
-
-			// Create transaction with the OP_RETURN output.
-			// The wallet automatically adds inputs and a change output if needed.
-			tx, err := node.CreateTransaction([]*wire.TxOut{opReturnOutput}, 10, true)
-			require.NoError(t, err)
-
-			// Log the actual transaction size.
-			txSize := tx.SerializeSize()
-			txWeight := txSize * 4 // Non-segwit: weight = size * 4
-			t.Logf("Transaction size: %d bytes, weight: %d (limit: 400000)", txSize, txWeight)
-
-			// Submit to the mempool.
-			txHash, err := node.Client.SendRawTransaction(tx, true)
-
-			if tc.shouldSucceed {
-				require.NoError(t, err, "Large OP_RETURN tx should be accepted")
-				t.Logf("✓ Large OP_RETURN tx (%d bytes data) accepted: %s", tc.dataSize, txHash)
-
-				// Verify it's in the mempool.
-				mempool, err := node.Client.GetRawMempool()
-				require.NoError(t, err)
-				require.Contains(t, mempool, txHash, "Transaction should be in mempool")
-			} else {
-				require.Error(t, err, "Transaction should be rejected: %s", tc.failureReason)
-				t.Logf("✓ Transaction correctly rejected (%s): %v", tc.failureReason, err)
-			}
+			testSingleOPReturn(t, node, tc)
 		})
 	}
+
+	// Run multiple OP_RETURN test
+	t.Run("Multiple OP_RETURNs", func(t *testing.T) {
+		testMultipleOPReturns(t, node)
+	})
+}
+
+func testSingleOPReturn(t *testing.T, node *rpctest.Harness, tc struct {
+	name                string
+	dataSize            int
+	shouldSucceed       bool
+	failureReason       string
+	failsScriptCreation bool
+}) {
+	require := require.New(t)
+
+	// Create large OP_RETURN script.
+	largeData := make([]byte, tc.dataSize)
+	for i := range largeData {
+		largeData[i] = byte(i % 256)
+	}
+
+	opReturnScript, err := txscript.NullDataScript(largeData)
+
+	// If we expect script creation to fail (e.g., data > MaxDataCarrierSize), verify and return.
+	if tc.failsScriptCreation {
+		require.Error(err, "NullDataScript should fail for data exceeding MaxDataCarrierSize")
+		t.Logf("✓ NullDataScript correctly rejected (%s): %v", tc.failureReason, err)
+		return
+	}
+
+	require.NoError(err, "NullDataScript should succeed for data under MaxDataCarrierSize")
+
+	// Create a transaction with OP_RETURN output using the harness wallet.
+	// The wallet will handle signing and input selection.
+	opReturnOutput := &wire.TxOut{
+		Value:    0,
+		PkScript: opReturnScript,
+	}
+
+	// Create transaction with the OP_RETURN output.
+	// The wallet automatically adds inputs and a change output if needed.
+	tx, err := node.CreateTransaction([]*wire.TxOut{opReturnOutput}, 10, true)
+	require.NoError(err)
+
+	// Log the actual transaction size.
+	txSize := tx.SerializeSize()
+	txWeight := txSize * 4 // Non-segwit: weight = size * 4
+	t.Logf("Transaction size: %d bytes, weight: %d (limit: 400000)", txSize, txWeight)
+
+	// Submit to the mempool.
+	txHash, err := node.Client.SendRawTransaction(tx, true)
+
+	if tc.shouldSucceed {
+		require.NoError(err, "Large OP_RETURN tx should be accepted")
+		t.Logf("✓ Large OP_RETURN tx (%d bytes data) accepted: %s", tc.dataSize, txHash)
+
+		// Verify it's in the mempool.
+		mempool, err := node.Client.GetRawMempool()
+		require.NoError(err)
+		require.Contains(mempool, txHash, "Transaction should be in mempool")
+	} else {
+		require.Error(err, "Transaction should be rejected: %s", tc.failureReason)
+		t.Logf("✓ Transaction correctly rejected (%s): %v", tc.failureReason, err)
+	}
+}
+
+func testMultipleOPReturns(t *testing.T, node *rpctest.Harness) {
+	require := require.New(t)
+
+	// Create multiple large OP_RETURN outputs totaling ~75KB.
+	// This tests that multiple OP_RETURNs work even with large data sizes.
+	data1 := make([]byte, 25000)
+	data2 := make([]byte, 25000)
+	data3 := make([]byte, 25000)
+
+	for i := range data1 {
+		data1[i] = byte(i % 256)
+	}
+	for i := range data2 {
+		data2[i] = byte((i + 100) % 256)
+	}
+	for i := range data3 {
+		data3[i] = byte((i + 200) % 256)
+	}
+
+	script1, err := txscript.NullDataScript(data1)
+	require.NoError(err)
+
+	script2, err := txscript.NullDataScript(data2)
+	require.NoError(err)
+
+	script3, err := txscript.NullDataScript(data3)
+	require.NoError(err)
+
+	// Create transaction with three OP_RETURN outputs.
+	outputs := []*wire.TxOut{
+		{Value: 0, PkScript: script1},
+		{Value: 0, PkScript: script2},
+		{Value: 0, PkScript: script3},
+	}
+
+	tx, err := node.CreateTransaction(outputs, 10, true)
+	require.NoError(err)
+
+	txSize := tx.SerializeSize()
+	txWeight := txSize * 4
+	totalDataSize := len(data1) + len(data2) + len(data3)
+	t.Logf("Multiple OP_RETURN transaction: %d bytes (weight: %d, data: %d bytes)",
+		txSize, txWeight, totalDataSize)
+
+	// Submit to the mempool.
+	txHash, err := node.Client.SendRawTransaction(tx, true)
+	require.NoError(err, "Transaction with multiple OP_RETURNs should be accepted")
+	t.Logf("✓ Transaction with 3 OP_RETURNs (~75KB total data) accepted: %s", txHash)
+
+	// Verify it's in the mempool.
+	mempool, err := node.Client.GetRawMempool()
+	require.NoError(err)
+	require.Contains(mempool, txHash, "Transaction should be in mempool")
 }

--- a/mempool/policy.go
+++ b/mempool/policy.go
@@ -365,12 +365,9 @@ func CheckTransactionStandard(tx *btcutil.Tx, height int32,
 		}
 	}
 
-	// A standard transaction must not have more than one output script that
-	// only carries data.
-	if numNullDataOutputs > 1 {
-		str := "more than one transaction output in a nulldata script"
-		return txRuleError(wire.RejectNonstandard, str)
-	}
+	// Note: Multiple OP_RETURN outputs are now allowed as standard.
+	// Each output is still subject to MaxDataCarrierSize and the
+	// overall transaction remains subject to maxStandardTxWeight.
 
 	return nil
 }

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -462,6 +462,33 @@ func TestCheckTransactionStandard(t *testing.T) {
 			height:     300000,
 			isStandard: true,
 		},
+		{
+			name: "Large nulldata output with 75KB data (standard after v30)",
+			tx: func() wire.MsgTx {
+				// Create a large OP_RETURN with 75KB of data
+				// This is well over previous limits (80 bytes, 520 bytes MaxScriptElementSize)
+				// but under the new 100KB MaxDataCarrierSize limit
+				largeData := make([]byte, 75000)
+				for i := range largeData {
+					largeData[i] = byte(i % 256)
+				}
+				pkScript, err := txscript.NullDataScript(largeData)
+				if err != nil {
+					t.Fatalf("NullDataScript: unexpected error: %v", err)
+				}
+				return wire.MsgTx{
+					Version: 1,
+					TxIn:    []*wire.TxIn{&dummyTxIn},
+					TxOut: []*wire.TxOut{{
+						Value:    0,
+						PkScript: pkScript,
+					}},
+					LockTime: 0,
+				}
+			}(),
+			height:     300000,
+			isStandard: true,
+		},
 	}
 
 	pastMedianTime := time.Now()

--- a/mempool/policy_test.go
+++ b/mempool/policy_test.go
@@ -416,7 +416,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 			code:       wire.RejectNonstandard,
 		},
 		{
-			name: "More than one nulldata output",
+			name: "Multiple nulldata outputs (now standard)",
 			tx: wire.MsgTx{
 				Version: 1,
 				TxIn:    []*wire.TxIn{&dummyTxIn},
@@ -430,8 +430,7 @@ func TestCheckTransactionStandard(t *testing.T) {
 				LockTime: 0,
 			},
 			height:     300000,
-			isStandard: false,
-			code:       wire.RejectNonstandard,
+			isStandard: true,
 		},
 		{
 			name: "Dust output",
@@ -488,6 +487,125 @@ func TestCheckTransactionStandard(t *testing.T) {
 			}(),
 			height:     300000,
 			isStandard: true,
+		},
+		{
+			name: "Three nulldata outputs totaling ~75KB",
+			tx: func() wire.MsgTx {
+				// Create three large OP_RETURNs totaling approximately 75KB
+				data1 := make([]byte, 25000)
+				data2 := make([]byte, 25000)
+				data3 := make([]byte, 25000)
+				for i := range data1 {
+					data1[i] = byte(i % 256)
+				}
+				for i := range data2 {
+					data2[i] = byte((i + 100) % 256)
+				}
+				for i := range data3 {
+					data3[i] = byte((i + 200) % 256)
+				}
+
+				pkScript1, _ := txscript.NullDataScript(data1)
+				pkScript2, _ := txscript.NullDataScript(data2)
+				pkScript3, _ := txscript.NullDataScript(data3)
+
+				return wire.MsgTx{
+					Version: 1,
+					TxIn:    []*wire.TxIn{&dummyTxIn},
+					TxOut: []*wire.TxOut{{
+						Value:    0,
+						PkScript: pkScript1,
+					}, {
+						Value:    0,
+						PkScript: pkScript2,
+					}, {
+						Value:    0,
+						PkScript: pkScript3,
+					}},
+					LockTime: 0,
+				}
+			}(),
+			height:     300000,
+			isStandard: true,
+		},
+		{
+			name: "Mixed outputs with two large OP_RETURNs and payment",
+			tx: func() wire.MsgTx {
+				// Create two large OP_RETURNs plus a payment output
+				data1 := make([]byte, 37000)
+				data2 := make([]byte, 37000)
+				for i := range data1 {
+					data1[i] = byte(i % 256)
+				}
+				for i := range data2 {
+					data2[i] = byte((i + 150) % 256)
+				}
+
+				pkScript1, _ := txscript.NullDataScript(data1)
+				pkScript2, _ := txscript.NullDataScript(data2)
+
+				return wire.MsgTx{
+					Version: 1,
+					TxIn:    []*wire.TxIn{&dummyTxIn},
+					TxOut: []*wire.TxOut{{
+						Value:    100000000, // 1 BTC payment
+						PkScript: dummyPkScript,
+					}, {
+						Value:    0,
+						PkScript: pkScript1,
+					}, {
+						Value:    0,
+						PkScript: pkScript2,
+					}},
+					LockTime: 0,
+				}
+			}(),
+			height:     300000,
+			isStandard: true,
+		},
+		{
+			name: "Multiple OP_RETURNs with combined size over 100KB (but each under limit)",
+			tx: func() wire.MsgTx {
+				// Each OP_RETURN is under 100KB individually, but combined they exceed it.
+				// Each is 60KB, total is 180KB of OP_RETURN data.
+				// This tests that each output is independently subject to MaxDataCarrierSize,
+				// and the transaction as a whole is limited by maxStandardTxWeight.
+				data1 := make([]byte, 60000)
+				data2 := make([]byte, 60000)
+				data3 := make([]byte, 60000)
+				for i := range data1 {
+					data1[i] = byte(i % 256)
+				}
+				for i := range data2 {
+					data2[i] = byte((i + 100) % 256)
+				}
+				for i := range data3 {
+					data3[i] = byte((i + 200) % 256)
+				}
+
+				pkScript1, _ := txscript.NullDataScript(data1)
+				pkScript2, _ := txscript.NullDataScript(data2)
+				pkScript3, _ := txscript.NullDataScript(data3)
+
+				return wire.MsgTx{
+					Version: 1,
+					TxIn:    []*wire.TxIn{&dummyTxIn},
+					TxOut: []*wire.TxOut{{
+						Value:    0,
+						PkScript: pkScript1,
+					}, {
+						Value:    0,
+						PkScript: pkScript2,
+					}, {
+						Value:    0,
+						PkScript: pkScript3,
+					}},
+					LockTime: 0,
+				}
+			}(),
+			height:     300000,
+			isStandard: false, // Rejected due to exceeding maxStandardTxWeight
+			code:       wire.RejectNonstandard,
 		},
 	}
 

--- a/txscript/scriptbuilder.go
+++ b/txscript/scriptbuilder.go
@@ -199,13 +199,19 @@ func (b *ScriptBuilder) addData(data []byte) *ScriptBuilder {
 	return b
 }
 
-// AddFullData should not typically be used by ordinary users as it does not
-// include the checks which prevent data pushes larger than the maximum allowed
-// sizes which leads to scripts that can't be executed.  This is provided for
-// testing purposes such as regression tests where sizes are intentionally made
-// larger than allowed.
+// AddFullData pushes the passed data to the end of the script without
+// enforcing MaxScriptElementSize limits. It automatically chooses canonical
+// opcodes depending on the length of the data.
 //
-// Use AddData instead.
+// This function bypasses the 520-byte MaxScriptElementSize limit and is
+// intended for:
+//
+//  1. Creating OP_RETURN outputs with data larger than 520 bytes, since they
+//     are provably unspendable and never executed.
+//  2. Testing purposes where scripts need to intentionally exceed limits.
+//
+// For regular data pushes that will be executed, use AddData instead, which
+// enforces size limits to ensure the resulting script can be executed.
 func (b *ScriptBuilder) AddFullData(data []byte) *ScriptBuilder {
 	if b.err != nil {
 		return b

--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -15,7 +15,7 @@ import (
 const (
 	// MaxDataCarrierSize is the maximum number of bytes allowed in pushed
 	// data to be considered a nulldata transaction
-	MaxDataCarrierSize = 80
+	MaxDataCarrierSize = 100000
 
 	// StandardVerifyFlags are the script flags which are used when
 	// executing transaction scripts to enforce additional checks which
@@ -885,6 +885,10 @@ func PayToAddrScript(addr btcutil.Address) ([]byte, error) {
 // NullDataScript creates a provably-prunable script containing OP_RETURN
 // followed by the passed data.  An Error with the error code ErrTooMuchNullData
 // will be returned if the length of the passed data exceeds MaxDataCarrierSize.
+//
+// Note: This function uses AddFullData to bypass MaxScriptElementSize since
+// OP_RETURN outputs are provably unspendable and never executed. The data size
+// is only constrained by MaxDataCarrierSize policy and MaxScriptSize consensus.
 func NullDataScript(data []byte) ([]byte, error) {
 	if len(data) > MaxDataCarrierSize {
 		str := fmt.Sprintf("data size %d is larger than max "+
@@ -892,7 +896,7 @@ func NullDataScript(data []byte) ([]byte, error) {
 		return nil, scriptError(ErrTooMuchNullData, str)
 	}
 
-	return NewScriptBuilder().AddOp(OP_RETURN).AddData(data).Script()
+	return NewScriptBuilder().AddOp(OP_RETURN).AddFullData(data).Script()
 }
 
 // MultiSigScript returns a valid script for a multisignature redemption where


### PR DESCRIPTION
## Change Description

This PR implements Bitcoin Core v30 OP_RETURN policy changes by:
1. Increasing `MaxDataCarrierSize` from 80 bytes to 100,000 bytes
2. Removing the restriction limiting transactions to a single OP_RETURN output

These changes align btcd with Bitcoin Core v30, which removed both the 80-byte data limit and the single OP_RETURN restriction.

### Motivation

Bitcoin Core v30 updated OP_RETURN policies by removing the specific `-datacarriersize` default of 80 bytes (replacing it with 100,000 bytes) and eliminating the single OP_RETURN per transaction restriction. These changes bring btcd into alignment with Bitcoin Core v30 for several critical reasons:

**1. Policy Alignment**  
Maintains consistency with Bitcoin Core v30, ensuring btcd nodes accept the same set of standard transactions as the Bitcoin reference implementation. Both the data size limit and multiple OP_RETURN restrictions were arbitrary policy limitations with no consensus basis.

**2. Accurate Fee Estimation**  
Filtering large OP_RETURN transactions or transactions with multiple OP_RETURNs from the mempool hides transactions competing for blockspace, leading to inaccurate fee estimation. Full mempool visibility is essential for informed fee rate calculation.

**3. Validation Performance & Block Propagation**  
Rejecting transactions that will be mined by other nodes means they must be validated "cold" when processing blocks, without cached results. This causes slower block validation, delayed block propagation, and increased orphan risk for miners.

**4. Network Decentralization**  
Slow block propagation disproportionately advantages large mining operations with preferentially peered nodes, giving them a head start on the next block. Pre-validating all likely-to-be-mined transactions helps maintain network decentralization.

### Changes

#### Data Carrier Size Increase
- **txscript/standard.go**: Increased `MaxDataCarrierSize` from 80 to 100,000 bytes
- **txscript/standard.go**: Modified `NullDataScript()` to use `AddFullData()` to bypass `MaxScriptElementSize` (520 bytes) since OP_RETURN outputs are never executed
- **txscript/scriptbuilder.go**: Updated `AddFullData()` documentation to reflect its legitimate use for large OP_RETURN outputs
- **txscript/standard_test.go**: Updated tests for new size limits (81 bytes, 9,995 bytes, 100,001 bytes)

#### Multiple OP_RETURN Support
- **mempool/policy.go**: Removed the check restricting transactions to one OP_RETURN output
- **mempool/policy_test.go**: Added tests for multiple OP_RETURNs with varying sizes
  - Two small OP_RETURNs
  - Three 25KB OP_RETURNs (~75KB total)
  - Two 37KB OP_RETURNs + payment output
  - Three 60KB OP_RETURNs (180KB total - correctly rejected by transaction weight)

#### Integration Tests
- **integration/rawtx_test.go**: Comprehensive end-to-end tests
  - 75KB single OP_RETURN: Accepted
  - 100KB single OP_RETURN: Rejected (exceeds transaction weight limit)
  - 101KB single OP_RETURN: Rejected (exceeds MaxDataCarrierSize)
  - Multiple OP_RETURNs (3 × 25KB): Accepted into mempool

### Technical Notes

**MaxDataCarrierSize**  
Increased to 100,000 bytes, effectively removing the specific data carrier size limit. The existing transaction size limit (maxStandardTxWeight of 400,000 weight units ≈ 100KB total transaction) will apply before the data carrier limit is reached due to transaction overhead (inputs, outputs, signatures, etc.).

**Multiple OP_RETURNs**  
Each OP_RETURN output is independently validated against MaxDataCarrierSize (100KB). The transaction as a whole remains subject to maxStandardTxWeight (400,000 weight units ≈ 100KB total transaction).

**Script Limits**  
OP_RETURN outputs are exempt from `MaxScriptElementSize` (520 bytes) execution limits because they are provably unspendable and never executed by the script engine.

### Compatibility

- ✅ Backward compatible: All existing OP_RETURN transactions remain valid
- ✅ Forward compatible: Aligns with Bitcoin Core v30 behavior  
- ✅ No consensus changes: These are policy-only changes

## Steps to Test

### 1. Run Unit Tests
```bash
go test ./txscript/... -v
```
Expected: All tests pass, including new tests for:
- 81-byte OP_RETURN (now standard, previously rejected)
- 9,995-byte OP_RETURN (under MaxScriptSize)
- 100,001-byte OP_RETURN (exceeds MaxDataCarrierSize, rejected)

### 2. Run Policy Tests
```bash
go test ./mempool/... -v -run TestCheckTransactionStandard
```
Expected: All tests pass, including:
- 75KB single OP_RETURN (accepted)
- Multiple OP_RETURNs totaling ~75KB (accepted)
- Multiple OP_RETURNs totaling 180KB (rejected by transaction weight)

### 3. Run Integration Tests
```bash
go test -tags=rpctest ./integration/... -v -run TestLargeOPReturnMempool
```
Expected: All test cases pass:
- 75KB OP_RETURN: Accepted into mempool (weight: 300,840 < 400,000 limit)
- 100KB OP_RETURN: Rejected (weight: 400,840 > 400,000 limit)
- 101KB OP_RETURN: Rejected (exceeds MaxDataCarrierSize)
- Multiple OP_RETURNs (3 × 25KB): Accepted into mempool

### 4. Run Full Test Suite
```bash
go test ./...
```
Expected: All tests pass across the entire codebase.

### 5. Code Quality Checks
```bash
go fmt ./...
go vet ./...
```
Expected: No issues found.

## Pull Request Checklist

### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.