### PR TITLE
rpc: reject trailing bytes in decoderawtransaction

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -792,11 +792,24 @@ func handleDecodeRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan 
 		return nil, rpcDecodeHexError(hexStr)
 	}
 	var mtx wire.MsgTx
-	err = mtx.Deserialize(bytes.NewReader(serializedTx))
+	txReader := bytes.NewReader(serializedTx)
+	err = mtx.Deserialize(txReader)
 	if err != nil {
 		return nil, &btcjson.RPCError{
 			Code:    btcjson.ErrRPCDeserialization,
 			Message: "TX decode failed: " + err.Error(),
+		}
+	}
+
+	// Ensure the entire input was consumed during deserialization. Any
+	// trailing bytes mean the input is not a valid serialized transaction,
+	// so reject it to match bitcoind's behavior instead of silently
+	// discarding the extra data.
+	if txReader.Len() != 0 {
+		return nil, &btcjson.RPCError{
+			Code: btcjson.ErrRPCDeserialization,
+			Message: "TX decode failed: transaction has " +
+				"unexpected trailing bytes",
 		}
 	}
 

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -67,6 +67,36 @@ func TestHandleTestMempoolAcceptFailDecode(t *testing.T) {
 	}
 }
 
+// TestHandleDecodeRawTransactionTrailingBytes checks that
+// decoderawtransaction rejects an input that has trailing bytes left over
+// after a transaction has been fully deserialized, matching bitcoind's
+// behavior.
+func TestHandleDecodeRawTransactionTrailingBytes(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+
+	// Create a testing server.
+	s := &rpcServer{}
+
+	// txHex1 is a valid, fully-formed transaction. Appending extra bytes
+	// to it must cause the decode to fail since the whole input is no
+	// longer consumed by deserialization.
+	hexTxWithTrailingBytes := txHex1 + "00"
+
+	cmd := btcjson.NewDecodeRawTransactionCmd(hexTxWithTrailingBytes)
+
+	closeChan := make(chan struct{})
+	result, err := handleDecodeRawTransaction(s, cmd, closeChan)
+
+	// A deserialization error should be returned and no result produced.
+	require.Error(err)
+	rpcErr, ok := err.(*btcjson.RPCError)
+	require.True(ok)
+	require.Equal(btcjson.ErrRPCDeserialization, rpcErr.Code)
+	require.Nil(result)
+}
+
 var (
 	// TODO(yy): make a `btctest` package and move these testing txns there
 	// so they be used in other tests.


### PR DESCRIPTION
### Summary

`handleDecodeRawTransaction` deserialized the supplied hex into a `wire.MsgTx` but never checked that the entire input was consumed. `MsgTx.Deserialize` reads exactly the bytes that make up a transaction and stops, so any extra bytes appended after a fully-formed transaction were silently discarded and the RPC still returned a successful decode result.

This diverges from bitcoind, which rejects such input with a deserialization error.

### Root cause

The handler passed the raw bytes to `Deserialize` via a `*bytes.Reader` and inspected only the returned error, ignoring whether unread bytes remained in the reader.

### Fix

After a successful `Deserialize`, check `txReader.Len() != 0`. If any bytes remain, the input is not a valid serialized transaction and an `ErrRPCDeserialization` error is returned, matching Core's behavior.

### Testing

Added `TestHandleDecodeRawTransactionTrailingBytes`, which appends a spurious byte to an otherwise valid transaction and asserts the handler now returns `ErrRPCDeserialization`. Before the fix the trailing byte was silently dropped (the handler continued past deserialization); after the fix it is rejected.

Verified locally: `go build ./...`, `go test .`, `go vet .`, and `gofmt` are all clean.

### Repro from the issue

```
decoderawtransaction "0a9a9e01010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010100000000010001010101a09a"
```

This decoded successfully on btcd while Bitcoin Core errors out; with this change btcd now rejects the trailing bytes.

Closes #2195