### PR TITLE
btcutil, main: fix android builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,14 @@ jobs:
       - name: Build
         run: make build
 
+      - name: Cross-compile (android/arm64)
+        env:
+          GOOS: android
+          GOARCH: arm64
+        run: |
+          go build ./...
+          (cd btcutil && go build ./...)
+
   test-cover:
     name: Unit coverage
     runs-on: ubuntu-latest

--- a/btcutil/certgen.go
+++ b/btcutil/certgen.go
@@ -76,7 +76,7 @@ func NewTLSCertPair(organization string, validUntil time.Time, extraHosts []stri
 		dnsNames = append(dnsNames, host)
 	}
 
-	addrs, err := interfaceAddrs()
+	addrs, err := InterfaceAddrs()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/btcutil/go.mod
+++ b/btcutil/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
+	github.com/kcalvinalvin/anet v0.0.0-20251112173137-d8ddc1f6dbee
 	github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23
 	github.com/stretchr/testify v1.8.4
 	golang.org/x/crypto v0.25.0

--- a/btcutil/go.sum
+++ b/btcutil/go.sum
@@ -16,6 +16,8 @@ github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
 github.com/golang/snappy v0.0.4 h1:yAGX7huGHXlcLOEtBnF4w7FQwA26wojNCwOYAEhLjQM=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/kcalvinalvin/anet v0.0.0-20251112173137-d8ddc1f6dbee h1:FPP9HDkBbPyniu+u7FHZg+kKFX1WW0gxOGteJ0h3AJk=
+github.com/kcalvinalvin/anet v0.0.0-20251112173137-d8ddc1f6dbee/go.mod h1:N6sz6HwJAenJ6d+/xmSl0ikfV05ZrVGmjt1ryy/WOtE=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23 h1:FOOIBWrEkLgmlgGfMuZT83xIwfPDxEI2OHu6xUmJMFE=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/btcutil/net.go
+++ b/btcutil/net.go
@@ -2,8 +2,8 @@
 // Use of this source code is governed by an ISC
 // license that can be found in the LICENSE file.
 
-//go:build !appengine
-// +build !appengine
+//go:build !android && !appengine
+// +build !android,!appengine
 
 package btcutil
 

--- a/btcutil/net.go
+++ b/btcutil/net.go
@@ -11,9 +11,9 @@ import (
 	"net"
 )
 
-// interfaceAddrs returns a list of the system's network interface addresses.
+// InterfaceAddrs returns a list of the system's network interface addresses.
 // It is wrapped here so that we can substitute it for other functions when
 // building for systems that do not allow access to net.InterfaceAddrs().
