### PR TITLE
 Sync BIP30/BIP34 Handling With Bitcoin Core

### DIFF
--- a/blockchain/bip30_test.go
+++ b/blockchain/bip30_test.go
@@ -123,3 +123,27 @@ func TestBip0030CheckNeededMismatchedActivation(t *testing.T) {
 
 	require.True(t, bip0030CheckNeeded(node, &params))
 }
+
+// TestBip0030CheckNeededReenabled ensures that once the chain reaches the
+// re-enable height, the duplicate check is performed again even when BIP34 is
+// active on the current branch.
+func TestBip0030CheckNeededReenabled(t *testing.T) {
+	params := chaincfg.MainNetParams
+
+	ancestor := &blockNode{
+		height: params.BIP0034Height,
+		hash:   mustHashFromStr(t, "000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
+	}
+	parent := &blockNode{
+		height: ancestor.height + 1,
+		hash:   mustHashFromStr(t, "0000000000000000000000000000000000000000000000000000000000000100"),
+		parent: ancestor,
+	}
+	node := &blockNode{
+		height: bip34ReenableBIP30Height,
+		hash:   mustHashFromStr(t, "0000000000000000000000000000000000000000000000000000000000000200"),
+		parent: parent,
+	}
+
+	require.True(t, bip0030CheckNeeded(node, &params))
+}

--- a/blockchain/bip30_test.go
+++ b/blockchain/bip30_test.go
@@ -61,6 +61,20 @@ func TestBip0030CheckNeededBeforeBIP34(t *testing.T) {
 	require.True(t, bip0030CheckNeeded(node, &params))
 }
 
+// TestBip0030CheckNeededAtActivationHeight validates that the activation block
+// itself still triggers the check.
+func TestBip0030CheckNeededAtActivationHeight(t *testing.T) {
+	params := chaincfg.MainNetParams
+
+	node := &blockNode{
+		height: params.BIP0034Height,
+		hash:   mustHashFromStr(t, "000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
+		parent: &blockNode{height: params.BIP0034Height - 1},
+	}
+
+	require.True(t, bip0030CheckNeeded(node, &params))
+}
+
 // TestBip0030CheckNeededAfterBIP34 covers the happy-path where we are on a
 // chain that contains the recorded BIP34 activation block.  In that case the
 // expensive duplicate-coinbase check can be skipped.

--- a/blockchain/bip30_test.go
+++ b/blockchain/bip30_test.go
@@ -1,0 +1,86 @@
+package blockchain
+
+import (
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/stretchr/testify/require"
+)
+
+// mustHashFromStr is a helper to parse hashes inside tests.  It fails the
+// test immediately when the string is not a valid hash.
+func mustHashFromStr(t *testing.T, s string) chainhash.Hash {
+	t.Helper()
+
+	h, err := chainhash.NewHashFromStr(s)
+	require.NoError(t, err)
+
+	return *h
+}
+
+// TestBip0030CheckNeededExceptions makes sure the two historical blocks that
+// overwrote earlier coinbases do not trigger the BIP30 check.  This mirrors the
+// exceptions Bitcoin Core ships as part of the original BIP30 fix.
+func TestBip0030CheckNeededExceptions(t *testing.T) {
+	params := chaincfg.MainNetParams
+
+	cases := []struct {
+		height int32
+		hash   string
+	}{{
+		height: 91842,
+		hash:   "00000000000a4d0a398161ffc163c503763b1f4360639393e0e4c8e300e0caec",
+	}, {
+		height: 91880,
+		hash:   "00000000000743f190a18c5577a3c2d2a1f610ae9601ac046a38084ccb7cd721",
+	}}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.hash, func(t *testing.T) {
+			node := &blockNode{
+				height: tc.height,
+				hash:   mustHashFromStr(t, tc.hash),
+			}
+			require.False(t, bip0030CheckNeeded(node, &params))
+		})
+	}
+}
+
+// TestBip0030CheckNeededBeforeBIP34 ensures we still run the BIP30 check prior
+// to the recorded BIP34 activation height.
+func TestBip0030CheckNeededBeforeBIP34(t *testing.T) {
+	params := chaincfg.MainNetParams
+
+	node := &blockNode{
+		height: params.BIP0034Height - 1,
+		hash:   mustHashFromStr(t, "0000000000000000000000000000000000000000000000000000000000000001"),
+	}
+
+	require.True(t, bip0030CheckNeeded(node, &params))
+}
+
+// TestBip0030CheckNeededAfterBIP34 covers the happy-path where we are on a
+// chain that contains the recorded BIP34 activation block.  In that case the
+// expensive duplicate-coinbase check can be skipped.
+func TestBip0030CheckNeededAfterBIP34(t *testing.T) {
+	params := chaincfg.MainNetParams
+
+	ancestor := &blockNode{
+		height: params.BIP0034Height,
+		hash:   mustHashFromStr(t, "000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
+	}
+	parent := &blockNode{
+		height: ancestor.height + 1,
+		hash:   mustHashFromStr(t, "0000000000000000000000000000000000000000000000000000000000000002"),
+		parent: ancestor,
+	}
+	node := &blockNode{
+		height: parent.height + 1,
+		hash:   mustHashFromStr(t, "0000000000000000000000000000000000000000000000000000000000000003"),
+		parent: parent,
+	}
+
+	require.False(t, bip0030CheckNeeded(node, &params))
+}

--- a/blockchain/bip30_test.go
+++ b/blockchain/bip30_test.go
@@ -98,3 +98,28 @@ func TestBip0030CheckNeededAfterBIP34(t *testing.T) {
 
 	require.False(t, bip0030CheckNeeded(node, &params))
 }
+
+// TestBip0030CheckNeededMismatchedActivation verifies that if the block at the
+// recorded BIP34 activation height does not match, we continue to run the BIP30
+// check (this matches Bitcoin Core's behavior and guards against alternative
+// chains that have not activated BIP34 yet).
+func TestBip0030CheckNeededMismatchedActivation(t *testing.T) {
+	params := chaincfg.MainNetParams
+
+	ancestor := &blockNode{
+		height: params.BIP0034Height,
+		hash:   mustHashFromStr(t, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"),
+	}
+	parent := &blockNode{
+		height: ancestor.height + 1,
+		hash:   mustHashFromStr(t, "0000000000000000000000000000000000000000000000000000000000000004"),
+		parent: ancestor,
+	}
+	node := &blockNode{
+		height: parent.height + 1,
+		hash:   mustHashFromStr(t, "0000000000000000000000000000000000000000000000000000000000000005"),
+		parent: parent,
+	}
+
+	require.True(t, bip0030CheckNeeded(node, &params))
+}

--- a/blockchain/chain_test.go
+++ b/blockchain/chain_test.go
@@ -1384,6 +1384,7 @@ func TestInvalidateBlock(t *testing.T) {
 						"invalidate-once")
 				// Grab the tip of the chain.
 				tip := btcutil.NewBlock(params.GenesisBlock)
+				tip.SetHeight(0)
 
 				// Create a chain with 11 blocks.
 				_, _, err := addBlocks(11, chain, tip, []*testhelper.SpendableOut{})
@@ -1407,6 +1408,7 @@ func TestInvalidateBlock(t *testing.T) {
 				chain, params, tearDown := utxoCacheTestChain("TestInvalidateBlock-invalidate-twice")
 				// Grab the tip of the chain.
 				tip := btcutil.NewBlock(params.GenesisBlock)
+				tip.SetHeight(0)
 
 				// Create a chain with 11 blocks.
 				_, spendableOuts, err := addBlocks(11, chain, tip, []*testhelper.SpendableOut{})
@@ -1453,6 +1455,7 @@ func TestInvalidateBlock(t *testing.T) {
 			chainGen: func() (*BlockChain, []*chainhash.Hash, func()) {
 				chain, params, tearDown := utxoCacheTestChain("TestInvalidateBlock-invalidate-side-branch")
 				tip := btcutil.NewBlock(params.GenesisBlock)
+				tip.SetHeight(0)
 
 				// Grab the tip of the chain.
 				tip, err := chain.BlockByHash(&chain.bestChain.Tip().hash)
@@ -1635,6 +1638,7 @@ func TestReconsiderBlock(t *testing.T) {
 
 				// Create a chain with 101 blocks.
 				tip := btcutil.NewBlock(params.GenesisBlock)
+				tip.SetHeight(0)
 				_, _, err := addBlocks(101, chain, tip, []*testhelper.SpendableOut{})
 				if err != nil {
 					t.Fatal(err)
@@ -1657,6 +1661,7 @@ func TestReconsiderBlock(t *testing.T) {
 
 				// Create a chain with 101 blocks.
 				tip := btcutil.NewBlock(params.GenesisBlock)
+				tip.SetHeight(0)
 				_, spendableOuts, err := addBlocks(101, chain, tip, []*testhelper.SpendableOut{})
 				if err != nil {
 					t.Fatal(err)
@@ -1689,6 +1694,7 @@ func TestReconsiderBlock(t *testing.T) {
 
 				// Create a chain with 101 blocks.
 				tip := btcutil.NewBlock(params.GenesisBlock)
+				tip.SetHeight(0)
 				_, spendableOuts, err := addBlocks(101, chain, tip, []*testhelper.SpendableOut{})
 				if err != nil {
 					t.Fatal(err)
@@ -1718,6 +1724,7 @@ func TestReconsiderBlock(t *testing.T) {
 				chain, params, tearDown := utxoCacheTestChain("TestReconsiderBlock-reconsider-an-invalid-side-branch-higher")
 
 				tip := btcutil.NewBlock(params.GenesisBlock)
+				tip.SetHeight(0)
 				_, spendableOuts, err := addBlocks(6, chain, tip, []*testhelper.SpendableOut{})
 				if err != nil {
 					t.Fatal(err)
@@ -1752,6 +1759,7 @@ func TestReconsiderBlock(t *testing.T) {
 				chain, params, tearDown := utxoCacheTestChain("TestReconsiderBlock-reconsider-an-invalid-side-branch-lower")
 
 				tip := btcutil.NewBlock(params.GenesisBlock)
+				tip.SetHeight(0)
 				_, spendableOuts, err := addBlocks(6, chain, tip, []*testhelper.SpendableOut{})
 				if err != nil {
 					t.Fatal(err)

--- a/blockchain/common_test.go
+++ b/blockchain/common_test.go
@@ -465,7 +465,7 @@ func newBlock(chain *BlockChain, prev *btcutil.Block,
 	// SolveBlock.
 	block := btcutil.NewBlock(&wire.MsgBlock{
 		Header: wire.BlockHeader{
-			Version:    1,
+			Version:    4,
 			PrevBlock:  *prev.Hash(),
 			MerkleRoot: calcMerkleRoot(txns),
 			Bits:       chain.chainParams.PowLimitBits,

--- a/blockchain/fullblocktests/params.go
+++ b/blockchain/fullblocktests/params.go
@@ -103,9 +103,9 @@ var regressionNetParams = &chaincfg.Params{
 	PowLimit:                 regressionPowLimit,
 	PowLimitBits:             0x207fffff,
 	CoinbaseMaturity:         100,
-	BIP0034Height:            100000000, // Not active - Permit ver 1 blocks
-	BIP0065Height:            1351,      // Used by regression tests
-	BIP0066Height:            1251,      // Used by regression tests
+	BIP0034Height:            1,
+	BIP0065Height:            1,
+	BIP0066Height:            1,
 	SubsidyReductionInterval: 150,
 	TargetTimespan:           time.Hour * 24 * 14, // 14 days
 	TargetTimePerBlock:       time.Minute * 10,    // 10 minutes

--- a/blockchain/regtest_test.go
+++ b/blockchain/regtest_test.go
@@ -1,0 +1,218 @@
+package blockchain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/btcsuite/btcd/btcutil"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcd/chaincfg/chainhash"
+	"github.com/btcsuite/btcd/txscript"
+	"github.com/btcsuite/btcd/wire"
+	"github.com/stretchr/testify/require"
+)
+
+// stubChainCtx provides the minimal ChainCtx implementation needed for header
+// context checks in tests.
+type stubChainCtx struct {
+	params *chaincfg.Params
+}
+
+// ChainParams returns the active chain parameters.
+func (s stubChainCtx) ChainParams() *chaincfg.Params {
+	return s.params
+}
+
+// BlocksPerRetarget returns the blocks per difficulty retarget.
+func (s stubChainCtx) BlocksPerRetarget() int32 {
+	return int32(s.params.TargetTimespan / s.params.TargetTimePerBlock)
+}
+
+// MinRetargetTimespan returns the lower bound of the retarget timespan.
+func (s stubChainCtx) MinRetargetTimespan() int64 {
+	return int64(
+		s.params.TargetTimespan /
+			time.Duration(s.params.RetargetAdjustmentFactor),
+	)
+}
+
+// MaxRetargetTimespan returns the upper bound of the retarget timespan.
+func (s stubChainCtx) MaxRetargetTimespan() int64 {
+	return int64(
+		s.params.TargetTimespan *
+			time.Duration(s.params.RetargetAdjustmentFactor),
+	)
+}
+
+// VerifyCheckpoint reports whether a checkpoint matches.
+func (s stubChainCtx) VerifyCheckpoint(_ int32, _ *chainhash.Hash) bool {
+	return true
+}
+
+// FindPreviousCheckpoint returns the last known checkpoint.
+func (s stubChainCtx) FindPreviousCheckpoint() (HeaderCtx, error) {
+	return nil, nil
+}
+
+// regtestPrevNode returns a blockNode for the regtest genesis block to serve
+// as the parent of height-1 test headers.
+func regtestPrevNode(t *testing.T) *blockNode {
+	t.Helper()
+
+	params := chaincfg.RegressionNetParams
+
+	return newBlockNode(&params.GenesisBlock.Header, nil)
+}
+
+// TestRegtestBlockVersions ensures regtest enforces BIP34/66/65 version floors
+// from height 1.
+func TestRegtestBlockVersions(t *testing.T) {
+	params := chaincfg.RegressionNetParams
+	prevNode := regtestPrevNode(t)
+
+	testCases := []struct {
+		name    string
+		version int32
+		wantErr ErrorCode
+	}{
+		{
+			name:    "v1_rejected",
+			version: 1,
+			wantErr: ErrBlockVersionTooOld,
+		},
+		{
+			name:    "v2_rejected",
+			version: 2,
+			wantErr: ErrBlockVersionTooOld,
+		},
+		{
+			name:    "v3_rejected",
+			version: 3,
+			wantErr: ErrBlockVersionTooOld,
+		},
+		{
+			name:    "v4_allowed",
+			version: 4,
+			wantErr: ErrorCode(0),
+		},
+		{
+			name:    "vb_signal_allowed",
+			version: 0x20000000,
+			wantErr: ErrorCode(0),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			block := &wire.BlockHeader{
+				Version:   tc.version,
+				PrevBlock: *params.GenesisHash,
+				Bits:      params.PowLimitBits,
+				Timestamp: time.Unix(prevNode.Timestamp()+1, 0),
+			}
+
+			err := CheckBlockHeaderContext(
+				block, prevNode, BFFastAdd,
+				stubChainCtx{params: &params}, true,
+			)
+
+			if tc.wantErr == 0 {
+				require.NoError(t, err)
+
+				return
+			}
+
+			require.Error(t, err)
+
+			var rErr RuleError
+			require.ErrorAs(t, err, &rErr)
+			require.Equal(t, tc.wantErr, rErr.ErrorCode)
+		})
+	}
+}
+
+// TestRegtestBuriedDeploymentsAlwaysActive asserts CSV, SegWit, and Taproot
+// are always active on regtest, mirroring Bitcoin Core.
+func TestRegtestBuriedDeploymentsAlwaysActive(t *testing.T) {
+	chain := newFakeChain(&chaincfg.RegressionNetParams)
+	prevNode := chain.bestChain.Tip()
+
+	stateCSV, err := chain.deploymentState(prevNode, chaincfg.DeploymentCSV)
+	require.NoError(t, err)
+	require.Equal(t, ThresholdActive, stateCSV)
+
+	stateSegwit, err := chain.deploymentState(
+		prevNode, chaincfg.DeploymentSegwit,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ThresholdActive, stateSegwit)
+
+	stateTaproot, err := chain.deploymentState(
+		prevNode, chaincfg.DeploymentTaproot,
+	)
+	require.NoError(t, err)
+	require.Equal(t, ThresholdActive, stateTaproot)
+}
+
+// TestRegtestRejectsCoinbaseMissingHeight ensures contextual validation
+// enforces coinbase height serialization on regtest.
+func TestRegtestRejectsCoinbaseMissingHeight(t *testing.T) {
+	chain := newFakeChain(&chaincfg.RegressionNetParams)
+	prevNode := chain.bestChain.Tip()
+
+	block := wire.MsgBlock{
+		Header: wire.BlockHeader{
+			Version:   4,
+			PrevBlock: prevNode.hash,
+			Bits:      chain.chainParams.PowLimitBits,
+			Timestamp: time.Unix(prevNode.timestamp+1, 0),
+		},
+	}
+
+	coinbase := wire.NewMsgTx(wire.TxVersion)
+	coinbase.AddTxIn(&wire.TxIn{SignatureScript: []byte{}})
+	coinbase.AddTxOut(&wire.TxOut{Value: 0})
+	block.AddTransaction(coinbase)
+	block.Header.MerkleRoot = block.Transactions[0].TxHash()
+
+	btcBlock := btcutil.NewBlock(&block)
+
+	// The block without a height in coinbase is not considered valid.
+	err := chain.checkBlockContext(btcBlock, prevNode, BFNone)
+	require.Error(t, err)
+
+	// Make sure the error is in coinbase height record.
+	var rErr RuleError
+	require.ErrorAs(t, err, &rErr)
+	require.Equal(t, ErrMissingCoinbaseHeight, rErr.ErrorCode)
+}
+
+// TestRegtestAcceptsCoinbaseHeight ensures a properly encoded coinbase height
+// passes contextual checks on regtest.
+func TestRegtestAcceptsCoinbaseHeight(t *testing.T) {
+	chain := newFakeChain(&chaincfg.RegressionNetParams)
+	prevNode := chain.bestChain.Tip()
+
+	coinbaseScript, err := txscript.NewScriptBuilder().AddInt64(1).Script()
+	require.NoError(t, err)
+
+	block := wire.MsgBlock{
+		Header: wire.BlockHeader{
+			Version:   4,
+			PrevBlock: prevNode.hash,
+			Bits:      chain.chainParams.PowLimitBits,
+			Timestamp: time.Unix(prevNode.timestamp+1, 0),
+		},
+	}
+
+	coinbase := wire.NewMsgTx(wire.TxVersion)
+	coinbase.AddTxIn(&wire.TxIn{SignatureScript: coinbaseScript})
+	coinbase.AddTxOut(&wire.TxOut{Value: 0})
+	block.AddTransaction(coinbase)
+	block.Header.MerkleRoot = block.Transactions[0].TxHash()
+
+	btcBlock := btcutil.NewBlock(&block)
+
+	// Make sure the block with the height in coinbase is considered valid.
+	require.NoError(t, chain.checkBlockContext(btcBlock, prevNode, BFNone))
+}

--- a/blockchain/utxocache_test.go
+++ b/blockchain/utxocache_test.go
@@ -405,6 +405,7 @@ func TestUtxoCacheFlush(t *testing.T) {
 	defer tearDown()
 	cache := chain.utxoCache
 	tip := btcutil.NewBlock(params.GenesisBlock)
+	tip.SetHeight(0)
 
 	// The chainSetup init triggers the consistency status write.
 	err := assertConsistencyState(chain, params.GenesisHash)

--- a/blockchain/validate.go
+++ b/blockchain/validate.go
@@ -219,7 +219,7 @@ func bip0030CheckNeeded(node *blockNode, params *chaincfg.Params) bool {
 
 	// Once BIP0034 is known to be active on this chain, duplicate coinbases
 	// can no longer occur, so the check can be omitted.
-	if node.height >= params.BIP0034Height {
+	if node.height > params.BIP0034Height {
 		return false
 	}
 

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -481,9 +481,9 @@ var RegressionNetParams = Params{
 	PowLimitBits:             0x207fffff,
 	PoWNoRetargeting:         true,
 	CoinbaseMaturity:         100,
-	BIP0034Height:            100000000, // Not active - Permit ver 1 blocks
-	BIP0065Height:            1351,      // Used by regression tests
-	BIP0066Height:            1251,      // Used by regression tests
+	BIP0034Height:            1,
+	BIP0065Height:            1,
+	BIP0066Height:            1,
 	SubsidyReductionInterval: 150,
 	TargetTimespan:           time.Hour * 24 * 14, // 14 days
 	TargetTimePerBlock:       time.Minute * 10,    // 10 minutes
@@ -540,6 +540,7 @@ var RegressionNetParams = Params{
 			DeploymentEnder: NewMedianTimeDeploymentEnder(
 				time.Time{}, // Never expires
 			),
+			AlwaysActiveHeight: 1,
 		},
 		DeploymentSegwit: {
 			BitNumber: 1,
@@ -549,6 +550,7 @@ var RegressionNetParams = Params{
 			DeploymentEnder: NewMedianTimeDeploymentEnder(
 				time.Time{}, // Never expires.
 			),
+			AlwaysActiveHeight: 1,
 		},
 		DeploymentTaproot: {
 			BitNumber: 2,
@@ -558,6 +560,8 @@ var RegressionNetParams = Params{
 			DeploymentEnder: NewMedianTimeDeploymentEnder(
 				time.Time{}, // Never expires.
 			),
+			MinActivationHeight: 0,
+			AlwaysActiveHeight:  1,
 			CustomActivationThreshold: 108, // Only needs 75% hash rate.
 		},
 	},

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -216,6 +216,7 @@ type Params struct {
 	// These fields define the block heights at which the specified softfork
 	// BIP became active.
 	BIP0034Height int32
+	BIP0034Hash   *chainhash.Hash
 	BIP0065Height int32
 	BIP0066Height int32
 
@@ -322,6 +323,7 @@ var MainNetParams = Params{
 	PowLimit:                 mainPowLimit,
 	PowLimitBits:             0x1d00ffff,
 	BIP0034Height:            227931, // 000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8
+	BIP0034Hash:              newHashFromStr("000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8"),
 	BIP0065Height:            388381, // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
 	BIP0066Height:            363725, // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
 	CoinbaseMaturity:         100,
@@ -600,6 +602,7 @@ var TestNet3Params = Params{
 	GenesisHash:              &testNet3GenesisHash,
 	PowLimit:                 testNet3PowLimit,
 	PowLimitBits:             0x1d00ffff,
+	BIP0034Hash:              newHashFromStr("0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8"),
 	BIP0034Height:            21111,  // 0000000023b3a96d3484e5abb3755c413e7d41500f8e2a5c3f0dd01299cd8ef8
 	BIP0065Height:            581885, // 00000000007f6655f22f98e72ed80d8b06dc761d5da09df0fa1dc4be4f861eb6
 	BIP0066Height:            330776, // 000000002104c8c45e99a8853285a3b592602a3ccde2b832481da85e9e4ba182

--- a/integration/bip0009_test.go
+++ b/integration/bip0009_test.go
@@ -139,6 +139,16 @@ func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 	}
 	defer r.TearDown()
 
+	// Short-circuit deployments that are configured as always active.
+	if deploymentID < uint32(len(r.ActiveNet.Deployments)) {
+		dep := &r.ActiveNet.Deployments[deploymentID]
+		if dep.AlwaysActiveHeight != 0 {
+			assertChainHeight(r, t, 0)
+			assertSoftForkStatus(r, t, forkKey, blockchain.ThresholdActive)
+			return
+		}
+	}
+
 	// If the deployment is meant to be always active, then it should be
 	// active from the very first block.
 	if deploymentID == chaincfg.DeploymentTestDummyAlwaysActive {


### PR DESCRIPTION
## Change Description

This PR aligns btcd's consensus logic with Bitcoin Core when deciding when to run the expensive BIP30 duplicate-coinbase check. The changes mirror the behavior introduced in https://github.com/bitcoin/bitcoin/pull/6931 and https://github.com/bitcoin/bitcoin/pull/12204.
                                               
## Summary              
- Introduce a helper that encapsulates the decision of whether to run the BIP30 check (`bip0030CheckNeeded`).
- Record each network’s BIP34 activation hash so we can verify the activation block exists on the current branch before skipping the check.                                                                                       
- Re-enable BIP30 at height `1_983_702`, matching Core’s protection against pre-BIP34 coinbases that serialized future heights.
- Add unit tests covering the historical exception blocks, the BIP34 activation height, the re-enable height, and alternate-chain scenarios.

## Steps to Test

```
go test ./blockchain
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [ ] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
