### PR TITLE
rpc: expose signet challenge in chain info

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -227,6 +227,7 @@ type UnifiedSoftForks struct {
 // command.
 type GetBlockChainInfoResult struct {
 	Chain                string        `json:"chain"`
+	SignetChallenge      string        `json:"signet_challenge,omitempty"`
 	Blocks               int32         `json:"blocks"`
 	Headers              int32         `json:"headers"`
 	BestBlockHash        string        `json:"bestblockhash"`
@@ -740,6 +741,7 @@ type GetMiningInfoResult struct {
 	HashesPerSec       float64 `json:"hashespersec"`
 	NetworkHashPS      float64 `json:"networkhashps"`
 	PooledTx           uint64  `json:"pooledtx"`
+	SignetChallenge    string  `json:"signet_challenge,omitempty"`
 	TestNet            bool    `json:"testnet"`
 }
 

--- a/btcjson/chainsvrresults_test.go
+++ b/btcjson/chainsvrresults_test.go
@@ -197,6 +197,15 @@ func TestChainSvrMiningInfoResults(t *testing.T) {
 				NetworkHashPS: 89790618491361,
 			},
 		},
+		{
+			name: "mining info with signet challenge",
+			result: `{"networkhashps": 89790618491361, ` +
+				`"signet_challenge": "51"}`,
+			expected: btcjson.GetMiningInfoResult{
+				NetworkHashPS:   89790618491361,
+				SignetChallenge: "51",
+			},
+		},
 	}
 
 	t.Logf("Running %d tests", len(tests))
@@ -363,6 +372,29 @@ func TestGetBlockChainInfoWarnings(t *testing.T) {
 					"want %+v", info.Warnings, test.expected)
 			}
 		})
+	}
+}
+
+// TestGetBlockChainInfoSignetChallenge tests that the signet_challenge field in
+// GetBlockChainInfoResult can be unmarshalled from signet responses.
+func TestGetBlockChainInfoSignetChallenge(t *testing.T) {
+	t.Parallel()
+
+	const signetChallenge = "51"
+
+	var info btcjson.GetBlockChainInfoResult
+	err := json.Unmarshal(
+		[]byte(`{"chain":"signet","signet_challenge":"`+
+			signetChallenge+`"}`),
+		&info,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if info.SignetChallenge != signetChallenge {
+		t.Fatalf("unexpected signet challenge - got %v, want %v",
+			info.SignetChallenge, signetChallenge)
 	}
 }
 

--- a/chaincfg/params.go
+++ b/chaincfg/params.go
@@ -190,6 +190,10 @@ type Params struct {
 	// as one method to discover peers.
 	DNSSeeds []DNSSeed
 
+	// SignetChallenge defines the signet block challenge script for signet
+	// networks.
+	SignetChallenge []byte
+
 	// GenesisBlock defines the first block of the chain.
 	GenesisBlock *wire.MsgBlock
 
@@ -1009,6 +1013,8 @@ func CustomSignetParams(challenge []byte, dnsSeeds []DNSSeed) Params {
 		Net:         wire.BitcoinNet(net),
 		DefaultPort: "38333",
 		DNSSeeds:    dnsSeeds,
+
+		SignetChallenge: append([]byte(nil), challenge...),
 
 		// Chain parameters
 		GenesisBlock:             &sigNetGenesisBlock,

--- a/chaincfg/params_test.go
+++ b/chaincfg/params_test.go
@@ -113,6 +113,21 @@ func TestSigNetMagic(t *testing.T) {
 	require.Equal(t, wire.SigNet, SigNetParams.Net)
 }
 
+// TestSigNetChallenge ensures signet params retain the challenge used to derive
+// their network magic.
+func TestSigNetChallenge(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, DefaultSignetChallenge, SigNetParams.SignetChallenge)
+
+	challenge := []byte{0x51}
+	params := CustomSignetParams(challenge, nil)
+	require.Equal(t, challenge, params.SignetChallenge)
+
+	challenge[0] = 0x52
+	require.Equal(t, []byte{0x51}, params.SignetChallenge)
+}
+
 // compactToBig is a copy of the blockchain.CompactToBig function. We copy it
 // here so we don't run into a circular dependency just because of a test.
 func compactToBig(compact uint32) *big.Int {

--- a/go.mod
+++ b/go.mod
@@ -70,3 +70,7 @@ retract (
 	v0.13.0-beta2
 	v0.13.0-beta
 )
+
+// TODO: Replace this with a tagged/pseudo chaincfg/v2 version before cutting a
+// release consumed by btcwallet/lnd.
+replace github.com/btcsuite/btcd/chaincfg/v2 => ./chaincfg

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1317,6 +1317,12 @@ func handleGetBlockChainInfo(s *rpcServer, cmd interface{}, closeChan <-chan str
 		}
 	}
 
+	if params.Name == chaincfg.SigNetParams.Name {
+		chainInfo.SignetChallenge = hex.EncodeToString(
+			params.SignetChallenge,
+		)
+	}
+
 	return chainInfo, nil
 }
 
@@ -2419,6 +2425,12 @@ func handleGetMiningInfo(s *rpcServer, cmd interface{}, closeChan <-chan struct{
 		PooledTx:           uint64(s.cfg.TxMemPool.Count()),
 		TestNet:            cfg.TestNet3 || cfg.TestNet4,
 	}
+	if s.cfg.ChainParams.Name == chaincfg.SigNetParams.Name {
+		result.SignetChallenge = hex.EncodeToString(
+			s.cfg.ChainParams.SignetChallenge,
+		)
+	}
+
 	return &result, nil
 }
 

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -174,6 +174,7 @@ var helpDescsEnUS = map[string]string{
 
 	// GetBlockChainInfoResult help.
 	"getblockchaininforesult-chain":                "The name of the chain the daemon is on (testnet, mainnet, etc)",
+	"getblockchaininforesult-signet_challenge":     "The hex-encoded signet challenge for signet chains",
 	"getblockchaininforesult-blocks":               "The number of blocks in the best known chain",
 	"getblockchaininforesult-headers":              "The number of headers that we've gathered for in the best known chain",
 	"getblockchaininforesult-bestblockhash":        "The block hash for the latest block in the main chain",
@@ -449,6 +450,7 @@ var helpDescsEnUS = map[string]string{
 	"getmininginforesult-hashespersec":       "Recent hashes per second performance measurement while generating coins",
 	"getmininginforesult-networkhashps":      "Estimated network hashes per second for the most recent blocks",
 	"getmininginforesult-pooledtx":           "Number of transactions in the memory pool",
+	"getmininginforesult-signet_challenge":   "The hex-encoded signet challenge for signet chains",
 	"getmininginforesult-testnet":            "Whether or not server is using testnet",
 
 	// GetMiningInfoCmd help.


### PR DESCRIPTION
## Summary

- retain the signet challenge in chaincfg custom signet params
- expose signet_challenge from getblockchaininfo and getmininginfo
- add a temporary local chaincfg/v2 replace for root-module builds until a tagged/pseudo module version is used

## Tests

- go test ./... in chaincfg
- go test ./... in btcjson
- go test . in the root btcd module