### PR TITLE
psbt: fix nil pointer panic in TaprootLeafScript serialization

### DIFF
--- a/btcutil/psbt/partial_input.go
+++ b/btcutil/psbt/partial_input.go
@@ -515,6 +515,11 @@ func (pi *PInput) serialize(w io.Writer) error {
 			}
 		}
 
+		for _, leafScript := range pi.TaprootLeafScript {
+			if leafScript == nil {
+				return ErrInvalidPsbtFormat
+			}
+		}
 		sort.Slice(pi.TaprootLeafScript, func(i, j int) bool {
 			return pi.TaprootLeafScript[i].SortBefore(
 				pi.TaprootLeafScript[j],

--- a/btcutil/psbt/psbt_test.go
+++ b/btcutil/psbt/psbt_test.go
@@ -21,6 +21,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestSerializeNilTaprootLeafScript tests that serializing a PSBT with a nil
+// entry in TaprootLeafScript returns an error instead of panicking.
+// Regression test for https://github.com/btcsuite/btcd/issues/2495
+func TestSerializeNilTaprootLeafScript(t *testing.T) {
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  chainhash.Hash{},
+			Index: 0,
+		},
+	})
+	tx.AddTxOut(&wire.TxOut{Value: 1000})
+
+	packet, err := NewFromUnsignedTx(tx)
+	require.NoError(t, err)
+
+	packet.Inputs[0].TaprootLeafScript = []*TaprootTapLeafScript{nil}
+
+	_, err = packet.B64Encode()
+	require.ErrorIs(t, err, ErrInvalidPsbtFormat)
+}
+
 // Test vectors from:
 // // https://github.com/bitcoin/bips/blob/master/bip-0174.mediawiki#test-vectors
 

--- a/btcutil/psbt/utils.go
+++ b/btcutil/psbt/utils.go
@@ -465,6 +465,9 @@ func FindLeafScript(pInput *PInput,
 	targetLeafHash []byte) (*TaprootTapLeafScript, error) {
 
 	for _, leaf := range pInput.TaprootLeafScript {
+		if leaf == nil {
+			continue
+		}
 		leafHash := txscript.TapLeaf{
 			LeafVersion: leaf.LeafVersion,
 			Script:      leaf.Script,


### PR DESCRIPTION
## Summary

Fix a nil pointer dereference panic when calling `Packet.B64Encode()` (or `Serialize`) on a PSBT that contains a nil entry in `PInput.TaprootLeafScript`.

## Problem

If `TaprootLeafScript` contains a nil `*TaprootTapLeafScript` entry:

```go
packet.Inputs[0].TaprootLeafScript = []*TaprootTapLeafScript{nil}
```

Calling `B64Encode()` panics during the `sort.Slice` call or when accessing `leafScript.Script`, instead of returning an error.

## Fix

- **`partial_input.go`**: Add nil check before sorting and serializing `TaprootLeafScript` entries. Returns `ErrInvalidPsbtFormat` if a nil entry is found.
- **`utils.go`**: Add nil guard in `FindLeafScript` to skip nil entries instead of panicking.
- **`psbt_test.go`**: Add regression test `TestSerializeNilTaprootLeafScript`.

Fixes #2495