### PR TITLE
psbt: reject unsigned tx with trailing bytes

### DIFF
--- a/psbt/partial_input.go
+++ b/psbt/partial_input.go
@@ -90,9 +90,7 @@ func (pi *PInput) deserialize(r io.Reader) error {
 			if keyData != nil {
 				return ErrInvalidKeyData
 			}
-			tx := wire.NewMsgTx(2)
-
-			err := tx.Deserialize(bytes.NewReader(value))
+			tx, err := readTransaction(value, false)
 			if err != nil {
 				return err
 			}

--- a/psbt/psbt.go
+++ b/psbt/psbt.go
@@ -324,6 +324,18 @@ func NewFromRawBytes(r io.Reader, b64 bool) (*Packet, error) {
 		return nil, err
 	}
 
+	var trailing [1]byte
+	_, err = io.ReadFull(r, trailing[:])
+	switch {
+	case err == nil:
+		return nil, ErrInvalidPsbtFormat
+
+	case err == io.EOF:
+
+	case err != nil:
+		return nil, err
+	}
+
 	return &newPsbt, nil
 }
 

--- a/psbt/psbt.go
+++ b/psbt/psbt.go
@@ -225,11 +225,9 @@ func NewFromRawBytes(r io.Reader, b64 bool) (*Packet, error) {
 	if err != nil {
 		return nil, err
 	}
-	msgTx := wire.NewMsgTx(2)
-
 	// BIP-0174 states: "The transaction must be in the old serialization
 	// format (without witnesses)."
-	err = msgTx.DeserializeNoWitness(bytes.NewReader(value))
+	msgTx, err := readTransaction(value, true)
 	if err != nil {
 		return nil, err
 	}

--- a/psbt/strict_tx_values_test.go
+++ b/psbt/strict_tx_values_test.go
@@ -115,3 +115,19 @@ func TestRejectsTrailingDataInTransactionValues(t *testing.T) {
 		})
 	}
 }
+
+// TestRejectsTrailingDataAfterPacket verifies that extra bytes after a valid
+// PSBT packet are rejected.
+func TestRejectsTrailingDataAfterPacket(t *testing.T) {
+	unsignedTx, prevTx := strictnessTxPair(t)
+	rawPacket := strictnessPSBT(
+		t,
+		serializeTxForStrictness(t, unsignedTx, true),
+		serializeTxForStrictness(t, prevTx, false),
+	)
+
+	_, err := NewFromRawBytes(
+		bytes.NewReader(append(rawPacket, 0x00)), false,
+	)
+	require.ErrorIs(t, err, ErrInvalidPsbtFormat)
+}

--- a/psbt/strict_tx_values_test.go
+++ b/psbt/strict_tx_values_test.go
@@ -83,6 +83,45 @@ func strictnessPSBT(t *testing.T, unsignedTx,
 	return buf.Bytes()
 }
 
