### PR TITLE
wire: reject messages with unconsumed trailing payload bytes

### DIFF
--- a/wire/message.go
+++ b/wire/message.go
@@ -669,6 +669,16 @@ func readMessageWithEncodingNInternal(r io.Reader, pver uint32,
 		return totalBytes, nil, nil, err
 	}
 
+	// Reject messages where the payload was not fully consumed by
+	// BtcDecode. A peer could otherwise append arbitrary trailing bytes
+	// to an otherwise valid message, which would be silently accepted
+	// and persisted (e.g., in the block database).
+	if pr.Len() > 0 {
+		str := fmt.Sprintf("message payload has %d extra bytes "+
+			"after decode", pr.Len())
+		return totalBytes, nil, nil, messageError("ReadMessage", str)
+	}
+
 	return totalBytes, msg, payload, nil
 }
 

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -7,6 +7,7 @@ package wire
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"io"
 	"net"
 	"reflect"
@@ -346,6 +347,7 @@ func TestReadMessageWireErrors(t *testing.T) {
 			ErrUnknownMessage,
 			24,
 		},
+
 	}
 
 	t.Logf("Running %d tests", len(tests))
@@ -375,6 +377,54 @@ func TestReadMessageWireErrors(t *testing.T) {
 				continue
 			}
 		}
+	}
+}
+
+// TestReadMessageTrailingBytes verifies that a message with unconsumed
+// trailing bytes after BtcDecode is rejected with a MessageError.
+func TestReadMessageTrailingBytes(t *testing.T) {
+	t.Parallel()
+
+	pver := ProtocolVersion
+	btcnet := MainNet
+
+	me := &NetAddress{
+		Timestamp: time.Time{},
+		IP:        net.ParseIP("127.0.0.1"),
+		Port:      8333,
+	}
+	you := &NetAddress{
+		Timestamp: time.Time{},
+		IP:        net.ParseIP("192.168.0.1"),
+		Port:      8333,
+	}
+	verMsg := NewMsgVersion(me, you, 1, 0)
+
+	// Serialize the version message payload only (no wire header).
+	var payloadBuf bytes.Buffer
+	verMsg.BtcEncode(&payloadBuf, pver, BaseEncoding)
+	cleanPayload := payloadBuf.Bytes()
+
+	// Append garbage bytes to the valid payload.
+	garbage := []byte{0xde, 0xad, 0xbe, 0xef}
+	dirtyPayload := append(cleanPayload, garbage...)
+
+	// Build the wire frame: header + dirty payload with correct
+	// checksum over the full (dirty) payload.
+	checksum := chainhash.DoubleHashB(dirtyPayload)
+	hdr := makeHeader(btcnet, CmdVersion, uint32(len(dirtyPayload)), 0)
+	copy(hdr[20:], checksum[:4])
+	wireBytes := append(hdr, dirtyPayload...)
+
+	r := bytes.NewReader(wireBytes)
+	_, _, _, err := ReadMessageN(r, pver, btcnet)
+	if err == nil {
+		t.Fatal("expected error for message with trailing bytes")
+	}
+
+	var msgErr *MessageError
+	if !errors.As(err, &msgErr) {
+		t.Fatalf("expected MessageError, got: %T (%v)", err, err)
 	}
 }
 


### PR DESCRIPTION
In this PR, we add a strictness check to `readMessageWithEncodingNInternal` in
the `wire` package that rejects any message whose payload isn't fully consumed
by `BtcDecode`. After decoding completes, we now check `pr.Len()` and return a
`MessageError` if any bytes remain in the buffer.

Previously, the payload buffer was handed to `BtcDecode` without any
post-decode validation. If `BtcDecode` stopped reading before exhausting the
buffer (which is the correct behavior for all message types, they read exactly
what they need), any extra bytes at the tail were silently ignored. The full
raw payload, trailing bytes included, would then flow through to application
code unchecked. We now reject such messages at the wire layer before they reach
any higher-level processing.

The check is intentionally placed in the shared `readMessageWithEncodingNInternal`
path so it applies uniformly to all message types, not just blocks or transactions.

See each commit message for a detailed description w.r.t the incremental changes.