### PR TITLE
btcutil: reject out-of-range private keys in DecodeWIF

### DIFF
--- a/btcutil/wif.go
+++ b/btcutil/wif.go
@@ -127,6 +127,7 @@ func DecodeWIF(wif string) (*WIF, error) {
 	// the one actually encoded in the WIF (or the all-zero key) without
 	// reporting an error.
 	var keyScalar btcec.ModNScalar
+	defer keyScalar.Zero()
 	if overflow := keyScalar.SetByteSlice(privKeyBytes); overflow ||
 		keyScalar.IsZero() {
 

--- a/btcutil/wif.go
+++ b/btcutil/wif.go
@@ -118,6 +118,21 @@ func DecodeWIF(wif string) (*WIF, error) {
 
 	netID := decoded[0]
 	privKeyBytes := decoded[1 : 1+btcec.PrivKeyBytesLen]
+
+	// Ensure the private key is within the valid range for a secp256k1
+	// private key, that is [1, N-1].  Without this check, a WIF encoding a
+	// key of zero or one greater than or equal to the group order N is
+	// silently accepted: btcec.PrivKeyFromBytes reduces the scalar modulo
+	// N, so DecodeWIF would otherwise return a private key that differs from
+	// the one actually encoded in the WIF (or the all-zero key) without
+	// reporting an error.
+	var keyScalar btcec.ModNScalar
+	if overflow := keyScalar.SetByteSlice(privKeyBytes); overflow ||
+		keyScalar.IsZero() {
+
+		return nil, ErrMalformedPrivateKey
+	}
+
 	privKey, _ := btcec.PrivKeyFromBytes(privKeyBytes)
 	return &WIF{privKey, compress, netID}, nil
 }

--- a/btcutil/wif_test.go
+++ b/btcutil/wif_test.go
@@ -122,6 +122,30 @@ func TestEncodeDecodeWIF(t *testing.T) {
 			wif:  "5HueCGU8rMjxEXxiPuD5BDku4MkFqeZyd4dZ1jvhTVqvbTLvyTj",
 			err:  address.ErrChecksumMismatch,
 		},
+		{
+			// A WIF encoding a private key of zero, which is
+			// outside the valid range [1, N-1] for a secp256k1
+			// private key.
+			name: "decodeZeroPrivKeyWif",
+			wif:  "5HpHagT65TZzG1PH3CSu63k8DbpvD8s5ip4nEB3kEsreAbuatmU",
+			err:  ErrMalformedPrivateKey,
+		},
+		{
+			// A WIF encoding a private key equal to the group order
+			// N, which is outside the valid range [1, N-1].
+			name: "decodeOrderNPrivKeyWif",
+			wif:  "5Km2kuu7vtFDPpxywn4u3NLpbr5jKpTB3jsuDU2KYEqetwr388P",
+			err:  ErrMalformedPrivateKey,
+		},
+		{
+			// A WIF encoding a private key of N+5, which is outside
+			// the valid range [1, N-1].  Before validation was
+			// added, this was silently reduced modulo N and decoded
+			// to a different private key (5) without any error.
+			name: "decodeAboveOrderNPrivKeyWif",
+			wif:  "5Km2kuu7vtFDPpxywn4u3NLpbr5jKpTB3jsuDU2KYEqeuVhzTbv",
+			err:  ErrMalformedPrivateKey,
+		},
 	}
 
 	for _, invalidCase := range invalidDecodeCases {


### PR DESCRIPTION
@
### Problem

`DecodeWIF` never validates that the decoded private key falls within the valid range `[1, N-1]` for a secp256k1 key. The raw 32 bytes are passed straight to `btcec.PrivKeyFromBytes`, whose returned error is discarded (`privKey, _ := ...`). `PrivKeyFromBytes` reduces the scalar modulo the group order `N` and clamps to zero, so out-of-range keys are accepted silently.

### Impact (via the public API)

WIFs built with a correct checksum but an out-of-range private key are accepted by `DecodeWIF`:

| key encoded in the WIF | current behavior |
|---|---|
| `priv = 0`            | accepted, returns the zero key (point at infinity) |
| `priv = N`            | accepted, returns the zero key |
| `priv = N + 5`        | accepted, returns key **5** — silently a *different* key than the one encoded |

The `N + 5` case is the worst: a caller importing such a WIF gets a valid-looking keypair that does not correspond to the encoded key, with no error returned. `DecodeWIF` is the public key-import entry point.

For consistency, `hdkeychain.NewKeyFromString` in this same `btcutil` module already rejects out-of-range keys (`ErrUnusableSeed`).

### Fix

Validate the scalar before constructing the key, using a constant-time `btcec.ModNScalar`: `SetByteSlice` reports `overflow` when the value is `>= N`, and `IsZero()` covers the zero key. Out-of-range keys now return the existing `ErrMalformedPrivateKey`.

### Test

Added `zero`, `order_N`, and `N+5` cases to `TestEncodeDecodeWIF`. Verified red-before / green-after by stashing the fix (3 FAIL without it, all PASS with it). The two existing valid-WIF round-trip cases are unaffected.

### Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` (whole `btcutil` module) — ok
- `gofmt -l` on touched files — clean
@