+// serializeTxOutForStrictness serializes txOut in the PSBT form required by
+// the WitnessUtxo field.
+func serializeTxOutForStrictness(t *testing.T, txOut *wire.TxOut) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	require.NoError(t, wire.WriteTxOut(&buf, 0, 0, txOut))
+
+	return buf.Bytes()
+}
+
+// strictnessPSBTWithWitnessUtxo builds a minimal PSBT using the supplied
+// WitnessUtxo value verbatim.
+func strictnessPSBTWithWitnessUtxo(t *testing.T,
+	witnessUtxo []byte) []byte {
+
+	t.Helper()
+
+	unsignedTx, _ := strictnessTxPair(t)
+
+	var buf bytes.Buffer
+	_, err := buf.Write(psbtMagic[:])
+	require.NoError(t, err)
+
+	require.NoError(t, serializeKVPairWithType(
+		&buf, byte(UnsignedTxType), nil,
+		serializeTxForStrictness(t, unsignedTx, true),
+	))
+	require.NoError(t, buf.WriteByte(0x00))
+
+	require.NoError(t, serializeKVPairWithType(
+		&buf, byte(WitnessUtxoType), nil, witnessUtxo,
+	))
+	require.NoError(t, buf.WriteByte(0x00))
+	require.NoError(t, buf.WriteByte(0x00))
+
+	return buf.Bytes()
+}
+
 // TestRejectsTrailingDataInTransactionValues verifies that PSBT transaction
 // values must contain exactly one serialized transaction.
 func TestRejectsTrailingDataInTransactionValues(t *testing.T) {
@@ -129,5 +168,27 @@ func TestRejectsTrailingDataAfterPacket(t *testing.T) {
 	_, err := NewFromRawBytes(
 		bytes.NewReader(append(rawPacket, 0x00)), false,
 	)
+	require.ErrorIs(t, err, ErrInvalidPsbtFormat)
+}
+
+// TestParsesWitnessUtxoTxOutStrictly verifies that WitnessUtxo values are
+// parsed as exact transaction outputs.
+func TestParsesWitnessUtxoTxOutStrictly(t *testing.T) {
+	pkScript := bytes.Repeat([]byte{0x51}, 253)
+	txOutBytes := serializeTxOutForStrictness(t, &wire.TxOut{
+		Value:    1234,
+		PkScript: pkScript,
+	})
+
+	packet, err := NewFromRawBytes(bytes.NewReader(
+		strictnessPSBTWithWitnessUtxo(t, txOutBytes),
+	), false)
+	require.NoError(t, err)
+	require.Equal(t, pkScript, packet.Inputs[0].WitnessUtxo.PkScript)
+
+	malformedTxOut := append(append([]byte{}, txOutBytes...), 0x00)
+	_, err = NewFromRawBytes(bytes.NewReader(
+		strictnessPSBTWithWitnessUtxo(t, malformedTxOut),
+	), false)
 	require.ErrorIs(t, err, ErrInvalidPsbtFormat)
 }

--- a/psbt/strict_tx_values_test.go
+++ b/psbt/strict_tx_values_test.go
@@ -1,0 +1,117 @@
+package psbt
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/btcsuite/btcd/wire/v2"
+	"github.com/stretchr/testify/require"
+)
+
+// strictnessTxPair returns a minimal unsigned transaction and the previous
+// transaction provided as its non-witness UTXO.
+func strictnessTxPair(t *testing.T) (*wire.MsgTx, *wire.MsgTx) {
+	t.Helper()
+
+	prevTx := wire.NewMsgTx(2)
+	prevTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{Index: wire.MaxPrevOutIndex},
+		Sequence:         wire.MaxTxInSequenceNum,
+	})
+	prevTx.AddTxOut(&wire.TxOut{
+		Value:    12345,
+		PkScript: []byte{0x51},
+	})
+
+	unsignedTx := wire.NewMsgTx(2)
+	unsignedTx.AddTxIn(&wire.TxIn{
+		PreviousOutPoint: wire.OutPoint{
+			Hash:  prevTx.TxHash(),
+			Index: 0,
+		},
+		Sequence: wire.MaxTxInSequenceNum,
+	})
+	unsignedTx.AddTxOut(&wire.TxOut{
+		Value:    1000,
+		PkScript: []byte{0x51},
+	})
+
+	return unsignedTx, prevTx
+}
+
+// serializeTxForStrictness serializes tx in the PSBT form required by the
+// field under test.
+func serializeTxForStrictness(t *testing.T, tx *wire.MsgTx,
+	noWitness bool) []byte {
+
+	t.Helper()
+
+	var buf bytes.Buffer
+	var err error
+	if noWitness {
+		err = tx.SerializeNoWitness(&buf)
+	} else {
+		err = tx.Serialize(&buf)
+	}
+	require.NoError(t, err)
+
+	return buf.Bytes()
+}
+
+// strictnessPSBT builds a minimal PSBT using the supplied transaction-valued
+// fields verbatim.
+func strictnessPSBT(t *testing.T, unsignedTx,
+	nonWitnessUtxo []byte) []byte {
+
+	t.Helper()
+
+	var buf bytes.Buffer
+	_, err := buf.Write(psbtMagic[:])
+	require.NoError(t, err)
+
+	require.NoError(t, serializeKVPairWithType(
+		&buf, byte(UnsignedTxType), nil, unsignedTx,
+	))
+	require.NoError(t, buf.WriteByte(0x00))
+
+	require.NoError(t, serializeKVPairWithType(
+		&buf, byte(NonWitnessUtxoType), nil, nonWitnessUtxo,
+	))
+	require.NoError(t, buf.WriteByte(0x00))
+	require.NoError(t, buf.WriteByte(0x00))
+
+	return buf.Bytes()
+}
+
+// TestRejectsTrailingDataInTransactionValues verifies that PSBT transaction
+// values must contain exactly one serialized transaction.
+func TestRejectsTrailingDataInTransactionValues(t *testing.T) {
+	unsignedTx, prevTx := strictnessTxPair(t)
+	unsignedTxBytes := serializeTxForStrictness(t, unsignedTx, true)
+	prevTxBytes := serializeTxForStrictness(t, prevTx, false)
+
+	testCases := []struct {
+		name           string
+		unsignedTx     []byte
+		nonWitnessUtxo []byte
+	}{{
+		name:           "global unsigned tx",
+		unsignedTx:     append(unsignedTxBytes, 0x00),
+		nonWitnessUtxo: prevTxBytes,
+	}, {
+		name:           "input non-witness utxo",
+		unsignedTx:     unsignedTxBytes,
+		nonWitnessUtxo: append(prevTxBytes, 0x00),
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := NewFromRawBytes(bytes.NewReader(
+				strictnessPSBT(
+					t, tc.unsignedTx, tc.nonWitnessUtxo,
+				),
+			), false)
+			require.ErrorIs(t, err, ErrInvalidPsbtFormat)
+		})
+	}
+}