-func interfaceAddrs() ([]net.Addr, error) {
+func InterfaceAddrs() ([]net.Addr, error) {
 	return net.InterfaceAddrs()
 }

--- a/btcutil/net_android.go
+++ b/btcutil/net_android.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2025 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+//go:build android
+// +build android
+
+package btcutil
+
+import (
+	"net"
+
+	"github.com/kcalvinalvin/anet"
+)
+
+// InterfaceAddrs returns a list of the system's network interface addresses.
+// We specifically wrap anet.InterfaceAddrs as the net pakcage has been broken
+// since android 11.
+//
+// The relevant github issue link is:
+// https://github.com/golang/go/issues/40569.
+// When the issue is later resolved, we should remove it.
+func InterfaceAddrs() ([]net.Addr, error) {
+	return anet.InterfaceAddrs()
+}

--- a/btcutil/net_noop.go
+++ b/btcutil/net_noop.go
@@ -11,10 +11,10 @@ import (
 	"net"
 )
 
-// interfaceAddrs returns a list of the system's network interface addresses.
+// InterfaceAddrs returns a list of the system's network interface addresses.
 // It is wrapped here so that we can substitute it for a no-op function that
 // returns an empty slice of net.Addr when building for systems that do not
 // allow access to net.InterfaceAddrs().
-func interfaceAddrs() ([]net.Addr, error) {
+func InterfaceAddrs() ([]net.Addr, error) {
 	return []net.Addr{}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/aead/siphash v1.0.1 // indirect
 	github.com/decred/dcrd/crypto/blake256 v1.0.0 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
+	github.com/kcalvinalvin/anet v0.0.0-20251112173137-d8ddc1f6dbee // indirect
 	github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/jessevdk/go-flags v1.4.0 h1:4IU2WS7AumrZ/40jfhf4QVDMsQwqA7VEHozFRrGAR
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jrick/logrotate v1.0.0 h1:lQ1bL/n9mBNeIXoTUoYRlK4dHuNJVofX9oWqBtPnSzI=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
+github.com/kcalvinalvin/anet v0.0.0-20251112173137-d8ddc1f6dbee h1:FPP9HDkBbPyniu+u7FHZg+kKFX1WW0gxOGteJ0h3AJk=
+github.com/kcalvinalvin/anet v0.0.0-20251112173137-d8ddc1f6dbee/go.mod h1:N6sz6HwJAenJ6d+/xmSl0ikfV05ZrVGmjt1ryy/WOtE=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23 h1:FOOIBWrEkLgmlgGfMuZT83xIwfPDxEI2OHu6xUmJMFE=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=

--- a/server.go
+++ b/server.go
@@ -3360,7 +3360,7 @@ func addLocalAddress(addrMgr *addrmgr.AddrManager, addr string, services wire.Se
 
 	if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
 		// If bound to unspecified address, advertise all local interfaces
-		addrs, err := net.InterfaceAddrs()
+		addrs, err := btcutil.InterfaceAddrs()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Change Description
For android since version 11, `net.InterfaceAddrs()` has been broken.
This means that while btcd will build fine on android, it won't run as the logs show below:

```
[I] u0_a306@localhost ~/btcd (master)> ./btcd --prune=1536
2025-11-12 18:15:09.771 [INF] BTCD: Version 0.25.0-beta
2025-11-12 18:15:09.771 [INF] BTCD: Loading block database from '/data/data/com.termux/files/home/.btcd/data/mainnet/blocks_ffldb'
2025-11-12 18:15:09.779 [INF] BTCD: Block database loaded
2025-11-12 18:15:09.780 [WRN] AMGR: Skipping bound address 0.0.0.0:8333: route ip+net: netlinkrib: permission denied
2025-11-12 18:15:09.780 [WRN] AMGR: Skipping bound address [::]:8333: route ip+net: netlinkrib: permission denied
2025-11-12 18:15:09.799 [INF] INDX: Committed filter index is enabled
2025-11-12 18:15:09.799 [INF] BTCD: Prune set to 1536 MiB
2025-11-12 18:15:09.799 [INF] CHAN: Pre-alloacting for 251 MiB
2025-11-12 18:15:09.867 [INF] INDX: Catching up indexes from height -1 to 0
2025-11-12 18:15:09.867 [INF] INDX: Indexes caught up to height 0
2025-11-12 18:15:09.867 [INF] CHAN: Chain state (height 0, hash 000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f, totaltx 1, work [4295032833](tel:4295032833))
2025-11-12 18:15:09.867 [INF] RPCS: Generating TLS certificates...
2025-11-12 18:15:09.874 [ERR] BTCD: Unable to start server on [:8333]: route ip+net: netlinkrib: permission denied
2025-11-12 18:15:09.874 [INF] BTCD: Gracefully shutting down the database...
2025-11-12 18:15:09.882 [INF] BTCD: Shutdown complete
```

So if we're building on Android, we use the alternate net library called [anet](https://github.com/wlynxg/anet).
I specifically use my own fork to utilize https://github.com/wlynxg/anet/pull/9 as the master branch requires an extra build flag.

## Steps to Test
1: Download [Termux](https://github.com/termux/termux-app) on an Android device.
2: Clone btcd.
3: Build.
4: Run to see if it works.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.