### PR TITLE
.github: actually run the integration tests in the CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -145,3 +145,18 @@ jobs:
 
       - name: Test
         run: make unit-race
+
+  test-rpctest:
+    name: Unit rpctest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Check out source
+        uses: actions/checkout@v4
+
+      - name: Test
+        run: make unit

--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -385,6 +385,9 @@ func (h *StringOrArray) UnmarshalJSON(data []byte) error {
 	}
 
 	switch v := unmarshalled.(type) {
+	case nil:
+		*h = nil
+
 	case string:
 		*h = []string{v}
 

--- a/btcjson/chainsvrresults_test.go
+++ b/btcjson/chainsvrresults_test.go
@@ -350,6 +350,16 @@ func TestGetBlockChainInfoWarnings(t *testing.T) {
 			result:   `{"warnings": []}`,
 			expected: btcjson.StringOrArray{},
 		},
+		{
+			name:     "blockchain info with null warnings",
+			result:   `{"warnings": null}`,
+			expected: nil,
+		},
+		{
+			name:     "blockchain info with warnings field omitted",
+			result:   `{}`,
+			expected: nil,
+		},
 	}
 
 	for _, test := range tests {

--- a/integration/p2a_test.go
+++ b/integration/p2a_test.go
@@ -6,6 +6,7 @@ package integration
 import (
 	"testing"
 
+	"github.com/btcsuite/btcd/address/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/integration/rpctest"
@@ -46,7 +47,7 @@ func TestPayToAnchorSimple(t *testing.T) {
 
 	// Create a P2A output using the helper to get a P2A address. This
 	// ensures we're using the same P2A script generation logic.
-	p2aAddr, err := btcutil.NewAddressPayToAnchor(&chaincfg.SimNetParams)
+	p2aAddr, err := address.NewAddressPayToAnchor(&chaincfg.SimNetParams)
 	if err != nil {
 		t.Fatalf("unable to create P2A address: %v", err)
 	}

--- a/integration/rpctest/btcd.go
+++ b/integration/rpctest/btcd.go
@@ -6,6 +6,7 @@ package rpctest
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -43,8 +44,12 @@ func btcdExecutablePath() (string, error) {
 		return "", err
 	}
 
-	// Build btcd and output an executable in a static temp path.
-	outputPath := filepath.Join(testDir, "btcd")
+	// Build btcd to a random path so concurrent `go test` processes
+	// (e.g. when test packages run in parallel under `make unit`) do
+	// not race on the same output file. Each test process pays a
+	// one-time compile cost; within a process the compileMtx-guarded
+	// cache keeps it to one build.
+	outputPath := filepath.Join(testDir, fmt.Sprintf("btcd-%d", rand.Uint32()))
 	if runtime.GOOS == "windows" {
 		outputPath += ".exe"
 	}

--- a/integration/rpctest/rpc_harness.go
+++ b/integration/rpctest/rpc_harness.go
@@ -6,6 +6,7 @@ package rpctest
 
 import (
 	"fmt"
+	"math/rand/v2"
 	"net"
 	"os"
 	"path/filepath"
@@ -76,7 +77,15 @@ var (
 
 	// lastPort is the last port determined to be free for use by a new
 	// node. It should be used atomically.
-	lastPort uint32 = defaultNodePort
+	//
+	// Seed with a random offset so concurrent `go test` processes
+	// (e.g. when integration/ and integration/rpctest/ run in parallel
+	// under `make unit`) do not race on the same port range. The
+	// bind-test in NextAvailablePort closes the listener before
+	// returning, leaving a window where another process could grab the
+	// same port; staggering each process's starting point avoids the
+	// collision. The 50k-port window leaves headroom below 65535.
+	lastPort uint32 = defaultNodePort + rand.Uint32N(50000)
 )
 
 // HarnessTestCase represents a test-case which utilizes an instance of the

--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -1124,9 +1124,10 @@ func (sm *SyncManager) handleInvMsg(imsg *invMsg) {
 		peer.UpdateLastAnnouncedBlock(&invVects[lastBlock].Hash)
 	}
 
-	// Ignore invs from peers that aren't the sync if we are not current.
-	// Helps prevent fetching a mass of orphans.
-	if peer != sm.syncPeer && !sm.current() {
+	// Ignore invs from peers that aren't the sync peer if we are not
+	// current. Helps prevent fetching a mass of orphans. When syncPeer
+	// is nil, accept invs from any peer.
+	if sm.syncPeer != nil && peer != sm.syncPeer && !sm.current() {
 		return
 	}
 


### PR DESCRIPTION
## Change Description
`make build`, `make unit-cover`, and `make unit-race` all use plain `go test` without the rpctest build tag, so anything under //go:build rpctest -- the entire integration/ package outside of rpctest/, and parts of rpctest/ itself -- is not run by the CI. Bugs that only surface under -tags=rpctest can land on master without detection.

Add a test-rpctest job that runs `make unit` (which sets -tags=rpctest) so rpctest-tagged tests are part of every push and PR.

## Steps to Test

run `make all` locally and see that the tests are failing
Let the CI run on your local github repo

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
