### PR TITLE
musig2: add WithExternalCombinedNonce option to Sign

### DIFF
--- a/btcec/schnorr/musig2/context.go
+++ b/btcec/schnorr/musig2/context.go
@@ -553,6 +553,20 @@ func (s *Session) RegisterPubNonce(nonce [PubNonceSize]byte) (bool, error) {
 	return haveAllNonces, nil
 }
 
+// CombinedNonce returns the combined public nonce for the signing session.
+// This will be available after either:
+//   - All individual nonces have been registered via RegisterPubNonce, or
+//   - A combined nonce has been registered via RegisterCombinedNonce
+//
+// If the combined nonce is not yet available, this method returns an error.
+func (s *Session) CombinedNonce() ([PubNonceSize]byte, error) {
+	if s.combinedNonce == nil {
+		return [PubNonceSize]byte{}, ErrCombinedNonceUnavailable
+	}
+
+	return *s.combinedNonce, nil
+}
+
 // RegisterCombinedNonce allows a caller to directly register a combined nonce
 // that was generated externally. This is useful in coordinator-based
 // protocols where the coordinator aggregates all nonces and distributes the


### PR DESCRIPTION
This PR adds a new functional option to the Session.Sign function which allows specifying an external combined Nonce. This is useful when a central coordinator aggregates all nonces.

Externally Aggregated Nonces are part of the spec:
```
Third-party nonce and partial signature aggregation: Instead of every signer sending their nonce and partial signature to every 
other signer, it is possible to use an untrusted third-party aggregator in order to reduce the communication complexity from 
quadratic to linear in the number of signers. In each of the two rounds, the aggregator collects all signers' contributions 
(nonces or partial signatures), aggregates them, and broadcasts the aggregate back to the signers. A malicious aggregator can 
force the signing session to fail to produce a valid Schnorr signature but cannot negatively affect the unforgeability of the
 scheme.
```
https://github.com/bitcoin/bips/blob/master/bip-0327.mediawiki#user-content-Nonce_Aggregation