### PR TITLE
rpcclient: compute httpURL once at construction time

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -144,6 +144,11 @@ type Client struct {
 	// POST mode.
 	httpClient *http.Client
 
+	// httpURL is the request URL used for every HTTP POST. It depends only
+	// on the configured Host and DisableTLS, both of which are immutable
+	// after New, so it is computed once at construction time and reused.
+	httpURL string
+
 	// backendVersion is the version of the backend the client is currently
 	// connected to. This should be retrieved through GetVersion.
 	backendVersionMu sync.Mutex
@@ -779,7 +784,7 @@ func (c *Client) handleSendPostMessage(ctx context.Context, jReq *jsonRequest) {
 // shutdown-driven cancellation.
 func sendPostRequestWithRetry(ctx context.Context, jReq *jsonRequest,
 	tries int, httpClient *http.Client, config *ConnConfig,
-	batch bool) ([]byte, error) {
+	httpURL string, batch bool) ([]byte, error) {
 
 	var (
 		lastErr      error
@@ -787,11 +792,6 @@ func sendPostRequestWithRetry(ctx context.Context, jReq *jsonRequest,
 		httpResponse *http.Response
 		err          error
 	)
-
-	httpURL, err := config.httpURL()
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse address %v", err)
-	}
 
 retryloop:
 	for i := 0; i < tries; i++ {
@@ -899,7 +899,7 @@ func (c *Client) sendPostRequestAndRespond(ctx context.Context,
 	jReq *jsonRequest, tries int) {
 
 	res, err := sendPostRequestWithRetry(
-		ctx, jReq, tries, c.httpClient, c.config, c.batch,
+		ctx, jReq, tries, c.httpClient, c.config, c.httpURL, c.batch,
 	)
 
 	// Preserve the client contract that shutdown-related cancellations surface
@@ -1418,30 +1418,23 @@ func newHTTPClient(config *ConnConfig) (*http.Client, error) {
 	return &client, nil
 }
 
-// httpURL returns the URL to use for HTTP POST requests.
-func (config *ConnConfig) httpURL() (string, error) {
+// httpURL returns the URL for HTTP POST requests. The Unix-socket case
+// returns a placeholder, since the path is dialed by the Transport's
+// DialContext. config.Host is not validated here, because newHTTPClient
+// already validates it via ParseAddressString.
+func (config *ConnConfig) httpURL() string {
 	protocol := "http"
 	if !config.DisableTLS {
 		protocol = "https"
 	}
 
-	parsedAddr, err := ParseAddressString(config.Host)
-	if err != nil {
-		return "", fmt.Errorf("error parsing host '%v': %v",
-			config.Host, err)
+	if strings.HasPrefix(config.Host, "unix://") ||
+		strings.HasPrefix(config.Host, "unixpacket://") {
+
+		return protocol + "://unix"
 	}
 
-	var httpURL string
-	switch parsedAddr.Network() {
-	case "unix", "unixpacket":
-		// Using a placeholder URL because a non-empty URL is required.
-		// The Unix domain socket is specified in the DialContext.
-		httpURL = protocol + "://unix"
-	default:
-		httpURL = protocol + "://" + config.Host
-	}
-
-	return httpURL, nil
+	return protocol + "://" + config.Host
 }
 
 // dial opens a websocket connection using the passed connection configuration
@@ -1528,6 +1521,7 @@ func New(config *ConnConfig, ntfnHandlers *NotificationHandlers) (*Client, error
 	// when running in HTTP POST mode.
 	var wsConn *websocket.Conn
 	var httpClient *http.Client
+	var httpURL string
 	connEstablished := make(chan struct{})
 	var start bool
 	if config.HTTPPostMode {
@@ -1539,6 +1533,7 @@ func New(config *ConnConfig, ntfnHandlers *NotificationHandlers) (*Client, error
 		if err != nil {
 			return nil, err
 		}
+		httpURL = config.httpURL()
 	} else {
 		if !config.DisableConnectOnNew {
 			var err error
@@ -1554,6 +1549,7 @@ func New(config *ConnConfig, ntfnHandlers *NotificationHandlers) (*Client, error
 		config:          config,
 		wsConn:          wsConn,
 		httpClient:      httpClient,
+		httpURL:         httpURL,
 		requestMap:      make(map[uint64]*list.Element),
 		requestList:     list.New(),
 		batch:           false,

--- a/rpcclient/infrastructure_test.go
+++ b/rpcclient/infrastructure_test.go
@@ -322,8 +322,8 @@ func TestSendPostRequestWithRetrySuccess(t *testing.T) {
 	jReq := newPostTestRequest()
 
 	result, err := sendPostRequestWithRetry(
-		context.Background(), jReq, 1, client.httpClient, client.config,
-		false,
+		context.Background(), jReq, 1, client.httpClient,
+		client.config, client.httpURL, false,
 	)
 	require.NoError(t, err)
 	require.Equal(t, []byte("1"), result)
@@ -340,8 +340,8 @@ func TestSendPostRequestWithRetryShutdown(t *testing.T) {
 			jReq := newPostTestRequest()
 
 			result, err := sendPostRequestWithRetry(
-				ctx, jReq, tc.tries, client.httpClient, client.config,
-				false,
+				ctx, jReq, tc.tries, client.httpClient,
+				client.config, client.httpURL, false,
 			)
 			require.Nil(t, result)
 			require.ErrorIs(t, err, context.Canceled)
@@ -475,6 +475,80 @@ func TestSendPostRequestAndRespondShutdown(t *testing.T) {
 
 			require.EqualValues(t, tc.wantAttempts,
 				atomic.LoadInt32(&attempts))
+		})
+	}
+}
+
+// TestHTTPURL pins down the URL strings produced by httpURL for each
+// supported host shape. httpURL runs on every RPC and now uses a
+// hand-rolled prefix check rather than delegating to ParseAddressString,
+// so its output is exercised directly here.
+func TestHTTPURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name       string
+		host       string
+		disableTLS bool
+		expURL     string
+	}{
+		{
+			name:       "unix socket",
+			host:       "unix:///var/run/bitcoin/bitcoin.sock",
+			disableTLS: true,
+			expURL:     "http://unix",
+		},
+		{
+			name:       "unixpacket socket",
+			host:       "unixpacket:///var/run/bitcoin/bitcoin.sock",
+			disableTLS: true,
+			expURL:     "http://unix",
+		},
+		{
+			name:       "ipv4 literal",
+			host:       "127.0.0.1:8332",
+			disableTLS: true,
+			expURL:     "http://127.0.0.1:8332",
+		},
+		{
+			name:       "ipv6 literal",
+			host:       "[::1]:8332",
+			disableTLS: true,
+			expURL:     "http://[::1]:8332",
+		},
+		{
+			name:       "hostname",
+			host:       "localhost:8332",
+			disableTLS: true,
+			expURL:     "http://localhost:8332",
+		},
+		{
+			name:       "empty host",
+			host:       "",
+			disableTLS: true,
+			expURL:     "http://",
+		},
+		{
+			name:       "tls hostname",
+			host:       "bitcoind.example.com:8332",
+			disableTLS: false,
+			expURL:     "https://bitcoind.example.com:8332",
+		},
+		{
+			name:       "tls unix socket",
+			host:       "unix:///var/run/bitcoin/bitcoin.sock",
+			disableTLS: false,
+			expURL:     "https://unix",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &ConnConfig{
+				Host:       tc.host,
+				DisableTLS: tc.disableTLS,
+			}
+			require.Equal(t, tc.expURL, cfg.httpURL())
 		})
 	}
 }
@@ -671,4 +745,26 @@ func TestNewBatchSerializesPostSends(t *testing.T) {
 	}
 
 	require.EqualValues(t, 1, observedMax, "POST sends must be serialized")
+}
+
+// TestHTTPURLWiring guards the construction-time wiring that copies
+// (*ConnConfig).httpURL onto Client.httpURL when HTTPPostMode is set.
+// TestHTTPURL covers the method itself; this test catches the case
+// where a refactor of New silently drops the assignment, leaving
+// Client.httpURL as the zero value.
+func TestHTTPURLWiring(t *testing.T) {
+	t.Parallel()
+
+	cfg := &ConnConfig{
+		Host:         "localhost:8332",
+		HTTPPostMode: true,
+		DisableTLS:   true,
+		User:         "user",
+		Pass:         "pass",
+	}
+	c, err := New(cfg, nil)
+	require.NoError(t, err)
+	defer c.Shutdown()
+
+	require.Equal(t, "http://localhost:8332", c.httpURL)
 }


### PR DESCRIPTION
httpURL was being recomputed on every JSON-RPC POST. It went through ParseAddressString to discriminate Unix sockets from TCP, which called net.ResolveTCPAddr and triggered a DNS lookup whose result was thrown away.

Both inputs (config.Host and config.DisableTLS) are immutable after New, so the URL is constant for the life of the Client. Compute it once and store it on the Client, mirroring the parsedDialAddr cache already in newHTTPClient.

The httpURL method now uses HasPrefix and runs exactly once per Client. Drop its (string, error) signature — with the resolve gone nothing can fail. Add a table test for the URL strings; the old implementation was only covered indirectly via TestParseAddressString.