### PR TITLE
rpcclient: fix HTTP POST mode with scheme-prefixed Host

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -1348,7 +1348,13 @@ func newHTTPClient(config *ConnConfig) (*http.Client, error) {
 		}
 	}
 
-	parsedDialAddr, err := ParseAddressString(config.Host)
+	// Strip any scheme prefix from the host since the scheme is determined
+	// by DisableTLS. Then extract just the host:port for dialing (ignoring
+	// any path component).
+	host := stripScheme(config.Host)
+	dialHost := extractHostPort(host)
+
+	parsedDialAddr, err := ParseAddressString(dialHost)
 	if err != nil {
 		return nil, err
 	}
@@ -1379,7 +1385,13 @@ func (config *ConnConfig) httpURL() (string, error) {
 		protocol = "https"
 	}
 
-	parsedAddr, err := ParseAddressString(config.Host)
+	// Strip any scheme prefix from the host since the scheme is determined
+	// by DisableTLS. This allows users to pass full URLs like
+	// "https://host.example/path" in the Host field.
+	host := stripScheme(config.Host)
+	dialHost := extractHostPort(host)
+
+	parsedAddr, err := ParseAddressString(dialHost)
 	if err != nil {
 		return "", fmt.Errorf("error parsing host '%v': %v",
 			config.Host, err)
@@ -1392,7 +1404,7 @@ func (config *ConnConfig) httpURL() (string, error) {
 		// The Unix domain socket is specified in the DialContext.
 		httpURL = protocol + "://unix"
 	default:
-		httpURL = protocol + "://" + config.Host
+		httpURL = protocol + "://" + host
 	}
 
 	return httpURL, nil
@@ -1781,6 +1793,34 @@ func cutPrefix(s, prefix string) (after string, found bool) {
 		return s, false
 	}
 	return s[len(prefix):], true
+}
+
+// stripScheme removes any http:// or https:// scheme prefix from the given
+// host string. This allows callers to pass full URLs in the Host field.
+func stripScheme(host string) string {
+	if after, ok := cutPrefix(host, "https://"); ok {
+		return after
+	}
+	if after, ok := cutPrefix(host, "http://"); ok {
+		return after
+	}
+	return host
+}
+
+// extractHostPort extracts just the host:port portion from a string that may
+// contain a path component (e.g. "host.example:8332/api/key" -> "host.example:8332").
+func extractHostPort(host string) string {
+	// Use url.Parse to reliably extract the host from a string that may
+	// contain a path. We prepend a dummy scheme so that url.Parse treats
+	// the input as a hierarchical URL.
+	u, err := url.Parse("dummy://" + host)
+	if err != nil {
+		return host
+	}
+	if u.Host != "" {
+		return u.Host
+	}
+	return host
 }
 
 // ParseAddressString converts an address in string format to a net.Addr that is

--- a/rpcclient/infrastructure_test.go
+++ b/rpcclient/infrastructure_test.go
@@ -1,6 +1,7 @@
 package rpcclient
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -105,6 +106,136 @@ func TestParseAddressString(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tc.expNetwork, addr.Network())
 			require.Equal(t, tc.expAddress, addr.String())
