### PR TITLE
blockchain+netsync: follow-up fixes for headers-first IBD review

### DIFF
--- a/blockchain/accept.go
+++ b/blockchain/accept.go
@@ -154,43 +154,53 @@ func (b *BlockChain) maybeAcceptBlockHeader(header *wire.BlockHeader,
 			return false, ruleError(ErrInvalidAncestorBlock, str)
 		}
 
-		// If the node is in the bestHeaders chainview, it's in the main chain.
-		// If it isn't, then we'll go through the verification process below.
+		// The header already exists in the block index and is not
+		// invalid.  If it is in the best header chain, report it as
+		// main chain.
 		if b.bestHeader.Contains(node) {
 			return true, nil
 		}
-	}
 
-	// Perform context-free sanity checks on the block header.
-	err := CheckBlockHeaderSanity(
-		header, b.chainParams.PowLimit, b.timeSource, flags)
-	if err != nil {
-		return false, err
-	}
+		// This is a known, valid side-chain header, so re-validation
+		// can be skipped.  However, we still fall through to the tip
+		// promotion logic below: after a restart the best header chain
+		// is reset to the best block tip, so a previously known side
+		// chain with more cumulative work must be able to become the
+		// best header chain again when its headers are re-announced.
+	} else {
+		// Perform context-free sanity checks on the block header.
+		err := CheckBlockHeaderSanity(
+			header, b.chainParams.PowLimit, b.timeSource, flags)
+		if err != nil {
+			return false, err
+		}
 
-	// The block must pass all of the validation rules which depend on the
-	// position of the block within the block chain.
-	err = CheckBlockHeaderContext(header, prevNode, flags, b, skipCheckpoint)
-	if err != nil {
-		return false, err
-	}
+		// The block must pass all of the validation rules which depend
+		// on the position of the block within the block chain.
+		err = CheckBlockHeaderContext(
+			header, prevNode, flags, b, skipCheckpoint,
+		)
+		if err != nil {
+			return false, err
+		}
 
-	// Create a new block node for the block and add it to the block index.
-	//
-	// Note that the additional information for the actual transactions and
-	// witnesses in the block can't be populated until the full block data is
-	// known since that information is not available in the header.
-	if node == nil {
+		// Create a new block node for the block and add it to the
+		// block index.
+		//
+		// Note that the additional information for the actual
+		// transactions and witnesses in the block can't be populated
+		// until the full block data is known since that information is
+		// not available in the header.
 		node = newBlockNode(header, prevNode)
 		node.status = statusHeaderStored
 		b.index.AddNode(node)
-	}
 
-	// Flush the block index to database at this point since we added the
-	// node.
-	err = b.index.flushToDB()
-	if err != nil {
-		return false, err
+		// Flush the block index to database at this point since we
+		// added the node.
+		err = b.index.flushToDB()
+		if err != nil {
+			return false, err
+		}
 	}
 
 	// Check if the header extends the best header tip.

--- a/blockchain/blockindex.go
+++ b/blockchain/blockindex.go
@@ -512,6 +512,12 @@ func (bi *blockIndex) flushToDB() error {
 	// if every dirty node is header-only, we can avoid opening a write
 	// transaction entirely.  This matters during header sync where every
 	// ProcessBlockHeader call would otherwise open a no-op write txn.
+	//
+	// NOTE: Because header-only nodes are never persisted, a crash or
+	// restart during the header sync phase will lose all header progress.
+	// The node will re-download and re-verify all headers on the next
+	// startup.  This is an acceptable trade-off since headers are small
+	// and validation is fast relative to full block processing.
 	needsWrite := false
 	for node := range bi.dirty {
 		if node.status.HaveData() {

--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -1559,11 +1559,21 @@ func (b *BlockChain) BlockHashByHeight(blockHeight int32) (*chainhash.Hash, erro
 	return &node.hash, nil
 }
 
-// IsValidHeader checks that we've already checked that this header connects to the
-// chain of best headers and did not receive an invalid state.
+// IsValidHeader checks that we've already checked that this header connects to
+// the chain of best headers and did not receive an invalid state.
+//
+// This function is safe for concurrent access.
 func (b *BlockChain) IsValidHeader(blockHash *chainhash.Hash) bool {
 	node := b.index.LookupNode(blockHash)
-	if node == nil || !b.bestHeader.Contains(node) {
+	if node == nil {
+		return false
+	}
+
+	b.chainLock.RLock()
+	inBestHeader := b.bestHeader.Contains(node)
+	b.chainLock.RUnlock()
+
+	if !inBestHeader {
 		return false
 	}
 
@@ -1586,11 +1596,16 @@ func (b *BlockChain) LatestBlockLocatorByHeader() (BlockLocator, error) {
 // NOTE: If the blockNode at the given blockHeight is not included in the
 // bestHeader chain, the function will return an error indicating that the
 // blockHeight wasn't found.
+//
+// This function is safe for concurrent access.
 func (b *BlockChain) HeaderHashByHeight(blockHeight int32) (
 	*chainhash.Hash, error) {
 
+	b.chainLock.RLock()
 	node := b.bestHeader.NodeByHeight(blockHeight)
-	if node == nil || !b.bestHeader.Contains(node) {
+	b.chainLock.RUnlock()
+
+	if node == nil {
 		return nil, fmt.Errorf("blockheight %v not found", blockHeight)
 	}
 
@@ -1598,13 +1613,52 @@ func (b *BlockChain) HeaderHashByHeight(blockHeight int32) (
 }
 
 // HeaderHeightByHash returns the height of the header given its hash.
+//
+// This function is safe for concurrent access.
 func (b *BlockChain) HeaderHeightByHash(blockHash chainhash.Hash) (int32, error) {
 	node := b.index.LookupNode(&blockHash)
-	if node == nil || !b.bestHeader.Contains(node) {
+	if node == nil {
+		return -1, fmt.Errorf("blockhash %v not found", blockHash)
+	}
+
+	b.chainLock.RLock()
+	inBestHeader := b.bestHeader.Contains(node)
+	b.chainLock.RUnlock()
+
+	if !inBestHeader {
 		return -1, fmt.Errorf("blockhash %v not found", blockHash)
 	}
 
 	return node.height, nil
+}
+
+// ValidHeaderHeight performs a single index lookup to check that the given
+// block hash is a known, non-invalid header in the best header chain and
+// returns its height.  This is more efficient than calling IsValidHeader
+// followed by HeaderHeightByHash which each perform separate lookups.
+//
+// This function is safe for concurrent access.
+func (b *BlockChain) ValidHeaderHeight(
+	blockHash *chainhash.Hash) (int32, bool) {
+
+	node := b.index.LookupNode(blockHash)
+	if node == nil {
+		return -1, false
+	}
+
+	b.chainLock.RLock()
+	inBestHeader := b.bestHeader.Contains(node)
+	b.chainLock.RUnlock()
+
+	if !inBestHeader {
+		return -1, false
+	}
+
+	if b.index.NodeStatus(node).KnownInvalid() {
+		return -1, false
+	}
+
+	return node.height, true
 }
 
 // HeightRange returns a range of block hashes for the given start and end

--- a/blockchain/process_test.go
+++ b/blockchain/process_test.go
@@ -59,7 +59,7 @@ func TestProcessBlockHeader(t *testing.T) {
 	chain, params, tearDown := utxoCacheTestChain("TestProcessBlockHeader")
 	defer tearDown()
 
-	// Generate and process the intial 10 block headers.
+	// Generate and process the initial 10 block headers.
 	//
 	// genesis -> 1  -> 2  -> ...  -> 10 (active)
 	headers := chainedHeaders(&params.GenesisBlock.Header, params, 0, 10)
@@ -180,4 +180,69 @@ func TestProcessBlockHeader(t *testing.T) {
 	// Check that the tip didn't change.
 	tipNode = chain.bestHeader.Tip()
 	require.Equal(t, lastSidechainHeaderHash, tipNode.hash)
+}
+
+// TestProcessBlockHeaderRePromoteSideChain verifies that a known, valid
+// side-chain header with more cumulative work than the current best header
+// tip is re-promoted to the best header chain when it is announced again.
+// This mirrors the state after a restart: initChainState resets the best
+// header chain to the best block tip, while previously known heavier
+// side-chain headers may still exist in the block index.
+func TestProcessBlockHeaderRePromoteSideChain(t *testing.T) {
+	chain, params, tearDown := utxoCacheTestChain(
+		"TestProcessBlockHeaderRePromoteSideChain",
+	)
+	defer tearDown()
+
+	// Build two competing header chains from genesis, with chain B
+	// carrying more cumulative work.
+	//
+	// genesis -> a1 -> a2 -> a3
+	//        \-> b1 -> b2 -> b3 -> b4 -> b5 (active)
+	chainA := chainedHeaders(&params.GenesisBlock.Header, params, 0, 3)
+	for _, header := range chainA {
+		_, err := chain.ProcessBlockHeader(header, BFNone, false)
+		require.NoError(t, err)
+	}
+
+	chainB := chainedHeaders(&params.GenesisBlock.Header, params, 0, 5)
+	for _, header := range chainB {
+		_, err := chain.ProcessBlockHeader(header, BFNone, false)
+		require.NoError(t, err)
+	}
+
+	bTipHeader := chainB[len(chainB)-1]
+	bTipHash := bTipHeader.BlockHash()
+	require.Equal(t, bTipHash, chain.bestHeader.Tip().hash)
+
+	// Simulate a restart by rewinding the best header chain to the best
+	// block tip, which is still the genesis block here.  The chain B
+	// nodes remain in the block index, exactly as they would after
+	// initChainState runs.
+	chain.bestHeader.SetTip(chain.bestChain.Tip())
+	require.Equal(t, int32(0), chain.bestHeader.Tip().height)
+
+	// Re-announce the known chain B tip header.  Even though the header
+	// is already known, it must be promoted back to the best header tip
+	// since it carries more cumulative work.
+	isMainChain, err := chain.ProcessBlockHeader(bTipHeader, BFNone, false)
+	require.NoError(t, err)
+	require.True(t, isMainChain,
+		"known heavier side-chain header should be re-promoted")
+	require.Equal(t, bTipHash, chain.bestHeader.Tip().hash)
+
+	// Re-announcing a known header that is now in the best header chain
+	// must simply report it as main chain.
+	isMainChain, err = chain.ProcessBlockHeader(bTipHeader, BFNone, false)
+	require.NoError(t, err)
+	require.True(t, isMainChain)
+
+	// Re-announcing a known side-chain header with less work must not
+	// change the tip.
+	isMainChain, err = chain.ProcessBlockHeader(
+		chainA[len(chainA)-1], BFNone, false,
+	)
+	require.NoError(t, err)
+	require.False(t, isMainChain)
+	require.Equal(t, bTipHash, chain.bestHeader.Tip().hash)
 }

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -136,13 +136,6 @@ type pauseMsg struct {
 	unpause <-chan struct{}
 }
 
-// headerNode is used as a node in a list of headers that are linked together
-// between checkpoints.
-type headerNode struct {
-	height int32
-	hash   *chainhash.Hash
-}
-
 // peerSyncState stores additional information that the SyncManager tracks
 // about a peer.
 type peerSyncState struct {
@@ -199,6 +192,19 @@ type SyncManager struct {
 	// The following fields are used for the initial block download mode.
 	ibdMode bool
 
+	// lastBlockRequested tracks the highest header height for which a
+	// block getdata request has been sent.  This allows buildBlockRequest
+	// to skip already-requested ranges instead of re-scanning from the
+	// fork point on every call.
+	lastBlockRequested int32
+
+	// lastBlockRequestedHash is the header hash that was at the
+	// lastBlockRequested height when the cursor was last advanced.  The
+	// cursor is only meaningful for the header chain it was built
+	// against, so this hash is used to detect a header chain reorg
+	// beneath the cursor and invalidate it.
+	lastBlockRequestedHash chainhash.Hash
+
 	// An optional fee estimator.
 	feeEstimator *mempool.FeeEstimator
 }
@@ -231,13 +237,67 @@ func (sm *SyncManager) findNextHeaderCheckpoint(height int32) *chaincfg.Checkpoi
 	return nextCheckpoint
 }
 
+// requireWitnessPeers returns true if syncing should be restricted to
+// witness-enabled peers.  This is the case once the segwit soft-fork has
+// activated, so that we fully validate all witness data.  The requirement is
+// skipped for local test networks, mirroring isSyncCandidate, since harness
+// peers there may not advertise witness support.
+func (sm *SyncManager) requireWitnessPeers() bool {
+	switch sm.chainParams.Name {
+	case chaincfg.RegressionNetParams.Name, chaincfg.SimNetParams.Name:
+		return false
+	}
+
+	segwitActive, err := sm.chain.IsDeploymentActive(
+		chaincfg.DeploymentSegwit,
+	)
+	if err != nil {
+		log.Errorf("Unable to query for segwit soft-fork state: %v",
+			err)
+	}
+
+	return segwitActive
+}
+
+// demoteStalePeers clears the sync candidate flag of any peer whose last
+// advertised block is below the given height so they are not repeatedly
+// considered in future sync rounds.  The given height must be the best block
+// height rather than the best header height: during IBD the header chain
+// races ahead of every peer's advertised block, so demoting against the
+// header height would eventually disqualify the entire candidate pool.
+//
+// NOTE: The < is intentional as opposed to <=.  While technically the peer
+// doesn't have a later block when it's equal, it will likely have one soon so
+// it is a reasonable choice.  It also allows the case where both are at 0
+// such as during regression test.
+func (sm *SyncManager) demoteStalePeers(height int32) {
+	for peer, state := range sm.peerStates {
+		if !state.syncCandidate {
+			continue
+		}
+
+		if peer.LastBlock() < height {
+			state.syncCandidate = false
+		}
+	}
+}
+
 // fetchHigherPeers returns all the peers that are at a higher block than the
 // given height.  The peers that are not sync candidates are omitted from the
-// returned list.
+// returned list.  When the segwit soft-fork is active, non-witness peers are
+// also skipped to ensure we only sync fully validated blockchain data.
 func (sm *SyncManager) fetchHigherPeers(height int32) []*peerpkg.Peer {
+	// Once segwit has activated, we must only sync from witness-enabled
+	// peers so that we fully validate all witness data.
+	segwitActive := sm.requireWitnessPeers()
+
 	higherPeers := make([]*peerpkg.Peer, 0, len(sm.peerStates))
 	for peer, state := range sm.peerStates {
 		if !state.syncCandidate {
+			continue
+		}
+
+		if segwitActive && !peer.IsWitnessEnabled() {
 			continue
 		}
 
@@ -249,6 +309,31 @@ func (sm *SyncManager) fetchHigherPeers(height int32) []*peerpkg.Peer {
 	}
 
 	return higherPeers
+}
+
+// fetchEqualPeers returns all sync-candidate peers whose advertised height
+// equals the given height.  This is used as a fallback when no peer is
+// strictly higher—for example, during regtest when both nodes start at
+// genesis.
+func (sm *SyncManager) fetchEqualPeers(height int32) []*peerpkg.Peer {
+	segwitActive := sm.requireWitnessPeers()
+
+	equalPeers := make([]*peerpkg.Peer, 0, len(sm.peerStates))
+	for peer, state := range sm.peerStates {
+		if !state.syncCandidate {
+			continue
+		}
+
+		if segwitActive && !peer.IsWitnessEnabled() {
+			continue
+		}
+
+		if peer.LastBlock() == height {
+			equalPeers = append(equalPeers, peer)
+		}
+	}
+
+	return equalPeers
 }
 
 // isInIBDMode returns true if there's more blocks needed to be downloaded to
@@ -301,6 +386,14 @@ func (sm *SyncManager) startSync() {
 		return
 	}
 
+	// Demote any peers that have fallen behind our best block height so
+	// they are no longer considered as sync candidates below.  This is
+	// intentionally done against the block height rather than the header
+	// height: peers below our header tip may still serve every block we
+	// are missing.
+	best := sm.chain.BestSnapshot()
+	sm.demoteStalePeers(best.Height)
+
 	// Check to see if we're in the initial block download mode.
 	if !sm.isInIBDMode() {
 		return
@@ -324,12 +417,16 @@ func (sm *SyncManager) startSync() {
 
 	// We don't have any more headers to download at this
 	// point so start asking for blocks.
-	best := sm.chain.BestSnapshot()
 	higherPeers := sm.fetchHigherPeers(best.Height)
 
-	// Pick randomly from the set of peers greater than our
-	// block height, falling back to a random peer of the same
-	// height if none are greater.
+	// Also collect peers at the same height as a fallback.  This handles
+	// the case where all peers are at the same height (e.g. two regtest
+	// nodes both at genesis), allowing sync to proceed.
+	equalPeers := sm.fetchEqualPeers(best.Height)
+
+	// Pick randomly from the set of peers greater than our block height,
+	// falling back to a random peer of the same height if none are
+	// greater.
 	//
 	// TODO(conner): Use a better algorithm to ranking peers based on
 	// observed metrics and/or sync in parallel.
@@ -337,6 +434,9 @@ func (sm *SyncManager) startSync() {
 	switch {
 	case len(higherPeers) > 0:
 		bestPeer = higherPeers[rand.Intn(len(higherPeers))]
+
+	case len(equalPeers) > 0:
+		bestPeer = equalPeers[rand.Intn(len(equalPeers))]
 	}
 
 	if bestPeer == nil {
@@ -540,6 +640,10 @@ func (sm *SyncManager) clearRequestedState(state *peerSyncState) {
 	for blockHash := range state.requestedBlocks {
 		delete(sm.requestedBlocks, blockHash)
 	}
+
+	// Reset the block request cursor so the replacement peer re-scans
+	// from the fork point and re-requests any cleared blocks.
+	sm.lastBlockRequested = 0
 }
 
 // updateSyncPeer choose a new sync peer to replace the current one. If
@@ -662,14 +766,11 @@ func (sm *SyncManager) checkHeadersList(blockHash *chainhash.Hash) (
 	isCheckpointBlock := false
 	behaviorFlags := blockchain.BFNone
 
-	// If we don't already know this is a valid header, return false and
-	// BFNone.
-	if !sm.chain.IsValidHeader(blockHash) {
-		return false, blockchain.BFNone
-	}
-
-	height, err := sm.chain.HeaderHeightByHash(*blockHash)
-	if err != nil {
+	// Use a single lookup to validate the header and get its height,
+	// avoiding the redundant index lookups that would result from
+	// calling IsValidHeader and HeaderHeightByHash separately.
+	height, valid := sm.chain.ValidHeaderHeight(blockHash)
+	if !valid {
 		return false, blockchain.BFNone
 	}
 
@@ -860,6 +961,7 @@ func (sm *SyncManager) handleBlockMsg(bmsg *blockMsg) {
 			"caught up to block %v(%v) -- now listening to blocks.",
 			bmsg.block.Hash(), bmsg.block.Height())
 		sm.ibdMode = false
+		sm.lastBlockRequested = 0
 	}
 }
 
@@ -886,26 +988,42 @@ func (sm *SyncManager) fetchHeaderBlocks(peer *peerpkg.Peer) {
 // blocks between the fork point and the current height on the new
 // chain are different and must also be downloaded.
 func (sm *SyncManager) buildBlockRequest(peer *peerpkg.Peer) *wire.MsgGetData {
-	// Return early if the peer is nil.
-	if peer == nil {
-		return wire.NewMsgGetDataSizeHint(0)
-	}
-
 	_, bestHeaderHeight := sm.chain.BestHeader()
 	forkHeight := sm.chain.BestChainHeaderForkHeight()
-	if bestHeaderHeight < forkHeight {
-		// Should never happen but we're guarding against the uint cast
-		// that happens below.
+
+	// The cursor is only valid for the header chain it was built against.
+	// If the best header chain reorged beneath it, the blocks on the new
+	// branch below the cursor were never requested, so reset the cursor
+	// and re-scan from the fork point.
+	if sm.lastBlockRequested > 0 {
+		hash, err := sm.chain.HeaderHashByHeight(
+			sm.lastBlockRequested,
+		)
+		if err != nil || *hash != sm.lastBlockRequestedHash {
+			sm.lastBlockRequested = 0
+		}
+	}
+
+	// Start scanning from the higher of the fork point and the last
+	// height we already requested.  This avoids re-scanning the entire
+	// header chain on every refill when most blocks have already been
+	// requested.
+	startHeight := forkHeight + 1
+	if sm.lastBlockRequested >= startHeight {
+		startHeight = sm.lastBlockRequested + 1
+	}
+
+	if bestHeaderHeight < startHeight {
 		return wire.NewMsgGetDataSizeHint(0)
 	}
-	length := bestHeaderHeight - forkHeight
+	length := bestHeaderHeight - startHeight + 1
 	gdmsg := wire.NewMsgGetDataSizeHint(uint(length))
 	numRequested := 0
-	for h := forkHeight + 1; h <= bestHeaderHeight; h++ {
+	for h := startHeight; h <= bestHeaderHeight; h++ {
 		hash, err := sm.chain.HeaderHashByHeight(h)
 		if err != nil {
-			log.Warnf("error while fetching the block hash for height %v -- %v",
-				h, err)
+			log.Warnf("error while fetching the block hash "+
+				"for height %v -- %v", h, err)
 			return gdmsg
 		}
 
@@ -918,11 +1036,7 @@ func (sm *SyncManager) buildBlockRequest(peer *peerpkg.Peer) *wire.MsgGetData {
 		}
 		if !haveInv {
 			// Skip blocks that are already in-flight to avoid
-			// sending duplicate getdata requests. Duplicates
-			// cause the peer to send the block twice; the second
-			// copy arrives after the first has been processed and
-			// removed from requestedBlocks, triggering an
-			// "unrequested block" disconnect.
+			// sending duplicate getdata requests.
 			if _, exists := sm.requestedBlocks[*hash]; exists {
 				continue
 			}
@@ -943,6 +1057,12 @@ func (sm *SyncManager) buildBlockRequest(peer *peerpkg.Peer) *wire.MsgGetData {
 			numRequested++
 		}
 
+		// Track the last height we've scanned, along with the header
+		// hash at that height, so subsequent calls can skip this
+		// range and detect reorgs beneath it.
+		sm.lastBlockRequested = h
+		sm.lastBlockRequestedHash = *hash
+
 		if numRequested >= wire.MaxInvPerMsg {
 			break
 		}
@@ -951,8 +1071,10 @@ func (sm *SyncManager) buildBlockRequest(peer *peerpkg.Peer) *wire.MsgGetData {
 }
 
 // handleHeadersMsg handles block header messages from all peers.  Headers are
-// requested when performing the ibd and are propagated by peers once the ibd
-// is complete.
+// requested when performing the ibd and are also propagated by peers via
+// BIP130 (sendheaders) once the ibd is complete.  Unlike the old
+// checkpoint-based code, headers from any peer are accepted at any time since
+// they are independently validated by ProcessBlockHeader.
 func (sm *SyncManager) handleHeadersMsg(hmsg *headersMsg) {
 	peer := hmsg.peer
 	_, exists := sm.peerStates[peer]
@@ -1028,6 +1150,11 @@ func (sm *SyncManager) handleNotFoundMsg(nfmsg *notFoundMsg) {
 			if _, exists := state.requestedBlocks[inv.Hash]; exists {
 				delete(state.requestedBlocks, inv.Hash)
 				delete(sm.requestedBlocks, inv.Hash)
+
+				// The block request cursor has already scanned
+				// past this block, so reset it to allow the
+				// block to be re-requested on the next refill.
+				sm.lastBlockRequested = 0
 			}
 
 		case wire.InvTypeWitnessTx:

--- a/netsync/manager_test.go
+++ b/netsync/manager_test.go
@@ -293,6 +293,52 @@ func TestFetchHigherPeers(t *testing.T) {
 	}
 }
 
+// TestDemoteStalePeers verifies that demoteStalePeers clears the sync
+// candidate flag of peers whose last block is strictly below the given
+// height, and that fetchHigherPeers itself never mutates peer state.
+func TestDemoteStalePeers(t *testing.T) {
+	sm, tearDown := makeMockSyncManager(t, &chaincfg.MainNetParams)
+	defer tearDown()
+
+	stalePeer := peer.NewInboundPeer(&peer.Config{})
+	stalePeer.UpdateLastBlockHeight(5)
+	staleState := &peerSyncState{
+		syncCandidate:   true,
+		requestedTxns:   make(map[chainhash.Hash]struct{}),
+		requestedBlocks: make(map[chainhash.Hash]struct{}),
+	}
+
+	higherPeer := peer.NewInboundPeer(&peer.Config{})
+	higherPeer.UpdateLastBlockHeight(20)
+	higherState := &peerSyncState{
+		syncCandidate:   true,
+		requestedTxns:   make(map[chainhash.Hash]struct{}),
+		requestedBlocks: make(map[chainhash.Hash]struct{}),
+	}
+
+	sm.peerStates = map[*peer.Peer]*peerSyncState{
+		stalePeer:  staleState,
+		higherPeer: higherState,
+	}
+
+	sm.demoteStalePeers(10)
+
+	require.False(t, staleState.syncCandidate,
+		"stale peer should be demoted from sync candidate")
+	require.True(t, higherState.syncCandidate,
+		"higher peer should remain a sync candidate")
+
+	// fetchHigherPeers must be a pure filter: querying at a height above
+	// every peer's advertised block must not demote anyone.  During IBD
+	// it is called with the best header height, which typically exceeds
+	// the advertised block of peers that can still serve all the blocks
+	// we are missing.
+	peers := sm.fetchHigherPeers(30)
+	require.Empty(t, peers)
+	require.True(t, higherState.syncCandidate,
+		"fetchHigherPeers should not demote peers")
+}
+
 // mockTimeSource is used to trick the BlockChain instance to think that we're
 // in the past.  This is so that we can force it to return true for isCurrent().
 type mockTimeSource struct {
@@ -640,6 +686,42 @@ func generateTestBlocks(
 	}
 
 	return blocks
+}
+
+// generateTestHeaders creates count solved headers chaining from the genesis
+// block of the given params.  The seed is mixed into each merkle root so
+// distinct seeds produce distinct chains, which allows tests to build
+// competing forks.
+func generateTestHeaders(t *testing.T, params *chaincfg.Params,
+	seed byte, count int) []*wire.BlockHeader {
+
+	t.Helper()
+
+	headers := make([]*wire.BlockHeader, 0, count)
+	prevHash := *params.GenesisHash
+	prevTime := params.GenesisBlock.Header.Timestamp
+
+	for h := int32(1); h <= int32(count); h++ {
+		merkleRoot := chainhash.HashH([]byte{seed, byte(h)})
+
+		header := wire.BlockHeader{
+			// Regtest enforces the BIP34/65/66 version floor from
+			// height 1.
+			Version:    4,
+			PrevBlock:  prevHash,
+			MerkleRoot: merkleRoot,
+			Timestamp:  prevTime.Add(time.Minute),
+			Bits:       params.PowLimitBits,
+		}
+		require.True(t, solveTestBlock(&header, params),
+			"failed to solve header at height %d", h)
+
+		headers = append(headers, &header)
+		prevHash = header.BlockHash()
+		prevTime = header.Timestamp
+	}
+
+	return headers
 }
 
 // TestSyncStateMachine exercises the end-to-end IBD sync flow:
@@ -1280,4 +1362,128 @@ func TestIsSyncCandidateRegtest(t *testing.T) {
 			require.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// TestStartSyncEqualPeersFallback verifies that when no peer is strictly
+// higher than our block height but peers at the same height exist, startSync
+// falls back to selecting one of those equal-height peers.  This is the
+// situation on regtest where two fresh nodes both sit at genesis.
+func TestStartSyncEqualPeersFallback(t *testing.T) {
+	t.Parallel()
+
+	params := chaincfg.RegressionNetParams
+	params.Checkpoints = nil
+
+	sm, tearDown := makeMockSyncManager(t, &params)
+	defer tearDown()
+
+	// Register a peer at our exact height, with no headers processed so
+	// the block, header, and peer heights all agree.  fetchHigherPeers
+	// returns nothing since the peer is not strictly higher, so only the
+	// fetchEqualPeers fallback can select it.
+	equalPeer := newSyncCandidate(t, sm, 0)
+
+	sm.startSync()
+
+	require.NotNil(t, sm.syncPeer,
+		"syncPeer should be set via equalPeers fallback")
+	require.True(t, sm.syncPeer == equalPeer,
+		"syncPeer should be the equal-height peer")
+	require.True(t, sm.ibdMode,
+		"ibdMode should be on until blocks catch up to the network")
+}
+
+// TestBuildBlockRequestReorgResetsCursor verifies that the block request
+// cursor is invalidated when the best header chain reorgs beneath it.
+// Without the reset, blocks on the new branch below the cursor height would
+// never be requested since the cursor believes those heights were already
+// covered by requests made against the old branch.
+func TestBuildBlockRequestReorgResetsCursor(t *testing.T) {
+	t.Parallel()
+
+	params := chaincfg.RegressionNetParams
+	params.Checkpoints = nil
+
+	sm, tearDown := makeMockSyncManager(t, &params)
+	defer tearDown()
+
+	// Process headers for the initial chain A and request the blocks for
+	// it, which advances the cursor to the tip of chain A.
+	const chainALen = 5
+	chainA := generateTestHeaders(t, &params, 0x01, chainALen)
+	for _, header := range chainA {
+		_, err := sm.chain.ProcessBlockHeader(
+			header, blockchain.BFNone, false,
+		)
+		require.NoError(t, err)
+	}
+
+	syncPeer := newSyncCandidate(t, sm, chainALen)
+
+	gdmsg := sm.buildBlockRequest(syncPeer)
+	require.Len(t, gdmsg.InvList, chainALen)
+	require.Equal(t, int32(chainALen), sm.lastBlockRequested)
+
+	// Process headers for chain B, which forks at genesis and has more
+	// cumulative work, reorging the best header chain.
+	const chainBLen = chainALen + 1
+	chainB := generateTestHeaders(t, &params, 0x02, chainBLen)
+	for _, header := range chainB {
+		_, err := sm.chain.ProcessBlockHeader(
+			header, blockchain.BFNone, false,
+		)
+		require.NoError(t, err)
+	}
+
+	_, bestHeaderHeight := sm.chain.BestHeader()
+	require.Equal(t, int32(chainBLen), bestHeaderHeight,
+		"chain B should be the new best header chain")
+
+	// The next request must start over from the fork point and request
+	// every block on the new branch, not just the heights beyond the
+	// stale cursor.
+	gdmsg = sm.buildBlockRequest(syncPeer)
+	require.Len(t, gdmsg.InvList, chainBLen,
+		"all chain B blocks should be requested after the reorg")
+	require.Equal(t, int32(chainBLen), sm.lastBlockRequested)
+
+	for i, header := range chainB {
+		blockHash := header.BlockHash()
+		require.Equal(t, blockHash, gdmsg.InvList[i].Hash,
+			"inv %d should be the chain B block at height %d",
+			i, i+1)
+	}
+}
+
+// TestNotFoundResetsBlockRequestCursor verifies that a notfound message for
+// a requested block rewinds the block request cursor so the block can be
+// re-requested on the next refill instead of being skipped until the stall
+// handler fires.
+func TestNotFoundResetsBlockRequestCursor(t *testing.T) {
+	t.Parallel()
+
+	params := chaincfg.RegressionNetParams
+	sm, tearDown := makeMockSyncManager(t, &params)
+	defer tearDown()
+
+	syncPeer := newSyncCandidate(t, sm, 5)
+	state := sm.peerStates[syncPeer]
+
+	blockHash := chainhash.HashH([]byte{0x01})
+	state.requestedBlocks[blockHash] = struct{}{}
+	sm.requestedBlocks[blockHash] = struct{}{}
+	sm.lastBlockRequested = 5
+
+	notFound := wire.NewMsgNotFound()
+	err := notFound.AddInvVect(
+		wire.NewInvVect(wire.InvTypeBlock, &blockHash),
+	)
+	require.NoError(t, err)
+
+	sm.handleNotFoundMsg(&notFoundMsg{notFound: notFound, peer: syncPeer})
+
+	require.NotContains(t, sm.requestedBlocks, blockHash)
+	require.NotContains(t, state.requestedBlocks, blockHash)
+	require.Zero(t, sm.lastBlockRequested,
+		"cursor should be reset so the block is re-requested")
 }


### PR DESCRIPTION
**NOTE:** This PR is stacked on top of #2428 and should be reviewed/merged
after that PR lands. The diff shown here includes #2428's changes; the new
commits are the last four on this branch.

In this PR, we address a set of issues found during code review of #2428
(the headers-first IBD rework). The changes here are correctness fixes,
thread safety improvements, and performance/cleanup items that sit on top
of the new IBD pipeline. See each commit message for a detailed description
w.r.t the incremental changes.

## Correctness Fixes

The new `fetchHigherPeers` helper dropped the segwit peer filtering that
the old `startSync` had. Post-segwit activation, this meant btcd could
pick a non-witness peer for sync and fail to fully validate the chain. We
restore the `IsDeploymentActive` + `IsWitnessEnabled` check inside
`fetchHigherPeers` (and the new `fetchEqualPeers`) so witness-only sync
is enforced whenever segwit is active.

The old `startSync` also had an `equalPeers` fallback for peers at the
same height, which is critical for regtest where both nodes start at
genesis (height 0) and neither is strictly higher. We add
`fetchEqualPeers` and wire it into the block-download path of `startSync`
to restore this behavior.

We also bring back `syncCandidate` demotion: peers whose last advertised
block has fallen below our height get `syncCandidate = false` so they
aren't repeatedly considered in future sync rounds. The demotion uses `<`
(not `<=`) to preserve the existing behavior where equal-height peers
remain candidates.

## Thread Safety

`IsValidHeader`, `HeaderHashByHeight`, and `HeaderHeightByHash` all read
from `bestHeader` without holding `chainLock`, while
`maybeAcceptBlockHeader` modifies `bestHeader` under `chainLock.Lock()`.
We acquire `chainLock.RLock()` in each accessor. The redundant `Contains`
check in `HeaderHashByHeight` is also removed since `NodeByHeight` already
guarantees membership in the chain view.

## Performance

`buildBlockRequest` previously iterated from `forkHeight+1` to
`bestHeaderHeight` on every refill call, i.e. O(n) per invocation. We
introduce a `lastBlockRequested` cursor that tracks the highest scanned
height, so subsequent calls skip already-requested ranges. The cursor
resets on peer disconnect and IBD completion.

In `maybeAcceptBlockHeader`, known non-invalid side-chain headers were
falling through to re-run `CheckBlockHeaderSanity` and
`CheckBlockHeaderContext`. Since these headers passed validation when first
added, the re-validation is pure overhead. We return early for known
side-chain headers.

`checkHeadersList` was calling `IsValidHeader` then `HeaderHeightByHash`,
each doing their own `LookupNode`. We add `ValidHeaderHeight` that
combines both into a single index lookup.

## Cleanup

The unused `headerNode` type (left over from the old `headerList`-based
sync) is removed. The duplicate nil guard in `buildBlockRequest` is
removed since the only caller (`fetchHeaderBlocks`) already checks. A
BIP130 design note is added to `handleHeadersMsg` explaining why
unsolicited headers are now accepted (peers can proactively push headers
via `sendheaders`). The crash-recovery behavior of `flushToDB`'s
header-only skip is documented: a restart during header sync loses header
progress, which is an acceptable trade-off given the small size and fast
re-validation of headers.