### PR TITLE
`rpcclient`: clarify `ConnConfig` `Host` field description

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -1204,8 +1204,8 @@ func (c *Client) WaitForShutdown() {
 // ConnConfig describes the connection configuration parameters for the client.
 // This
 type ConnConfig struct {
-	// Host is the IP address and port of the RPC server you want to connect
-	// to.
+	// Host is the IP address and port, or Unix socket path, of the RPC server
+	// you want to connect to.
 	Host string
 
 	// Endpoint is the websocket endpoint on the RPC server.  This is


### PR DESCRIPTION
## Change Description

The previous description incorrectly implied that Unix sockets were not supported (support was added in #2168).

I think the description is still a bit more vague than would be ideal (i.e. it doesn't say how the IP should be separated from the port, nor does it say what prefix is used to signify a Unix socket). This PR is still an improvement, but if you prefer that I fix the vagueness too, let me know and I'm happy to update this PR to do so.

## Steps to Test

No testing applicable; it's just a comment change.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks. (I don't think there should be any PR check that apply to comments, but maybe I'm mistaken?)
- [x] Tests covering the positive and negative (error paths) are included. (No new code.)
- [x] Bug fixes contain tests triggering the bug to prevent regressions. (No code fixes.)

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level. (No new code.)

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
