### PR TITLE
rpcclient: add typed SubmitPackage method

### DIFF
--- a/rpcclient/backend_version.go
+++ b/rpcclient/backend_version.go
@@ -19,6 +19,10 @@ type BackendVersion interface {
 	// SupportGetTxSpendingPrevOut returns true if the backend supports the
 	// gettxspendingprevout RPC.
 	SupportGetTxSpendingPrevOut() bool
+
+	// SupportSubmitPackage returns true if the backend supports the
+	// submitpackage RPC.
+	SupportSubmitPackage() bool
 }
 
 // BitcoindVersion represents the version of the bitcoind the client is
@@ -85,6 +89,15 @@ func (b BitcoindVersion) SupportTestMempoolAccept() bool {
 // SupportGetTxSpendingPrevOut returns true if bitcoind version is 24.0.0 or
 // above.
 func (b BitcoindVersion) SupportGetTxSpendingPrevOut() bool {
+	return b > BitcoindPre24
+}
+
+// SupportSubmitPackage returns true if bitcoind version is 24.0.0 or above,
+// the release in which the submitpackage RPC was introduced.
+//
+// NOTE: the optional maxfeerate/maxburnamount arguments were only added in
+// v28; this predicate only gates the call itself, not those arguments.
+func (b BitcoindVersion) SupportSubmitPackage() bool {
 	return b > BitcoindPre24
 }
 
@@ -185,6 +198,11 @@ func (b BtcdVersion) SupportTestMempoolAccept() bool {
 // SupportGetTxSpendingPrevOut returns true if btcd version is 24.1.0 or above.
 func (b BtcdVersion) SupportGetTxSpendingPrevOut() bool {
 	return b > BtcdPre2401
+}
+
+// SupportSubmitPackage returns false: btcd has no submitpackage RPC handler.
+func (b BtcdVersion) SupportSubmitPackage() bool {
+	return false
 }
 
 // Compile-time checks to ensure that BtcdVersion satisfy the BackendVersion

--- a/rpcclient/rawtransactions.go
+++ b/rpcclient/rawtransactions.go
@@ -1015,6 +1015,110 @@ func (c *Client) TestMempoolAccept(txns []*wire.MsgTx,
 	return c.TestMempoolAcceptAsync(txns, maxFeeRate).Receive()
 }
 
+// FutureSubmitPackageResult is a future promise to deliver the result of a
+// SubmitPackage RPC invocation (or an applicable error).
+type FutureSubmitPackageResult chan *Response
+
+// Receive waits for the Response promised by the future and returns the result
+// of submitting the package.
+func (r FutureSubmitPackageResult) Receive() (*btcjson.SubmitPackageResult,
+	error) {
+
+	response, err := ReceiveFuture(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// btcjson.SubmitPackageResult implements a custom UnmarshalJSON that
+	// maps the raw submitpackage response into higher-level types.
+	var result btcjson.SubmitPackageResult
+	if err := json.Unmarshal(response, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
+// maxPackageTxns is the maximum number of transactions a single submitpackage
+// call may contain. It mirrors bitcoind's MAX_PACKAGE_COUNT (see
+// src/policy/packages.h), which caps a package at 25 transactions.
+const maxPackageTxns = 25
+
+// SubmitPackageAsync returns an instance of a type that can be used to get the
+// result of the RPC at some future time by invoking the Receive function on
+// the returned instance.
+//
+// See SubmitPackage for the blocking version and more details.
+func (c *Client) SubmitPackageAsync(txns []*wire.MsgTx,
+	maxFeeRate, maxBurnAmount *float64) FutureSubmitPackageResult {
+
+	// Gate on the backend version so an unsupported backend (btcd, or
+	// Bitcoin Core before v24) returns a typed ErrBackendVersion rather
+	// than a raw method-not-found error the caller would have to
+	// string-match. This mirrors TestMempoolAccept/GetTxSpendingPrevOut.
+	version, err := c.BackendVersion()
+	if err != nil {
+		return newFutureError(err)
+	}
+
+	if !version.SupportSubmitPackage() {
+		err := fmt.Errorf("%w: %v", ErrBackendVersion, version)
+
+		return newFutureError(err)
+	}
+
+	// A package must contain at least one transaction (the child) and at
+	// most maxPackageTxns.
+	if len(txns) == 0 {
+		err := fmt.Errorf("%w: no transactions provided",
+			ErrInvalidParam)
+
+		return newFutureError(err)
+	}
+
+	if len(txns) > maxPackageTxns {
+		err := fmt.Errorf("%w: too many transactions provided",
+			ErrInvalidParam)
+
+		return newFutureError(err)
+	}
+
+	// Serialize each transaction to a hex string, preserving the
+	// topological order (parents first, child last) the caller provides.
+	rawTxns := make([]string, 0, len(txns))
+	for _, tx := range txns {
+		buf := bytes.NewBuffer(make([]byte, 0, tx.SerializeSize()))
+		if err := tx.Serialize(buf); err != nil {
+			err = fmt.Errorf("%w: %v", ErrInvalidParam, err)
+
+			return newFutureError(err)
+		}
+
+		rawTxns = append(rawTxns, hex.EncodeToString(buf.Bytes()))
+	}
+
+	cmd := btcjson.NewJsonSubmitPackageCmd(
+		rawTxns, maxFeeRate, maxBurnAmount,
+	)
+
+	return c.SendCmd(cmd)
+}
+
+// SubmitPackage submits a package of related, topologically-sorted
+// transactions (unconfirmed parents first, child last) to the backend's
+// mempool for atomic validation and acceptance via the submitpackage RPC. It
+// lets a zero-fee v3/TRUC parent be accepted via its fee-paying CPFP child,
+// which a standalone broadcast would reject.
+//
+// maxFeeRate (BTC/kvB) and maxBurnAmount (BTC) are optional limits; a nil
+// value uses the backend's RPC default.
+func (c *Client) SubmitPackage(txns []*wire.MsgTx,
+	maxFeeRate, maxBurnAmount *float64) (*btcjson.SubmitPackageResult,
+	error) {
+
+	return c.SubmitPackageAsync(txns, maxFeeRate, maxBurnAmount).Receive()
+}
+
 // FutureGetTxSpendingPrevOut is a future promise to deliver the result of a
 // GetTxSpendingPrevOut RPC invocation (or an applicable error).
 type FutureGetTxSpendingPrevOut chan *Response


### PR DESCRIPTION
## Summary

Adds a typed `SubmitPackage` to `rpcclient`, wrapping the `submitpackage` RPC the same way `TestMempoolAccept` wraps `testmempoolaccept`.

The `btcjson` `submitpackage` command + result types already exist; this adds the client-side method so callers don't have to drop down to `RawRequest`:

- `FutureSubmitPackageResult` + `Receive()` — decodes the response into `btcjson.SubmitPackageResult` (which already maps the raw fields to higher-level types via its `UnmarshalJSON`).
- `SubmitPackageAsync(txns, maxFeeRate, maxBurnAmount)` — serializes the topologically-sorted package (parents first, child last) to hex and issues the command.
- `SubmitPackage(...)` — the blocking wrapper.

This keeps the clean layering where `rpcclient` owns the multi-backend RPCs. `submitpackage` is a Bitcoin Core RPC (v24+); btcd has no server handler for it, so this is a client-only addition.

## Test plan

`go build ./...`, `go vet ./rpcclient/...`, `gofmt` clean. The method mirrors the existing `TestMempoolAccept` plumbing; it's exercised end-to-end by a downstream `btcwallet` change that relays v3/TRUC CPFP packages through it.