+		})
+	}
+}
+
+// TestStripScheme verifies that scheme prefixes are correctly removed.
+func TestStripScheme(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"localhost:8332", "localhost:8332"},
+		{"http://localhost:8332", "localhost:8332"},
+		{"https://localhost:8332", "localhost:8332"},
+		{"https://go.getblock.io/xxxx", "go.getblock.io/xxxx"},
+		{"http://go.getblock.io/xxxx", "go.getblock.io/xxxx"},
+		{"unix:///var/run/btcd.sock", "unix:///var/run/btcd.sock"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.want, stripScheme(tc.input))
+		})
+	}
+}
+
+// TestExtractHostPort verifies that host:port is extracted from strings that
+// may contain path components.
+func TestExtractHostPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"localhost:8332", "localhost:8332"},
+		{"localhost", "localhost"},
+		{"go.getblock.io/xxxx", "go.getblock.io"},
+		{"go.getblock.io:443/xxxx", "go.getblock.io:443"},
+		{"127.0.0.1:8332", "127.0.0.1:8332"},
+		{"[::1]:8332", "[::1]:8332"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			require.Equal(t, tc.want, extractHostPort(tc.input))
+		})
+	}
+}
+
+// TestHTTPURLWithSchemePrefix verifies that httpURL correctly handles Host
+// values that include a scheme prefix (regression test for issue #2464).
+func TestHTTPURLWithSchemePrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		host   string
+		tls    bool
+		expect string
+	}{
+		{
+			name:   "plain host",
+			host:   "localhost:8332",
+			tls:    false,
+			expect: "http://localhost:8332",
+		},
+		{
+			name:   "plain host with TLS",
+			host:   "localhost:8332",
+			tls:    true,
+			expect: "https://localhost:8332",
+		},
+		{
+			name:   "host with https prefix and path",
+			host:   "https://go.getblock.io/xxxx",
+			tls:    true,
+			expect: "https://go.getblock.io/xxxx",
+		},
+		{
+			name:   "host with http prefix and path",
+			host:   "http://go.getblock.io/xxxx",
+			tls:    false,
+			expect: "http://go.getblock.io/xxxx",
+		},
+		{
+			name:   "host with path but no scheme",
+			host:   "go.getblock.io/xxxx",
+			tls:    true,
+			expect: "https://go.getblock.io/xxxx",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &ConnConfig{
+				Host:       tc.host,
+				DisableTLS: !tc.tls,
+			}
+			got, err := config.httpURL()
+			require.NoError(t, err)
+			require.Equal(t, tc.expect, got)
+		})
+	}
+}
+
+// TestNewHTTPClientWithSchemePrefix verifies that newHTTPClient correctly
+// handles Host values that include a scheme prefix (issue #2464).
+func TestNewHTTPClientWithSchemePrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		host string
+	}{
+		{"plain host", "localhost:8332"},
+		{"host with https prefix", "https://localhost:8332"},
+		{"host with path", "https://go.getblock.io/xxxx"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			config := &ConnConfig{
+				Host:       tc.host,
+				DisableTLS: strings.HasPrefix(tc.host, "http://"),
+			}
+			client, err := newHTTPClient(config)
+			require.NoError(t, err)
+			require.NotNil(t, client)
 		})
 	}
 }

--- a/rpcclient/infrastructure_test.go
+++ b/rpcclient/infrastructure_test.go
@@ -1,6 +1,9 @@
 package rpcclient
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -238,4 +241,45 @@ func TestNewHTTPClientWithSchemePrefix(t *testing.T) {
 			require.NotNil(t, client)
 		})
 	}
+}
+
+// TestIssue2464_SchemeInHostHTTPPost is a regression test for
+// https://github.com/btcsuite/btcd/issues/2464. It verifies that creating an
+// rpcclient with a scheme-prefixed Host in HTTP POST mode works correctly.
+// Before the fix, this would fail with "dial tcp [...:0]: connect: can't
+// assign requested address" because ParseAddressString couldn't handle the
+// scheme prefix.
+func TestIssue2464_SchemeInHostHTTPPost(t *testing.T) {
+	t.Parallel()
+
+	// Spin up a test HTTP server that returns a valid JSON-RPC response.
+	const rpcResponse = `{"jsonrpc":"1.0","id":1,"result":100,"error":null}`
+	srv := httptest.NewServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, rpcResponse)
+		},
+	))
+	defer srv.Close()
+
+	// The user's original code used a full URL with scheme as Host:
+	//   Host: "https://go.getblock.io/xxxx"
+	// We reproduce this with our test server's URL which starts with
+	// "http://".
+	connCfg := &ConnConfig{
+		Host:         srv.URL + "/myapikey",
+		User:         "user",
+		Pass:         "pass",
+		HTTPPostMode: true,
+		DisableTLS:   true,
+	}
+
+	client, err := New(connCfg, nil)
+	require.NoError(t, err, "New() should not fail with scheme-prefixed Host")
+	defer client.Shutdown()
+
+	// Make an actual RPC call to verify the full pipeline works.
+	blockCount, err := client.GetBlockCount()
+	require.NoError(t, err, "GetBlockCount() should succeed")
+	require.Equal(t, int64(100), blockCount)
 }


### PR DESCRIPTION
Fixes #2464, a regression introduced by PR #2168  which added unix socket support.

When `ConnConfig.Host` contains a scheme prefix (e.g. `https://go.getblock.io/xxxx`), the rpcclient fails with a dial error because `ParseAddressString` rejects addresses containing `://` (only `unix://` is supported). 

