### PR TITLE
rpcclient: ensure http dial respects timeout

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -1356,10 +1356,11 @@ func newHTTPClient(config *ConnConfig) (*http.Client, error) {
 		Transport: &http.Transport{
 			Proxy:           proxyFunc,
 			TLSClientConfig: tlsConfig,
-			DialContext: func(_ context.Context, _,
+			DialContext: func(ctx context.Context, _,
 				_ string) (net.Conn, error) {
-
-				return net.Dial(
+				d := &net.Dialer{}
+				return d.DialContext(
+					ctx,
 					parsedDialAddr.Network(),
 					parsedDialAddr.String(),
 				)


### PR DESCRIPTION
## Change Description
Ensure that the dial phase of rpcclient's HTTP posts respects the http.Client's Timeout. It was instead falling back to the OS settings.

## Steps to Test
This is a bit challenging to test, as it requires simulating a very laggy dial. Not sure the juice is worth the squeeze.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
