### PR TITLE
rpcclient: add ListLabels RPC using RawRequest

### DIFF
--- a/rpcclient/wallet.go
+++ b/rpcclient/wallet.go
@@ -1672,6 +1672,20 @@ func (c *Client) ListAccountsMinConf(minConfirms int) (map[string]btcutil.Amount
 	return c.ListAccountsMinConfAsync(minConfirms).Receive()
 }
 
+// ListLabels returns the list of labels from the wallet.
+func (c *Client) ListLabels() ([]string, error) {
+	res, err := c.RawRequest("listlabels", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var labels []string
+	if err := json.Unmarshal(res, &labels); err != nil {
+		return nil, err
+	}
+	return labels, nil
+}
+
 // FutureGetBalanceResult is a future promise to deliver the result of a
 // GetBalanceAsync or GetBalanceMinConfAsync RPC invocation (or an applicable
 // error).


### PR DESCRIPTION
## Change Description
Adds a ListLabels() helper to rpcclient using RawRequest.

This allows callers to access the listlabels RPC without modifying or
removing the existing account-based helpers and avoids introducing any
breaking changes.

This follows the RawRequest approach discussed in #1974.

## Steps to Test
Build the project:
go build ./...

Run all tests:
go test ./...

## Pull Request Checklist
### Testing
- [✔] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [✔] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ✔] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ✔] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [ ] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
