### PR TITLE
feat: support all networks (addrv2 decoding message)

### DIFF
--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -271,6 +271,10 @@ func IsRoutable(na *wire.NetAddressV2) bool {
 		return false
 	}
 
+	if na.IsCJDNS() {
+		return false
+	}
+
 	lna := na.ToLegacy()
 	return IsValid(lna) && !(IsRFC1918(lna) || IsRFC2544(lna) ||
 		IsRFC3927(lna) || IsRFC4862(lna) || IsRFC3849(lna) ||

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -275,6 +275,10 @@ func IsRoutable(na *wire.NetAddressV2) bool {
 		return false
 	}
 
+	if na.IsYggdrasil() {
+		return false
+	}
+
 	lna := na.ToLegacy()
 	return IsValid(lna) && !(IsRFC1918(lna) || IsRFC2544(lna) ||
 		IsRFC3927(lna) || IsRFC4862(lna) || IsRFC3849(lna) ||

--- a/addrmgr/network.go
+++ b/addrmgr/network.go
@@ -264,12 +264,13 @@ func IsValid(na *wire.NetAddress) bool {
 // in any reserved ranges.
 func IsRoutable(na *wire.NetAddressV2) bool {
 	if na.IsTorV3() {
-		// na is a torv3 address, return true.
 		return true
 	}
 
-	// Else na can be represented as a legacy NetAddress since i2p and
-	// cjdns are unsupported.
+	if na.IsI2P() {
+		return false
+	}
+
 	lna := na.ToLegacy()
 	return IsValid(lna) && !(IsRFC1918(lna) || IsRFC2544(lna) ||
 		IsRFC3927(lna) || IsRFC4862(lna) || IsRFC3849(lna) ||

--- a/wire/netaddressv2.go
+++ b/wire/netaddressv2.go
@@ -25,14 +25,11 @@ var (
 	// maximum size for an unknown networkID.
 	ErrInvalidAddressSize = fmt.Errorf("invalid address size")
 
-	// ErrSkippedNetworkID is returned when the cjdns, i2p, or unknown
-	// networks are encountered during decoding. btcd does not support i2p
-	// or cjdns addresses. In the case of an unknown networkID, this is so
-	// that a future BIP reserving a new networkID does not cause older
-	// addrv2-supporting btcd software to disconnect upon receiving the new
-	// addresses. This error can also be returned when an OnionCat-encoded
-	// torv2 address is received with the ipv6 networkID. This error
-	// signals to the caller to continue reading.
+	// ErrSkippedNetworkID is returned when an unknown network ID is
+	// encountered during decoding, or when an OnionCat-encoded torv2 address
+	// is received with the ipv6 networkID. This allows future BIP-reserved
+	// networkIDs to be silently skipped rather than causing a disconnect.
+	// It signals to the caller to continue reading the message.
 	ErrSkippedNetworkID = fmt.Errorf("skipped networkID")
 )
 
@@ -155,6 +152,13 @@ func (na *NetAddressV2) IsI2P() bool {
 	return ok
 }
 
+// IsCJDNS returns a bool that signals to the caller whether or not this is a
+// cjdns address.
+func (na *NetAddressV2) IsCJDNS() bool {
+	_, ok := na.Addr.(*cjdnsAddr)
+	return ok
+}
+
 // TorV3Key returns the first byte of the v3 public key. This is used in the
 // addrmgr to calculate a key from a network group.
 func (na *NetAddressV2) TorV3Key() byte {
@@ -255,6 +259,9 @@ func writeNetAddressV2(w io.Writer, pver uint32, na *NetAddressV2) error {
 		netID = a.netID
 		address = a.addr[:]
 	case *i2pAddr:
+		netID = a.netID
+		address = a.addr[:]
+	case *cjdnsAddr:
 		netID = a.netID
 		address = a.addr[:]
 	default:
@@ -445,7 +452,7 @@ func readNetAddressV2(r io.Reader, pver uint32, na *NetAddressV2) error {
 			return err
 		}
 
-		return ErrSkippedNetworkID
+		na.Addr = addr
 	}
 
 	return nil
@@ -640,3 +647,16 @@ type cjdnsAddr struct {
 	addr  [cjdnsSize]byte
 	netID networkID
 }
+
+// Part of the net.Addr interface.
+func (a *cjdnsAddr) String() string {
+	return net.IP(a.addr[:]).String()
+}
+
+// Part of the net.Addr interface.
+func (a *cjdnsAddr) Network() string {
+	return string(a.netID)
+}
+
+// Compile-time constraint to check that cjdnsAddr meets the net.Addr interface.
+var _ net.Addr = (*cjdnsAddr)(nil)

--- a/wire/netaddressv2.go
+++ b/wire/netaddressv2.go
@@ -159,6 +159,13 @@ func (na *NetAddressV2) IsCJDNS() bool {
 	return ok
 }
 
+// IsYggdrasil returns a bool that signals to the caller whether or not this is
+// a yggdrasil address.
+func (na *NetAddressV2) IsYggdrasil() bool {
+	_, ok := na.Addr.(*yggdrasilAddr)
+	return ok
+}
+
 // TorV3Key returns the first byte of the v3 public key. This is used in the
 // addrmgr to calculate a key from a network group.
 func (na *NetAddressV2) TorV3Key() byte {
@@ -262,6 +269,9 @@ func writeNetAddressV2(w io.Writer, pver uint32, na *NetAddressV2) error {
 		netID = a.netID
 		address = a.addr[:]
 	case *cjdnsAddr:
+		netID = a.netID
+		address = a.addr[:]
+	case *yggdrasilAddr:
 		netID = a.netID
 		address = a.addr[:]
 	default:
@@ -453,6 +463,23 @@ func readNetAddressV2(r io.Reader, pver uint32, na *NetAddressV2) error {
 		}
 
 		na.Addr = addr
+	case yggdrasil:
+		addr := &yggdrasilAddr{}
+		addr.netID = yggdrasil
+		if decodedSize != uint64(yggdrasilSize) {
+			return ErrInvalidAddressSize
+		}
+
+		if err := readElement(r, &addr.addr); err != nil {
+			return err
+		}
+
+		na.Port, err = binarySerializer.Uint16(r, bigEndian)
+		if err != nil {
+			return err
+		}
+
+		na.Addr = addr
 	}
 
 	return nil
@@ -480,6 +507,9 @@ const (
 
 	// cjdns means the following address is a cjdns address.
 	cjdns
+
+	// yggdrasil means the following address is a yggdrasil address.
+	yggdrasil
 )
 
 const (
@@ -500,6 +530,9 @@ const (
 
 	// cjdnsSize is the size of a cjdns address.
 	cjdnsSize = 16
+
+	// yggdrasilSize is the size of a yggdrasil address.
+	yggdrasilSize = 16
 )
 
 const (
@@ -515,7 +548,7 @@ const (
 // isKnownNetworkID returns true if the networkID is one listed above and false
 // otherwise.
 func isKnownNetworkID(netID uint8) bool {
-	return uint8(ipv4) <= netID && netID <= uint8(cjdns)
+	return uint8(ipv4) <= netID && netID <= uint8(yggdrasil)
 }
 
 type ipv4Addr struct {
@@ -660,3 +693,21 @@ func (a *cjdnsAddr) Network() string {
 
 // Compile-time constraint to check that cjdnsAddr meets the net.Addr interface.
 var _ net.Addr = (*cjdnsAddr)(nil)
+
+type yggdrasilAddr struct {
+	addr  [yggdrasilSize]byte
+	netID networkID
+}
+
+// Part of the net.Addr interface.
+func (a *yggdrasilAddr) String() string {
+	return net.IP(a.addr[:]).String()
+}
+
+// Part of the net.Addr interface.
+func (a *yggdrasilAddr) Network() string {
+	return string(a.netID)
+}
+
+// Compile-time constraint to check that yggdrasilAddr meets the net.Addr interface.
+var _ net.Addr = (*yggdrasilAddr)(nil)

--- a/wire/netaddressv2.go
+++ b/wire/netaddressv2.go
@@ -148,6 +148,13 @@ func (na *NetAddressV2) IsTorV3() bool {
 	return ok
 }
 
+// IsI2P returns a bool that signals to the caller whether or not this is an
+// i2p address.
+func (na *NetAddressV2) IsI2P() bool {
+	_, ok := na.Addr.(*i2pAddr)
+	return ok
+}
+
 // TorV3Key returns the first byte of the v3 public key. This is used in the
 // addrmgr to calculate a key from a network group.
 func (na *NetAddressV2) TorV3Key() byte {
@@ -245,6 +252,9 @@ func writeNetAddressV2(w io.Writer, pver uint32, na *NetAddressV2) error {
 		netID = a.netID
 		address = a.addr[:]
 	case *torv3Addr:
+		netID = a.netID
+		address = a.addr[:]
+	case *i2pAddr:
 		netID = a.netID
 		address = a.addr[:]
 	default:
@@ -418,7 +428,7 @@ func readNetAddressV2(r io.Reader, pver uint32, na *NetAddressV2) error {
 			return err
 		}
 
-		return ErrSkippedNetworkID
+		na.Addr = addr
 	case cjdns:
 		addr := &cjdnsAddr{}
 		addr.netID = cjdns
@@ -611,6 +621,20 @@ type i2pAddr struct {
 	addr  [i2pSize]byte
 	netID networkID
 }
+
+// Part of the net.Addr interface.
+func (a *i2pAddr) String() string {
+	b32 := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(a.addr[:])
+	return strings.ToLower(b32) + ".b32.i2p"
+}
+
+// Part of the net.Addr interface.
+func (a *i2pAddr) Network() string {
+	return string(a.netID)
+}
+
+// Compile-time constraint to check that i2pAddr meets the net.Addr interface.
+var _ net.Addr = (*i2pAddr)(nil)
 
 type cjdnsAddr struct {
 	addr  [cjdnsSize]byte


### PR DESCRIPTION
## Change Description

In this PR, we allow returning the full range of supported network ID when parsing Arrdv2 message and we add utility functions to determine if the address is I2P, CJDNS or Yggdrasil.

They previously were parsed but then the result was ignored to return an error. However we don't allow connected to them using btcd to not change the current behavior of btcd.

## Steps to Test

Run the node with support for Bip155. Request a list of peers to connect to. Notice the I2P peers (for now I haven't seen any CJDNS or YggDrasil peer info).

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
