### PR TITLE
rpcclient: make shutdown interrupt in-flight POSTs

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -789,10 +789,6 @@ retryloop:
 		bodyReader := bytes.NewReader(jReq.marshalledJSON)
 		httpReq, err = http.NewRequestWithContext(ctx, "POST", httpURL, bodyReader)
 		if err != nil {
-			// We must observe the contract that shutdown returns ErrClientShutdown.
-			if errors.Is(err, context.Canceled) && errors.Is(context.Cause(ctx), ErrClientShutdown) {
-				err = ErrClientShutdown
-			}
 			jReq.responseChan <- &Response{result: nil, err: err}
 			return
 		}

--- a/rpcclient/infrastructure_test.go
+++ b/rpcclient/infrastructure_test.go
@@ -161,12 +161,14 @@ func TestHTTPPostShutdownInterruptsPendingRequest(t *testing.T) {
 
 	future := client.GetBlockCountAsync()
 
+	// Ensure the server sees the request before we initiate shutdown.
 	select {
 	case <-requestAccepted:
 	case <-time.After(2 * time.Second):
 		t.Fatalf("server did not accept client connection")
 	}
 
+	// The request should remain pending until shutdown is requested.
 	select {
 	case <-future:
 		t.Fatalf("expected request to remain pending until shutdown")
@@ -181,6 +183,7 @@ func TestHTTPPostShutdownInterruptsPendingRequest(t *testing.T) {
 		close(waitDone)
 	}()
 
+	// Wait for shutdown to complete before asserting the final error.
 	select {
 	case <-waitDone:
 	case <-time.After(5 * time.Second):


### PR DESCRIPTION
## Change Description
Modify the rpcclient http POST call to ensure that a shutdown immediately interrupts in-flight requests, which otherwise would have to wait until timeout.

This PR includes the change in https://github.com/btcsuite/btcd/pull/2450 as it is necessary to ensure interruption during Dial.

## Steps to Test
The test suite has an added test to ensure this works.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
