### PR TITLE
version: bump to v0.26.0-beta for final release

### DIFF
--- a/version.go
+++ b/version.go
@@ -22,7 +22,7 @@ const (
 
 	// appPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.
-	appPreRelease = "beta.rc1"
+	appPreRelease = "beta"
 )
 
 // appBuild is defined as a variable so it can be overridden during the build


### PR DESCRIPTION
In this PR, we drop the `rc1` pre-release suffix, bumping the version from
`v0.26.0-beta.rc1` to `v0.26.0-beta` for the final release.