### PR TITLE
netsync: require block-serving services on regtest/simnet sync peers

### DIFF
--- a/netsync/manager.go
+++ b/netsync/manager.go
@@ -360,38 +360,13 @@ func (sm *SyncManager) startSync() {
 // isSyncCandidate returns whether or not the peer is a candidate to consider
 // syncing from.
 func (sm *SyncManager) isSyncCandidate(peer *peerpkg.Peer) bool {
-	// Typically a peer is not a candidate for sync if it's not a full node,
-	// however regression test is special in that the regression tool is
-	// not a full node and still needs to be considered a sync candidate.
-	switch sm.chainParams.Name {
-	case chaincfg.RegressionNetParams.Name, chaincfg.SimNetParams.Name:
-		// In regtest/simnet mode, any peer is a valid sync candidate
-		// regardless of its address or service flags. This allows
-		// syncing from peers on non-localhost networks such as Docker
-		// bridge networks.
-		return true
-	}
-
-	// If the segwit soft-fork package has activated, then the peer must
-	// also be upgraded.
-	segwitActive, err := sm.chain.IsDeploymentActive(
-		chaincfg.DeploymentSegwit,
-	)
-	if err != nil {
-		log.Errorf("Unable to query for segwit soft-fork state: %v",
-			err)
-	}
-
-	if segwitActive && !peer.IsWitnessEnabled() {
-		return false
-	}
-
 	var (
 		nodeServices = peer.Services()
 		fullNode     = nodeServices.HasFlag(wire.SFNodeNetwork)
 		prunedNode   = nodeServices.HasFlag(wire.SFNodeNetworkLimited)
 	)
 
+	// We check the node's ability to serve blocks first.
 	switch {
 	case fullNode:
 		// Node is a sync candidate if it has all the blocks.
@@ -415,6 +390,29 @@ func (sm *SyncManager) isSyncCandidate(peer *peerpkg.Peer) bool {
 	default:
 		// If the peer isn't an archival node, and it's not signaling
 		// NODE_NETWORK_LIMITED, we can't sync off of this node.
+		return false
+	}
+
+	// We can skip the deployment requirement for local test networks.
+	switch sm.chainParams.Name {
+	case chaincfg.RegressionNetParams.Name, chaincfg.SimNetParams.Name:
+		// Being able to serve blocks in the range we need is the only
+		// requirement for regtest and simnet. Any light clients such as
+		// Neutrino would fail above already.
+		return true
+	}
+
+	// If the segwit soft-fork package has activated, then the peer must
+	// also be upgraded.
+	segwitActive, err := sm.chain.IsDeploymentActive(
+		chaincfg.DeploymentSegwit,
+	)
+	if err != nil {
+		log.Errorf("Unable to query for segwit soft-fork state: %v",
+			err)
+	}
+
+	if segwitActive && !peer.IsWitnessEnabled() {
 		return false
 	}
 

--- a/netsync/manager_test.go
+++ b/netsync/manager_test.go
@@ -1220,9 +1220,8 @@ func TestStartSyncChainCurrent(t *testing.T) {
 		"ibdMode should not be activated when chain is already current")
 }
 
-// TestIsSyncCandidateRegtest verifies that isSyncCandidate accepts any peer
-// on regtest regardless of address, including non-localhost Docker bridge
-// addresses.
+// TestIsSyncCandidateRegtest verifies that isSyncCandidate accepts peers
+// on regtest and simnet based on their service flags.
 func TestIsSyncCandidateRegtest(t *testing.T) {
 	t.Parallel()
 
@@ -1231,29 +1230,41 @@ func TestIsSyncCandidateRegtest(t *testing.T) {
 	defer tearDown()
 
 	tests := []struct {
-		name string
-		addr string
-		want bool
+		name      string
+		flags     wire.ServiceFlag
+		lastBlock int32
+		want      bool
 	}{
 		{
-			name: "localhost",
-			addr: "127.0.0.1:18444",
-			want: true,
+			name:  "just node network",
+			flags: wire.SFNodeNetwork,
+			want:  true,
 		},
 		{
-			name: "docker bridge ip",
-			addr: "172.18.0.2:18444",
-			want: true,
+			name:  "just limited network",
+			flags: wire.SFNodeNetworkLimited,
+			want:  true,
 		},
 		{
-			name: "remote ip",
-			addr: "93.184.216.34:18444",
-			want: true,
+			name:      "limited network with block ahead",
+			flags:     wire.SFNodeNetworkLimited,
+			lastBlock: wire.NodeNetworkLimitedBlockThreshold + 1,
+			want:      false,
 		},
 		{
-			name: "ipv6 loopback",
-			addr: "[::1]:18444",
-			want: true,
+			name:  "node network and limited node network",
+			flags: wire.SFNodeNetwork | wire.SFNodeNetworkLimited,
+			want:  true,
+		},
+		{
+			name:  "no flags",
+			flags: 0,
+			want:  false,
+		},
+		{
+			name:  "different flag",
+			flags: wire.SFNodeBloom,
+			want:  false,
 		},
 	}
 
@@ -1261,7 +1272,9 @@ func TestIsSyncCandidateRegtest(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			p := peer.NewInboundPeer(&peer.Config{
 				ChainParams: sm.chainParams,
+				Services:    tc.flags,
 			})
+			p.UpdateLastBlockHeight(tc.lastBlock)
 
 			got := sm.isSyncCandidate(p)
 			require.Equal(t, tc.want, got)


### PR DESCRIPTION

## Change Description

Fixes a sync livelock on regtest/simnet introduced by #2487
(26124d275, `netsync: allow sync with non-localhost peers on
regtest/simnet`).

That commit's goal was to drop the localhost-only *address* restriction
so nodes on Docker bridge networks (e.g. `172.18.0.x`) can be used as
sync peers. However, the rewritten check returns `true` unconditionally
for regtest and simnet, so the *service-flag* requirement was dropped as
well — any connected peer became a valid sync candidate, including light
clients.

### The livelock

A light client such as neutrino advertises a recent best height in its
version message, but signals neither `SFNodeNetwork` nor
`SFNodeNetworkLimited` and cannot serve `getheaders`/`getblocks`. When a
simnet/regtest node has a light client connected:

1. `startSync` elects the light client as the sync peer (it advertises a
   height above our tip), and the header/block download stalls because
   the peer never responds.
2. After the stall timeout (~90s) the sync manager disconnects it.
3. The light client's persistent connection logic reconnects, and the
   light client is elected again — repeat indefinitely.

The damage isn't limited to the stalled download: while a sync peer is
set and its advertised height is above our tip, `sm.current()` returns
false, so `handleInvMsg` also discards block announcements from the
*other* (full-node) peers. The node can therefore neither pull from the
light client nor accept pushes from honest peers, and never syncs.

Log signature of the livelock (here `neutrino:0.17.1` is the light
client being elected over and over):

```
16:26:06 [INF] SYNC: Downloading headers for blocks 1 to 1225 from peer 127.0.0.1:36004
16:27:36 [INF] SYNC: Lost peer 127.0.0.1:36004 (inbound)
16:27:41 [INF] SYNC: Downloading headers for blocks 1 to 1225 from peer 127.0.0.1:60982
16:29:11 [INF] SYNC: Lost peer 127.0.0.1:60982 (inbound)
16:29:16 [INF] SYNC: Downloading headers for blocks 1 to 1225 from peer 127.0.0.1:56826
...
```

This surfaced in lightninglabs/neutrino's sync tests
(`TestNeutrinoSyncWithoutHeadersImport` and friends), which spin up
several simnet btcd nodes via `rpctest` while a neutrino `ChainService`
is connected to all of them: `rpctest.JoinNodes` never converges and the
test suite hits its 10 minute timeout.

### The fix

Keep accepting any peer *address* on regtest/simnet (the intent of
#2487), but require the peer to signal `SFNodeNetwork` or
`SFNodeNetworkLimited`, the same block-serving capability expected on
every other network. The further mainnet-only refinements (segwit
upgrade check, pruned-peer depth window) remain skipped on test
networks, matching the pre-#2487 behavior.