### PR TITLE
btcd: implement stopatheight

### DIFF
--- a/config.go
+++ b/config.go
@@ -181,6 +181,7 @@ type config struct {
 	SigNet               bool          `long:"signet" description:"Use the signet test network"`
 	SigNetChallenge      string        `long:"signetchallenge" description:"Connect to a custom signet network defined by this challenge instead of using the global default signet test network -- Can be specified multiple times"`
 	SigNetSeedNode       []string      `long:"signetseednode" description:"Specify a seed node for the signet network instead of using the global default signet network seed nodes"`
+	StopAtHeight         int           `long:"stopatheight" hidden:"true" description:"Stop running after the block at the given height in the main chain is processed. Blocks after the target height may be processed during shutdown. For testing only (default: 0, disabled)"`
 	TestNet3             bool          `long:"testnet" description:"Use the test network (version 3)"`
 	TestNet4             bool          `long:"testnet4" description:"Use the test network (version 4)"`
 	TorIsolation         bool          `long:"torisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`

--- a/config.go
+++ b/config.go
@@ -172,6 +172,7 @@ type config struct {
 	SigNet               bool          `long:"signet" description:"Use the signet test network"`
 	SigNetChallenge      string        `long:"signetchallenge" description:"Connect to a custom signet network defined by this challenge instead of using the global default signet test network -- Can be specified multiple times"`
 	SigNetSeedNode       []string      `long:"signetseednode" description:"Specify a seed node for the signet network instead of using the global default signet network seed nodes"`
+	StopAtHeight         int           `long:"stopatheight" hidden:"true" description:"Stop running after the block at the given height in the main chain is processed. Blocks after the target height may be processed during shutdown. For testing only (default: 0, disabled)"`
 	TestNet3             bool          `long:"testnet" description:"Use the test network (version 3)"`
 	TestNet4             bool          `long:"testnet4" description:"Use the test network (version 4)"`
 	TorIsolation         bool          `long:"torisolation" description:"Enable Tor stream isolation by randomizing user credentials for each connection."`

--- a/server.go
+++ b/server.go
@@ -2996,6 +2996,28 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 		return nil, err
 	}
 
+	// stopatheight is a testing aid: once the main chain connects the
+	// configured height, request a graceful shutdown through the same
+	// path as an interrupt signal. The notification fires with the chain
+	// lock released, so blocking on the channel here is safe.
+	if stopHeight := int32(cfg.StopAtHeight); stopHeight > 0 {
+		requestShutdown := sync.OnceFunc(func() {
+			srvrLog.Infof("Reached stopatheight %d; "+
+				"requesting shutdown", stopHeight)
+			shutdownRequestChannel <- struct{}{}
+		})
+		s.chain.Subscribe(func(n *blockchain.Notification) {
+			if n.Type != blockchain.NTBlockConnected {
+				return
+			}
+			block, ok := n.Data.(*btcutil.Block)
+			if !ok || block.Height() < stopHeight {
+				return
+			}
+			requestShutdown()
+		})
+	}
+
 	// Search for a FeeEstimator state in the database. If none can be found
 	// or if it cannot be loaded, create a new one.
 	db.Update(func(tx database.Tx) error {

--- a/server.go
+++ b/server.go
@@ -3098,6 +3098,28 @@ func newServer(listenAddrs, agentBlacklist, agentWhitelist []string,
 		return nil, err
 	}
 
+	// stopatheight is a testing aid: once the main chain connects the
+	// configured height, request a graceful shutdown through the same
+	// path as an interrupt signal. The notification fires with the chain
+	// lock released, so blocking on the channel here is safe.
+	if stopHeight := int32(cfg.StopAtHeight); stopHeight > 0 {
+		requestShutdown := sync.OnceFunc(func() {
+			srvrLog.Infof("Reached stopatheight %d; "+
+				"requesting shutdown", stopHeight)
+			shutdownRequestChannel <- struct{}{}
+		})
+		s.chain.Subscribe(func(n *blockchain.Notification) {
+			if n.Type != blockchain.NTBlockConnected {
+				return
+			}
+			block, ok := n.Data.(*btcutil.Block)
+			if !ok || block.Height() < stopHeight {
+				return
+			}
+			requestShutdown()
+		})
+	}
+
 	// Search for a FeeEstimator state in the database. If none can be found
 	// or if it cannot be loaded, create a new one.
 	db.Update(func(tx database.Tx) error {


### PR DESCRIPTION
## Change Description
    
When the flag stopatheight is set to something greater than zero, a chain notification subscription is created, when the subscription handler receives a notification containing a connected block with height equal or greater than stopatheight value a server shutdown request is sent.

The current implementation is very simple, but further blocks may be processed after the stopheight, so the user may use the rpc to invalidate the block after the target height to get the expected utxoset.

This is a very useful feature for testing purposes.

## Steps to Test

To test that the node is stopping when the expected height is reached, execute btcd with the flag `--stopatheight=N`, the node should stop after processing the block N, it can be verified by starting the node with `--connect=127.0.0.1:invalid_port`, the log will show that the chainstate is at height >= N.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.