### PR TITLE
rpc: reject trailing bytes in sendrawtransaction

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -3442,11 +3442,24 @@ func handleSendRawTransaction(s *rpcServer, cmd interface{}, closeChan <-chan st
 		return nil, rpcDecodeHexError(hexStr)
 	}
 	var msgTx wire.MsgTx
-	err = msgTx.Deserialize(bytes.NewReader(serializedTx))
+	txReader := bytes.NewReader(serializedTx)
+	err = msgTx.Deserialize(txReader)
 	if err != nil {
 		return nil, &btcjson.RPCError{
 			Code:    btcjson.ErrRPCDeserialization,
 			Message: "TX decode failed: " + err.Error(),
+		}
+	}
+
+	// Ensure the entire input was consumed during deserialization. Any
+	// trailing bytes mean the input is not a valid serialized transaction,
+	// so reject it to match bitcoind's behavior instead of silently
+	// discarding the extra data and relaying the transaction.
+	if txReader.Len() != 0 {
+		return nil, &btcjson.RPCError{
+			Code: btcjson.ErrRPCDeserialization,
+			Message: "TX decode failed: transaction has " +
+				"unexpected trailing bytes",
 		}
 	}
 

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -67,6 +67,37 @@ func TestHandleTestMempoolAcceptFailDecode(t *testing.T) {
 	}
 }
 
+// TestHandleSendRawTransactionTrailingBytes checks that sendrawtransaction
+// rejects an input that has trailing bytes left over after a transaction has
+// been fully deserialized, matching bitcoind's behavior, instead of silently
+// discarding the extra data and relaying the transaction.
+func TestHandleSendRawTransactionTrailingBytes(t *testing.T) {
+	t.Parallel()
+
+	require := require.New(t)
+
+	// Create a testing server. The trailing-bytes check happens before the
+	// mempool is touched, so a zero-value server is sufficient here.
+	s := &rpcServer{}
+
+	// txHex1 is a valid, fully-formed transaction. Appending extra bytes
+	// to it must cause the decode to fail since the whole input is no
+	// longer consumed by deserialization.
+	hexTxWithTrailingBytes := txHex1 + "00"
+
+	cmd := btcjson.NewSendRawTransactionCmd(hexTxWithTrailingBytes, nil)
+
+	closeChan := make(chan struct{})
+	result, err := handleSendRawTransaction(s, cmd, closeChan)
+
+	// A deserialization error should be returned and no result produced.
+	require.Error(err)
+	rpcErr, ok := err.(*btcjson.RPCError)
+	require.True(ok)
+	require.Equal(btcjson.ErrRPCDeserialization, rpcErr.Code)
+	require.Nil(result)
+}
+
 var (
 	// TODO(yy): make a `btctest` package and move these testing txns there
 	// so they be used in other tests.


### PR DESCRIPTION
### Problem

`handleSendRawTransaction` deserializes the supplied hex into a `wire.MsgTx` but never verifies that the entire input was consumed:

```go
var msgTx wire.MsgTx
err = msgTx.Deserialize(bytes.NewReader(serializedTx))
```

`MsgTx.Deserialize` reads exactly the bytes that make up a transaction and stops, so any extra bytes appended after a fully-formed transaction are silently discarded — and the transaction is still accepted and relayed.

This diverges from `bitcoind`, whose `sendrawtransaction` rejects such input with a deserialization error (`TX decode failed`) instead of broadcasting a transaction parsed from a malformed payload.

### Fix

Read the serialized transaction through a `*bytes.Reader` and, after a successful `Deserialize`, check that no unread bytes remain. If any are left over, return `ErrRPCDeserialization`, matching Core's behavior.

This mirrors the same trailing-bytes hardening applied to `decoderawtransaction` in #2550 and to the PSBT global unsigned tx in #2541 — completing the set across the RPC tx-decode paths.

### Test

`TestHandleSendRawTransactionTrailingBytes` appends a spurious byte to an otherwise valid transaction and asserts the handler now returns `ErrRPCDeserialization`. Verified red before the fix (the handler proceeded past deserialization) and green after.

`go build ./...`, `go vet .`, `gofmt -l` and the RPC handler tests all pass.