### PR TITLE
wire: don't wrap ipv4 in ipv6 addresses

### DIFF
--- a/wire/netaddressv2.go
+++ b/wire/netaddressv2.go
@@ -181,6 +181,19 @@ func NetAddressV2FromBytes(timestamp time.Time, services ServiceFlag,
 			break
 		}
 
+		// IPv4-mapped IPv6 addresses (::ffff:0:0/96) should use the
+		// IPv4 networkID. Bitcoin Core silently drops IPv6 addrv2
+		// entries with this prefix. Go's net.IP commonly stores
+		// IPv4 addresses in this 16-byte form, so extract the
+		// 4-byte IPv4 address.
+		if isIPv4Mapped(addrBytes) {
+			addr := &ipv4Addr{}
+			addr.netID = ipv4
+			copy(addr.addr[:], addrBytes[12:])
+			netAddr = addr
+			break
+		}
+
 		addr := &ipv6Addr{}
 		addr.netID = ipv6
 		copy(addr.addr[:], addrBytes)

--- a/wire/netaddressv2_test.go
+++ b/wire/netaddressv2_test.go
@@ -95,6 +95,17 @@ func TestNetAddressV2FromBytes(t *testing.T) {
 			string(ipv6),
 		},
 
+		// IPv4-mapped IPv6 encoding (::ffff:127.0.0.1) should be
+		// converted to IPv4.
+		{
+			[]byte{
+				0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+				0x00, 0x00, 0xff, 0xff, 0x7f, 0x00, 0x00, 0x01,
+			},
+			"127.0.0.1",
+			string(ipv4),
+		},
+
 		// OnionCat encoding
 		{
 			[]byte{


### PR DESCRIPTION
## Change Description

Go's `net.ParseIP` stores IPv4 addresses internally as 16-byte IPv4-mapped IPv6 addresses (`::ffff:x.x.x.x`). `NetAddressV2FromBytes` dispatches on address length, so these 16-byte representations were incorrectly treated as IPv6 and serialized with networkID `0x02` (IPv6) instead of `0x01` (IPv4).

BIP-155 doesn't actually forbid this. It defines network IDs and their expected address lengths, but says nothing about IPv4-mapped IPv6 addresses. However, Bitcoin Core's [`UnserializeV2Stream()`](https://github.com/bitcoin/bitcoin/blob/4f8bd396f8/src/netaddress.h#L459-L466) silently drops any IPv6 addrv2 entry with the `::ffff:` prefix. Naturally, this isn't documented in the BIP.

Bitcoin Core avoids producing these in the first place via [`SetLegacyIPv6()`](https://github.com/bitcoin/bitcoin/blob/4f8bd396f8/src/netaddress.cpp#L138-L165), which detects the `::ffff:` prefix early and reclassifies the address as `NET_IPV4`.

## Impact

This result in addresses propagated by btcd nodes being sliently dropped by Bitcoin Core nodes for ipv4 addresses. I debugged this when I was finding out why addresses would take a long time to propagate to bitcoin seeders.

Having this change would mean that discoverability would be better for btcd nodes.

## Steps to Test

You can just look at the aforementioned links and see that Core doesn't do ipv6 wrapped ipv4 addresses. If you wanna test that the address is actually sliently dropped:

```
1. Build btcd from master

2. Start Bitcoin Core on regtest

bitcoind -regtest -port=18555 -rpcport=18556 \
    -rpcuser=test -rpcpassword=test -server=1 -listen=1 \
    -debug=net -debug=addrman -daemon
sleep 2

3. Mine blocks so btcd will consider itself current after syncing
bitcoin-cli -regtest -rpcport=18556 -rpcuser=test -rpcpassword=test \
    generatetoaddress 101 bcrt1qw508d6qejxtdg4y5r3zarvary0c5xw7kygt080

4. Start btcd with a fake external IP
./btcd --regtest \
    --connect=127.0.0.1:18555 --listen=127.0.0.1:18777 \
    --externalip=1.2.3.4 --rpcuser=test --rpcpass=test \
    --rpclisten=127.0.0.1:18778 --notls &
sleep 10

5. Disconnect so btcd reconnects with IsCurrent=true and self-advertises
bitcoin-cli -regtest -rpcport=18556 -rpcuser=test -rpcpassword=test \
  disconnectnode 127.0.0.1:18777
sleep 5

6. Core received the addr but getnodeaddresses returns empty
grep "Received addr" ~/.bitcoin/regtest/debug.log
bitcoin-cli -regtest -rpcport=18556 -rpcuser=test -rpcpassword=test \
  getnodeaddresses 0
```

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
