### PR TITLE
treap, ffldb: improve pool recycling, add batched Delete

### DIFF
--- a/database/ffldb/dbcache.go
+++ b/database/ffldb/dbcache.go
@@ -611,24 +611,30 @@ func (c *dbCache) commitTx(tx *transaction) error {
 	c.cacheLock.RUnlock()
 
 	// Apply every key to add in the database transaction to the cache.
+	// Both puts and deletes are batched to enable intermediary node
+	// recycling via sync.Pool, reducing GC pressure during IBD.
 	pendingKVs := make([]treap.KVPair, 0, tx.pendingKeys.Len())
+	removeDeleteKeys := make([][]byte, 0, tx.pendingKeys.Len())
 	tx.pendingKeys.ForEach(func(k, v []byte) bool {
 		pendingKVs = append(pendingKVs, treap.KVPair{Key: k, Value: v})
-
-		newCachedRemove = newCachedRemove.Delete(k)
+		removeDeleteKeys = append(removeDeleteKeys, k)
 		return true
 	})
+	newCachedRemove = newCachedRemove.Delete(removeDeleteKeys...)
 	newCachedKeys = newCachedKeys.Put(pendingKVs...)
 	tx.pendingKeys = nil
 
 	// Apply every key to remove in the database transaction to the cache.
 	pendingRemoveKVs := make([]treap.KVPair, 0, tx.pendingRemove.Len())
+	keysDeleteKeys := make([][]byte, 0, tx.pendingRemove.Len())
 	tx.pendingRemove.ForEach(func(k, v []byte) bool {
-		pendingRemoveKVs = append(pendingRemoveKVs, treap.KVPair{Key: k, Value: v})
-
-		newCachedKeys = newCachedKeys.Delete(k)
+		pendingRemoveKVs = append(pendingRemoveKVs, treap.KVPair{
+			Key: k, Value: nil,
+		})
+		keysDeleteKeys = append(keysDeleteKeys, k)
 		return true
 	})
+	newCachedKeys = newCachedKeys.Delete(keysDeleteKeys...)
 	newCachedRemove = newCachedRemove.Put(pendingRemoveKVs...)
 	tx.pendingRemove = nil
 

--- a/database/internal/treap/immutable.go
+++ b/database/internal/treap/immutable.go
@@ -105,59 +105,93 @@ func (t *Immutable) Get(key []byte) []byte {
 	return nil
 }
 
-// KVPair is just a helper struct for a key-value pair that's going to be
-// inserted into the treap.
+// KVPair is a helper struct for a key-value pair that's going to be inserted
+// into the treap.
 type KVPair struct {
 	Key   []byte
 	Value []byte
 }
 
-// Put puts the passed in key/value pairs into the treap.  For operations
+// nodeInSet returns true if the given node pointer exists in the set array.
+// The set is terminated by the first nil entry.
+func nodeInSet(node *treapNode, set *[staticDepth]*treapNode) bool {
+	for _, n := range set {
+		if n == nil {
+			return false
+		}
+		if n == node {
+			return true
+		}
+	}
+	return false
+}
+
+// Put inserts the passed key/value pairs into the treap.  For operations
 // requiring many insertions at once, Put is memory efficient as the
-// intermediary treap nodes created between each put operation is recycled
+// intermediary treap nodes created between each put operation are recycled
 // through an internal sync.Pool, reducing overall memory allocation.
+//
+// MVCC Snapshot Safety: The recycling of intermediate nodes is safe with
+// respect to concurrent snapshot readers because:
+//
+//  1. Each internal put() call creates FRESH nodes via cloneTreapNode (pool
+//     allocation) that are distinct from any node in a pre-existing treap
+//     version or snapshot.
+//  2. Snapshots hold references to the ORIGINAL treap's root, whose nodes
+//     are never recycled here — only their clones are candidates.
+//  3. A cloned node from a previous put() iteration is recycled only if it
+//     was re-cloned by the subsequent put() (verified via pointer identity
+//     in the replaced source set), confirming the new treap no longer
+//     references it.
+//  4. Cloned nodes NOT re-cloned survive in the new treap via structural
+//     sharing and are never recycled.
 func (t *Immutable) Put(kvPairs ...KVPair) *Immutable {
+	if len(kvPairs) == 0 {
+		return t
+	}
+
 	treap := t
-	var prevTreapNodes [staticDepth]*treapNode
+	var prevCreated [staticDepth]*treapNode
 
 	for _, kvPair := range kvPairs {
-		newTreap, newTreapNodes := treap.put(kvPair.Key, kvPair.Value)
+		newTreap, created, replaced := treap.put(
+			kvPair.Key, kvPair.Value,
+		)
 
-		// Loop through the prevTreapNodes and check for treapNodes that
-		// are no longer being utilized.  These will be garbaged collected
-		// and they're better off being recycled in the treapNodePool.
-		for _, node := range prevTreapNodes {
+		// Recycle nodes from the previous put() that were re-cloned
+		// by the current put().  A node is safe to recycle when it
+		// appears in the replaced source set, meaning the new treap
+		// has a fresh clone in its place and no longer references the
+		// previous version.  This is O(depth^2) pointer comparisons
+		// which is far cheaper than the previous O(depth * log n)
+		// approach using get() with key comparisons.
+		for _, node := range prevCreated {
 			if node == nil {
 				break
 			}
 
-			// Make sure that the node we're going to recycle isn't
-			// being used by the latest immutable treap by checking
-			// if the pointer value of the node is the same.
-			got := newTreap.get(node.key)
-			if got == node {
-				continue
+			if nodeInSet(node, &replaced) {
+				node.recycle()
 			}
-
-			// This node is only being used by the previous immutable
-			// copy and can safely be put into the treapNodePool to be
-			// recycled.
-			node.recycle()
 		}
 
-		// Replace with the latest treap and treap nodes.
 		treap = newTreap
-		prevTreapNodes = newTreapNodes
+		prevCreated = created
 	}
 
 	return treap
 }
 
-// put inserts the passed key/value pair and returns all the newly created
-// treapNodes that were created during this put operation.  The returned
-// treapNodes can then be put into data structures like sync.Pool to reduce the
-// memory overhead of allocating new treapNodes during multiple put calls.
-func (t *Immutable) put(key, value []byte) (*Immutable, [staticDepth]*treapNode) {
+// put inserts the passed key/value pair and returns the new treap along with
+// two node arrays: created contains all newly allocated nodes (clones of
+// ancestors plus the new leaf), and replaced contains the original source
+// nodes that were cloned.  The caller can compare these arrays across
+// sequential put() calls to determine which intermediate nodes are no longer
+// live and can be safely returned to the pool.
+func (t *Immutable) put(key, value []byte) (
+	*Immutable, [staticDepth]*treapNode, [staticDepth]*treapNode,
+) {
+
 	// Use an empty byte slice for the value when none was provided.  This
 	// ultimately allows key existence to be determined from the value since
 	// an empty byte slice is distinguishable from nil.
@@ -165,19 +199,19 @@ func (t *Immutable) put(key, value []byte) (*Immutable, [staticDepth]*treapNode)
 		value = emptySlice
 	}
 
-	// recycle is the treapNodes that are created during this put operation.
-	// We keep track of the nodes as the caller may be choose to recycle
-	// them to keep memory allocation low.
 	var (
-		recycle             [staticDepth]*treapNode
-		currentRecycleIndex int
+		created     [staticDepth]*treapNode
+		replaced    [staticDepth]*treapNode
+		createdIdx  int
+		replacedIdx int
 	)
 
 	// The node is the root of the tree if there isn't already one.
 	if t.root == nil {
 		root := newTreapNode(key, value, rand.Int())
-		recycle[currentRecycleIndex] = root
-		return newImmutable(root, 1, nodeSize(root)), recycle
+		created[0] = root
+		return newImmutable(root, 1, nodeSize(root)),
+			created, replaced
 	}
 
 	// Find the binary tree insertion point and construct a replaced list of
@@ -194,13 +228,14 @@ func (t *Immutable) put(key, value []byte) (*Immutable, [staticDepth]*treapNode)
 		// Clone the node and link its parent to it if needed.
 		nodeCopy := cloneTreapNode(node)
 
-		// Check if we still have space in the recycle for this node.
-		// It's ok if we don't put every single new node to be recycled
-		// as there's no guarantee in the sync.Pool that every recycled
-		// treapNode will be re-utilized.
-		if currentRecycleIndex < staticDepth {
-			recycle[currentRecycleIndex] = nodeCopy
-			currentRecycleIndex++
+		// Track the new clone and the original source it replaced.
+		if createdIdx < staticDepth {
+			created[createdIdx] = nodeCopy
+			createdIdx++
+		}
+		if replacedIdx < staticDepth {
+			replaced[replacedIdx] = node
+			replacedIdx++
 		}
 
 		if oldParent := parents.At(0); oldParent != nil {
@@ -232,17 +267,16 @@ func (t *Immutable) put(key, value []byte) (*Immutable, [staticDepth]*treapNode)
 		newRoot := parents.At(parents.Len() - 1)
 		newTotalSize := t.totalSize - uint64(len(node.value)) +
 			uint64(len(value))
-		return newImmutable(newRoot, t.count, newTotalSize), recycle
+		return newImmutable(newRoot, t.count, newTotalSize),
+			created, replaced
 	}
 
-	// Check if we still have space in the recycle for this node.
-	// It's ok if we don't put every single new node to be recycled
-	// as there's no guarantee in the sync.Pool that every recycled
-	// treapNode will be re-utilized.
+	// Create the new leaf node.  There is no replaced source for a brand
+	// new node — only clones of existing nodes have sources.
 	node := newTreapNode(key, value, rand.Int())
-	if currentRecycleIndex < staticDepth {
-		recycle[currentRecycleIndex] = node
-		currentRecycleIndex++
+	if createdIdx < staticDepth {
+		created[createdIdx] = node
+		createdIdx++
 	}
 
 	// Link the new node into the binary tree in the correct position.
@@ -285,13 +319,68 @@ func (t *Immutable) put(key, value []byte) (*Immutable, [staticDepth]*treapNode)
 		}
 	}
 
-	return newImmutable(newRoot, t.count+1, t.totalSize+nodeSize(node)), recycle
+	return newImmutable(newRoot, t.count+1, t.totalSize+nodeSize(node)),
+		created, replaced
 }
 
-// Delete removes the passed key from the treap and returns the resulting treap
-// if it exists.  The original immutable treap is returned if the key does not
-// exist.
-func (t *Immutable) Delete(key []byte) *Immutable {
+// Delete removes the passed keys from the treap and returns the resulting
+// treap.  Keys that do not exist are silently ignored.  For operations
+// requiring many deletions at once, Delete is memory efficient as the
+// intermediary treap nodes created between each delete operation are recycled
+// through an internal sync.Pool, reducing overall memory allocation.
+//
+// The same MVCC snapshot safety guarantees as Put apply here — see Put for
+// the full safety argument.
+func (t *Immutable) Delete(keys ...[]byte) *Immutable {
+	if len(keys) == 0 {
+		return t
+	}
+
+	treap := t
+	var prevCreated [staticDepth]*treapNode
+
+	for _, key := range keys {
+		newTreap, created, replacedSrc := treap.delete(key)
+
+		// Only attempt recycling when the treap was actually modified.
+		// When the key was not found, delete() returns the same treap
+		// pointer and empty arrays, so prevCreated must be preserved
+		// for the next iteration that does modify the treap.
+		if newTreap != treap {
+			for _, node := range prevCreated {
+				if node == nil {
+					break
+				}
+
+				if nodeInSet(node, &replacedSrc) {
+					node.recycle()
+				}
+			}
+
+			prevCreated = created
+		}
+
+		treap = newTreap
+	}
+
+	return treap
+}
+
+// delete removes the passed key from the treap and returns the new treap along
+// with two node arrays following the same semantics as put(): created contains
+// all newly allocated clones, replaced contains the original source nodes.  If
+// the key does not exist, the original treap is returned with empty arrays.
+func (t *Immutable) delete(key []byte) (
+	*Immutable, [staticDepth]*treapNode, [staticDepth]*treapNode,
+) {
+
+	var (
+		created     [staticDepth]*treapNode
+		replaced    [staticDepth]*treapNode
+		createdIdx  int
+		replacedIdx int
+	)
+
 	// Find the node for the key while constructing a list of parents while
 	// doing so.
 	var parents parentStack
@@ -318,14 +407,14 @@ func (t *Immutable) Delete(key []byte) *Immutable {
 
 	// There is nothing to do if the key does not exist.
 	if delNode == nil {
-		return t
+		return t, created, replaced
 	}
 
 	// When the only node in the tree is the root node and it is the one
 	// being deleted, there is nothing else to do besides removing it.
 	parent := parents.At(1)
 	if parent == nil && delNode.left == nil && delNode.right == nil {
-		return newImmutable(nil, 0, 0)
+		return newImmutable(nil, 0, 0), created, replaced
 	}
 
 	// Construct a replaced list of parents and the node to delete itself.
@@ -336,6 +425,17 @@ func (t *Immutable) Delete(key []byte) *Immutable {
 	for i := parents.Len(); i > 0; i-- {
 		node := parents.At(i - 1)
 		nodeCopy := cloneTreapNode(node)
+
+		// Track the clone and its source.
+		if createdIdx < staticDepth {
+			created[createdIdx] = nodeCopy
+			createdIdx++
+		}
+		if replacedIdx < staticDepth {
+			replaced[replacedIdx] = node
+			replacedIdx++
+		}
+
 		if oldParent := newParents.At(0); oldParent != nil {
 			if oldParent.left == node {
 				oldParent.left = nodeCopy
@@ -367,11 +467,24 @@ func (t *Immutable) Delete(key []byte) *Immutable {
 			child = delNode.right
 		}
 
+		// Track the source before cloning.
+		if replacedIdx < staticDepth {
+			replaced[replacedIdx] = child
+			replacedIdx++
+		}
+
 		// Rotate left or right depending on which side the child node
 		// is on.  This has the effect of moving the node to delete
 		// towards the bottom of the tree while maintaining the
 		// min-heap.
 		child = cloneTreapNode(child)
+
+		// Track the newly created clone.
+		if createdIdx < staticDepth {
+			created[createdIdx] = child
+			createdIdx++
+		}
+
 		if isLeft {
 			child.right, delNode.left = delNode, child.right
 		} else {
@@ -406,7 +519,8 @@ func (t *Immutable) Delete(key []byte) *Immutable {
 		parent.left = nil
 	}
 
-	return newImmutable(newRoot, t.count-1, t.totalSize-nodeSize(delNode))
+	return newImmutable(newRoot, t.count-1, t.totalSize-nodeSize(delNode)),
+		created, replaced
 }
 
 // ForEach invokes the passed function with every key/value pair in the treap

--- a/database/internal/treap/immutable_bench_test.go
+++ b/database/internal/treap/immutable_bench_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2015-2016 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package treap
+
+import (
+	"crypto/sha256"
+	"testing"
+)
+
+// BenchmarkImmutablePutBatch benchmarks batched Put operations which exercise
+// the pool-based recycling of intermediate treap nodes.
+func BenchmarkImmutablePutBatch(b *testing.B) {
+	batchSizes := []struct {
+		name string
+		size int
+	}{
+		{"batch=1", 1},
+		{"batch=10", 10},
+		{"batch=100", 100},
+		{"batch=1000", 1000},
+	}
+
+	for _, bs := range batchSizes {
+		b.Run(bs.name, func(b *testing.B) {
+			// Pre-generate all keys to avoid measuring key
+			// generation overhead.
+			keys := make([]KVPair, bs.size)
+			for i := range keys {
+				hash := sha256.Sum256(serializeUint32(uint32(i)))
+				keys[i] = KVPair{
+					Key:   hash[:],
+					Value: hash[:],
+				}
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				t := NewImmutable()
+				t = t.Put(keys...)
+			}
+		})
+	}
+}
+
+// BenchmarkImmutableDeleteBatch benchmarks batched Delete operations which
+// exercise the pool-based recycling of intermediate treap nodes.
+func BenchmarkImmutableDeleteBatch(b *testing.B) {
+	batchSizes := []struct {
+		name string
+		size int
+	}{
+		{"batch=1", 1},
+		{"batch=10", 10},
+		{"batch=100", 100},
+		{"batch=1000", 1000},
+	}
+
+	for _, bs := range batchSizes {
+		b.Run(bs.name, func(b *testing.B) {
+			// Pre-generate keys and build the initial treap.
+			kvPairs := make([]KVPair, bs.size)
+			delKeys := make([][]byte, bs.size)
+			for i := range kvPairs {
+				hash := sha256.Sum256(serializeUint32(uint32(i)))
+				kvPairs[i] = KVPair{
+					Key:   hash[:],
+					Value: hash[:],
+				}
+				delKeys[i] = hash[:]
+			}
+			baseTreap := NewImmutable().Put(kvPairs...)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				baseTreap.Delete(delKeys...)
+			}
+		})
+	}
+}
+
+// BenchmarkImmutablePutSequential benchmarks sequential Put operations on a
+// growing treap, which is the hot path during initial block download when
+// populating the UTXO cache.
+func BenchmarkImmutablePutSequential(b *testing.B) {
+	const batchSize = 100
+
+	// Pre-generate keys.
+	keys := make([]KVPair, batchSize)
+	for i := range keys {
+		key := serializeUint32(uint32(i))
+		keys[i] = KVPair{Key: key, Value: key}
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		t := NewImmutable()
+		// Simulate multiple rounds of batch inserts to exercise
+		// recycling across iterations.
+		for round := 0; round < 10; round++ {
+			roundKeys := make([]KVPair, batchSize)
+			for j := range roundKeys {
+				key := serializeUint32(
+					uint32(round*batchSize + j),
+				)
+				roundKeys[j] = KVPair{Key: key, Value: key}
+			}
+			t = t.Put(roundKeys...)
+		}
+	}
+}
+
+// BenchmarkImmutableMixedPutDelete benchmarks interleaved batch Put and Delete
+// operations, simulating the commitTx pattern in dbcache.go.
+func BenchmarkImmutableMixedPutDelete(b *testing.B) {
+	const numKeys = 500
+
+	// Pre-generate keys.
+	putKVs := make([]KVPair, numKeys)
+	delKeys := make([][]byte, numKeys/2)
+	for i := 0; i < numKeys; i++ {
+		hash := sha256.Sum256(serializeUint32(uint32(i)))
+		putKVs[i] = KVPair{Key: hash[:], Value: hash[:]}
+		if i < numKeys/2 {
+			delKeys[i] = hash[:]
+		}
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		t := NewImmutable()
+		t = t.Put(putKVs...)
+		t = t.Delete(delKeys...)
+	}
+}

--- a/database/internal/treap/immutable_test.go
+++ b/database/internal/treap/immutable_test.go
@@ -78,7 +78,7 @@ func TestImmutableSequential(t *testing.T) {
 		// Ensure the treap length is the expected value.
 		if gotLen := testTreap.Len(); gotLen != (i+1)*keyCount {
 			t.Fatalf("Len #%d: unexpected length - got %d, want %d",
-				i, gotLen, i+1)
+				i, gotLen, (i+1)*keyCount)
 		}
 
 		for j, key := range keys {
@@ -190,7 +190,7 @@ func TestImmutableReverseSequential(t *testing.T) {
 		// Ensure the treap length is the expected value.
 		if gotLen := testTreap.Len(); gotLen != (i+1)*keyCount {
 			t.Fatalf("Len #%d: unexpected length - got %d, want %d",
-				i, gotLen, i+1)
+				i, gotLen, (i+1)*keyCount)
 		}
 
 		for j, key := range keys {
@@ -305,7 +305,7 @@ func TestImmutableUnordered(t *testing.T) {
 		// Ensure the treap length is the expected value.
 		if gotLen := testTreap.Len(); gotLen != (i+1)*keyCount {
 			t.Fatalf("Len #%d: unexpected length - got %d, want %d",
-				i, gotLen, i+1)
+				i, gotLen, (i+1)*keyCount)
 		}
 
 		for j, key := range keys {
@@ -530,6 +530,63 @@ func TestImmutableSnapshot(t *testing.T) {
 		}
 
 		expectedSize += (nodeFieldsSize + 8) * uint64(keyCount)
+	}
+
+	// Verify single-element Put() preserves snapshot immutability.  This
+	// specifically tests the recycling path with a single key where
+	// prevCreated is empty and no recycling should occur.
+	singleSnap := testTreap
+	singleKey := serializeUint32(uint32(numItems + 1))
+	testTreap = testTreap.Put(KVPair{singleKey, singleKey})
+	if singleSnap.Has(singleKey) {
+		t.Fatalf("single-key snapshot: key %q should not be in snapshot",
+			singleKey)
+	}
+	if gotLen := singleSnap.Len(); gotLen != numItems {
+		t.Fatalf("single-key snapshot: unexpected length - got %d, "+
+			"want %d", gotLen, numItems)
+	}
+	testTreap = testTreap.Delete(singleKey)
+
+	// Verify small-batch (3 keys) preserves snapshot immutability.  This
+	// exercises the recycling logic at a granularity where intermediate
+	// node recycling occurs between the 2nd and 3rd insertions.
+	smallSnap := testTreap
+	smallKeys := []KVPair{
+		{serializeUint32(uint32(numItems + 10)), []byte("a")},
+		{serializeUint32(uint32(numItems + 11)), []byte("b")},
+		{serializeUint32(uint32(numItems + 12)), []byte("c")},
+	}
+	testTreap = testTreap.Put(smallKeys...)
+	for _, kv := range smallKeys {
+		if smallSnap.Has(kv.Key) {
+			t.Fatalf("small-batch snapshot: key %q should not "+
+				"be in snapshot", kv.Key)
+		}
+	}
+	if gotLen := smallSnap.Len(); gotLen != numItems {
+		t.Fatalf("small-batch snapshot: unexpected length - got %d, "+
+			"want %d", gotLen, numItems)
+	}
+
+	// Verify that all original keys in the snapshot are still accessible
+	// after the Put with recycling.
+	for i := 0; i < numItems; i++ {
+		key := serializeUint32(uint32(i))
+		if !smallSnap.Has(key) {
+			t.Fatalf("small-batch snapshot integrity: key %q "+
+				"missing from snapshot after Put", key)
+		}
+		if gotVal := smallSnap.Get(key); !bytes.Equal(gotVal, key) {
+			t.Fatalf("small-batch snapshot integrity: key %q "+
+				"value corrupted - got %x, want %x",
+				key, gotVal, key)
+		}
+	}
+
+	// Undo the small-batch additions for the delete phase.
+	for _, kv := range smallKeys {
+		testTreap = testTreap.Delete(kv.Key)
 	}
 
 	// Delete the keys one-by-one while checking several of the treap


### PR DESCRIPTION
## Change Description

In this PR, we improve the `sync.Pool`-based node recycling introduced in #2425 and extend the same optimization to `Delete` operations.

### Faster Recycling Check in `Put()`

The original `Put()` recycling loop called `newTreap.get(node.key)` for each intermediate node to check if it was still live in the latest treap version. This worked correctly but cost O(depth × log n) key comparisons per batch iteration. We replace this with a pointer-set approach: `put()` now returns both the set of newly created nodes _and_ the set of original source nodes that were cloned (the "replaced" set). The recycling loop checks pointer identity via `nodeInSet()`, which is just a linear scan of a `[staticDepth]*treapNode` array. This brings the cost down to O(depth²) pointer comparisons, i.e. ~400 pointer equality checks for a typical depth of 20, versus ~8000 key comparisons before.

We also document the MVCC snapshot safety argument directly in the `Put()` godoc. The core insight is that intermediate clones are always fresh pool allocations, never shared with any pre-existing snapshot. Only clones that were subsequently re-cloned (and thus replaced in the new treap) are candidates for recycling. Clones still structurally shared with the new treap are left alone.

To gain confidence in this safety argument, we built a [Quint formal model](https://gist.github.com/Roasbeef/8e8afd1f24a02e775809688d5ec96b8a) (TLA+-inspired) that models the treap as a set of node IDs, non-deterministically applies batched puts, deletes, snapshot captures, and snapshot releases, then checks three invariants across 30,000 randomized traces: no recycled node appears in any snapshot, in the current treap, or anywhere live. All three invariants passed. The model confirmed that fresh clone IDs are always >= `nextId` at allocation time, so they can never collide with any pre-existing snapshot, which is exactly what allows us to use the simpler pointer-set check instead of a full treap traversal.

### Batched `Delete()` with Pool Recycling

Previously, `Delete` accepted a single key and allocated cloned nodes from the pool via `cloneTreapNode` without ever returning them. During IBD, `commitTx` issued many individual `Delete` calls inside `ForEach` loops, creating a one-way pool drain where nodes were pulled from the pool but never recycled back.

We extend `Delete` to accept variadic keys (`Delete(keys ...[]byte)`), mirroring `Put`'s batched API. The internal `delete()` method returns the same `(created, replaced)` arrays, enabling the same inter-step recycling. The `commitTx` callsite in `dbcache.go` now collects deletion keys into slices and issues single batched calls. We also fix the `pendingRemove` path to pass `nil` as the value in `KVPair` rather than carrying the actual value, since the remove treap only tracks keys.

### Test Fixes

We fix three test error messages that printed `i+1` as the expected value when the actual expected value was `(i+1)*keyCount`. We also add single-key and small-batch (3 keys) snapshot immutability tests that exercise the recycling logic at the granularity where intermediate node recycling actually occurs. The small-batch test additionally verifies that all 1000 original keys in the snapshot remain accessible with correct values after a `Put` with recycling.

## Benchmarks

```
goos: darwin
goarch: arm64
cpu: Apple M4 Max

                                   │    old     │              new               │
                                   │   B/op     │    B/op      vs base           │
ImmutableDeleteBatch/batch=10      │  2.932Ki   │  1.251Ki   -57.33% (p=0.002)  │
ImmutableDeleteBatch/batch=100     │  67.66Ki   │  42.03Ki   -37.89% (p=0.002)  │
ImmutableDeleteBatch/batch=1000    │  1323.5Ki  │  925.6Ki   -30.07% (p=0.002)  │
ImmutableMixedPutDelete            │  605.8Ki   │  524.3Ki   -13.46% (p=0.002)  │

                                   │  allocs/op │  allocs/op   vs base           │
ImmutableDeleteBatch/batch=10      │    44.50   │    23.00   -48.31% (p=0.002)  │
ImmutableDeleteBatch/batch=100     │    935.5   │    607.5   -35.06% (p=0.002)  │
ImmutableDeleteBatch/batch=1000    │   17.63k   │   12.53k   -28.90% (p=0.002)  │
ImmutableMixedPutDelete            │   8.274k   │   7.230k   -12.61% (p=0.002)  │
```

The batched Delete shows 30-57% reduction in bytes allocated and 29-48% fewer allocations. The mixed Put+Delete benchmark (which mirrors the `commitTx` pattern) shows a 13% reduction in both memory and allocations.

Put performance is roughly neutral, as expected: the pointer-set approach trades O(log n) key comparisons for O(depth) pointer comparisons, which are similar in practice for typical treap sizes.

See each commit message for a detailed description w.r.t the incremental changes.

## Steps to Test

```bash
go test ./database/internal/treap/ -v -race -count=1
go test ./database/ffldb/ -v -race -short -count=1
go test ./database/internal/treap/ -bench=BenchmarkImmutable -benchmem
```

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.

### Code Style and Documentation
- [x] The change obeys the Code Documentation and Commenting guidelines, and lines wrap at 80.
- [x] Commits follow the Ideal Git Commit Structure.