--- a/psbt/utils.go
+++ b/psbt/utils.go
@@ -291,6 +291,30 @@ func readTxOut(txout []byte) (*wire.TxOut, error) {
 	return wire.NewTxOut(int64(valueSer), scriptPubKey), nil
 }
 
+// readTransaction parses a transaction value and requires the full value to be
+// consumed. PSBT transaction-valued fields contain exactly one network
+// serialized transaction, not a transaction prefix with arbitrary trailing data.
+func readTransaction(txBytes []byte, noWitness bool) (*wire.MsgTx, error) {
+	tx := wire.NewMsgTx(2)
+	reader := bytes.NewReader(txBytes)
+
+	var err error
+	if noWitness {
+		err = tx.DeserializeNoWitness(reader)
+	} else {
+		err = tx.Deserialize(reader)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	if reader.Len() > 0 {
+		return nil, ErrInvalidPsbtFormat
+	}
+
+	return tx, nil
+}
+
 // SumUtxoInputValues tries to extract the sum of all inputs specified in the
 // UTXO fields of the PSBT. An error is returned if an input is specified that
 // does not contain any UTXO information.

--- a/psbt/utils.go
+++ b/psbt/utils.go
@@ -6,7 +6,6 @@ package psbt
 
 import (
 	"bytes"
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
@@ -278,17 +277,20 @@ func getKey(r io.Reader) (int, []byte, error) {
 	return int(keyType), keyData, nil
 }
 
-// readTxOut is a limited version of wire.ReadTxOut, because the latter is not
-// exported.
+// readTxOut parses a transaction output value and requires the full value to
+// be consumed.
 func readTxOut(txout []byte) (*wire.TxOut, error) {
-	if len(txout) < 10 {
+	txOut := &wire.TxOut{}
+	reader := bytes.NewReader(txout)
+
+	if err := wire.ReadTxOut(reader, 0, 0, txOut); err != nil {
+		return nil, err
+	}
+	if reader.Len() > 0 {
 		return nil, ErrInvalidPsbtFormat
 	}
 
-	valueSer := binary.LittleEndian.Uint64(txout[:8])
-	scriptPubKey := txout[9:]
-
-	return wire.NewTxOut(int64(valueSer), scriptPubKey), nil
+	return txOut, nil
 }
 
 // readTransaction parses a transaction value and requires the full value to be


### PR DESCRIPTION
## Summary

While parsing the global unsigned transaction of a PSBT, btcd reads it from a reader over the value bytes but never verifies that the transaction consumed the **entire** value. A value whose length prefix (`<valuelen>`) declares more bytes than the transaction actually occupies is silently accepted.

This diverges from Bitcoin Core, which enforces that the deserialized data exactly matches the stated length in `UnserializeFromVector`:

```cpp
if (remaining_after + expected_size != remaining_before) {
    throw std::ios_base::failure("Size of value was not the stated size");
}
```

This was originally surfaced by differential fuzzing between Bitcoin Core and btcd (#2424): btcd parsed a PSBT that Core rejected.

## Fix

After decoding the unsigned transaction, assert that the value reader has no bytes left; otherwise return `ErrInvalidPsbtFormat`. The ldflags-free path is unchanged — well-formed PSBTs are unaffected. This also avoids the wasted allocations and trie lookups a malicious peer could trigger with oversized values.

```diff
-	err = msgTx.DeserializeNoWitness(bytes.NewReader(value))
-	if err != nil {
+	txReader := bytes.NewReader(value)
+	err = msgTx.DeserializeNoWitness(txReader)
+	if err != nil {
 		return nil, err
 	}
+	if txReader.Len() != 0 {
+		return nil, ErrInvalidPsbtFormat
+	}
```

## Testing

Added `TestNewFromRawBytesTrailingTxBytes`, which:
1. Builds a minimal valid PSBT (single input/output) and confirms it parses cleanly (so the error is attributable to the trailing byte alone).
2. Injects one trailing byte into the global unsigned-tx value and grows the length prefix to cover it.
3. Asserts `NewFromRawBytes` now returns `ErrInvalidPsbtFormat`.

```
$ go test ./psbt/
ok  	github.com/btcsuite/btcd/psbt/v2
```

`gofmt`, `go vet ./psbt/...` clean; full `psbt` package suite passes. Tested on go1.26.4.

Closes #2424