### PR TITLE
rpcclient: allow disabling basic auth

### DIFF
--- a/rpcclient/infrastructure.go
+++ b/rpcclient/infrastructure.go
@@ -811,11 +811,13 @@ retryloop:
 		}
 
 		// Configure basic access authorization.
-		user, pass, authErr := config.getAuth()
-		if authErr != nil {
-			return nil, authErr
+		if !config.DisableAuth {
+			user, pass, authErr := config.getAuth()
+			if authErr != nil {
+				return nil, authErr
+			}
+			httpReq.SetBasicAuth(user, pass)
 		}
-		httpReq.SetBasicAuth(user, pass)
 
 		httpResponse, err = httpClient.Do(httpReq)
 
@@ -1264,6 +1266,12 @@ type ConnConfig struct {
 	// Pass is the passphrase to use to authenticate to the RPC server.
 	Pass string
 
+	// DisableAuth prevents the client from sending HTTP Basic Auth
+	// credentials. This is useful for RPC providers that authenticate
+	// out-of-band, for example with an API key in the request URL, and
+	// reject Authorization headers.
+	DisableAuth bool
+
 	// CookiePath is the path to a cookie file containing the username and
 	// passphrase to use to authenticate to the RPC server.  It is used
 	// instead of User and Pass if non-empty.
@@ -1469,16 +1477,21 @@ func dial(config *ConnConfig) (*websocket.Conn, error) {
 		dialer.NetDial = proxy.Dial
 	}
 
-	// The RPC server requires basic authorization, so create a custom
-	// request header with the Authorization header set.
-	user, pass, err := config.getAuth()
-	if err != nil {
-		return nil, err
-	}
-	login := user + ":" + pass
-	auth := "Basic " + base64.StdEncoding.EncodeToString([]byte(login))
+	// The RPC server requires basic authorization by default, so create a
+	// custom request header with the Authorization header set unless the
+	// caller explicitly disabled auth.
 	requestHeader := make(http.Header)
-	requestHeader.Add("Authorization", auth)
+	if !config.DisableAuth {
+		user, pass, err := config.getAuth()
+		if err != nil {
+			return nil, err
+		}
+		login := user + ":" + pass
+		auth := "Basic " + base64.StdEncoding.EncodeToString(
+			[]byte(login),
+		)
+		requestHeader.Add("Authorization", auth)
+	}
 	for key, value := range config.ExtraHeaders {
 		requestHeader.Add(key, value)
 	}

--- a/rpcclient/infrastructure_test.go
+++ b/rpcclient/infrastructure_test.go
@@ -329,6 +329,85 @@ func TestSendPostRequestWithRetrySuccess(t *testing.T) {
 	require.Equal(t, []byte("1"), result)
 }
 
+// TestSendPostRequestWithRetryUsesBasicAuthByDefault ensures the existing HTTP
+// POST-mode auth behavior is preserved when DisableAuth is false.
+func TestSendPostRequestWithRetryUsesBasicAuthByDefault(t *testing.T) {
+	t.Parallel()
+
+	authChecked := make(chan struct{}, 1)
+	client := newPostModeTestClient(postRoundTripFunc(
+		func(req *http.Request) (*http.Response, error) {
+			user, pass, ok := req.BasicAuth()
+			require.True(t, ok)
+			require.Equal(t, "user", user)
+			require.Equal(t, "pass", pass)
+			authChecked <- struct{}{}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(
+					`{"result":1,"error":null,"id":1}`,
+				)),
+			}, nil
+		},
+	))
+	jReq := newPostTestRequest()
+
+	result, err := sendPostRequestWithRetry(
+		context.Background(), jReq, 1, client.httpClient,
+		client.config, client.httpURL, false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []byte("1"), result)
+
+	select {
+	case <-authChecked:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for auth check")
+	}
+}
+
+// TestSendPostRequestWithRetryDisableAuth skips Basic Auth entirely for RPC
+// providers that authenticate out-of-band and reject Authorization headers.
+func TestSendPostRequestWithRetryDisableAuth(t *testing.T) {
+	t.Parallel()
+
+	authChecked := make(chan struct{}, 1)
+	client := newPostModeTestClient(postRoundTripFunc(
+		func(req *http.Request) (*http.Response, error) {
+			require.Empty(t, req.Header.Get("Authorization"))
+			authChecked <- struct{}{}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body: io.NopCloser(strings.NewReader(
+					`{"result":1,"error":null,"id":1}`,
+				)),
+			}, nil
+		},
+	))
+	client.config.User = ""
+	client.config.Pass = ""
+	client.config.CookiePath = ""
+	client.config.DisableAuth = true
+	jReq := newPostTestRequest()
+
+	result, err := sendPostRequestWithRetry(
+		context.Background(), jReq, 1, client.httpClient,
+		client.config, client.httpURL, false,
+	)
+	require.NoError(t, err)
+	require.Equal(t, []byte("1"), result)
+
+	select {
+	case <-authChecked:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for auth check")
+	}
+}
+
 // TestSendPostRequestWithRetryShutdown keeps the shutdown regression cases in
 // one table while preserving a distinct symptomatic failure for each path.
 func TestSendPostRequestWithRetryShutdown(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `ConnConfig.DisableAuth` so clients can skip HTTP Basic Auth.
- Do not call `getAuth` or send `Authorization` when disabled, including HTTP POST mode and websocket dialing.
- Add regression coverage that default POST requests still send Basic Auth, while disabled-auth POST requests work without credentials or an Authorization header.

Fixes #2505.

## Tests
- `go test ./rpcclient -run 'TestSendPostRequestWithRetry(UsesBasicAuthByDefault|DisableAuth|Success)$' -count=1`
- `go test ./rpcclient -count=1`
- `git diff --check`