### PR TITLE
btcd: fix nonzero exit code on sigint when indexing cfindex

### DIFF
--- a/blockchain/indexers/common.go
+++ b/blockchain/indexers/common.go
@@ -21,9 +21,9 @@ var (
 	// fields for storage in the database.
 	byteOrder = binary.LittleEndian
 
-	// errInterruptRequested indicates that an operation was cancelled due
+	// ErrInterruptRequested indicates that an operation was cancelled due
 	// to a user-requested interrupt.
-	errInterruptRequested = errors.New("interrupt requested")
+	ErrInterruptRequested = errors.New("interrupt requested")
 )
 
 // NeedsInputser provides a generic interface for an indexer to specify the it

--- a/blockchain/indexers/manager.go
+++ b/blockchain/indexers/manager.go
@@ -176,7 +176,7 @@ func (m *Manager) maybeFinishDrops(interrupt <-chan struct{}) error {
 	}
 
 	if interruptRequested(interrupt) {
-		return errInterruptRequested
+		return ErrInterruptRequested
 	}
 
 	// Finish dropping any of the enabled indexes that are already in the
@@ -240,7 +240,7 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 	}
 
 	if interruptRequested(interrupt) {
-		return errInterruptRequested
+		return ErrInterruptRequested
 	}
 
 	// Finish and drops that were previously interrupted.
@@ -350,7 +350,7 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 			}
 
 			if interruptRequested(interrupt) {
-				return errInterruptRequested
+				return ErrInterruptRequested
 			}
 		}
 
@@ -411,7 +411,7 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 		}
 
 		if interruptRequested(interrupt) {
-			return errInterruptRequested
+			return ErrInterruptRequested
 		}
 
 		// Connect the block for all indexes that need it.
@@ -448,7 +448,7 @@ func (m *Manager) Init(chain *blockchain.BlockChain, interrupt <-chan struct{}) 
 		progressLogger.LogBlockHeight(block)
 
 		if interruptRequested(interrupt) {
-			return errInterruptRequested
+			return ErrInterruptRequested
 		}
 	}
 
@@ -657,7 +657,7 @@ func dropIndex(db database.DB, idxKey []byte, idxName string, interrupt <-chan s
 		}
 
 		if interruptRequested(interrupt) {
-			return errInterruptRequested
+			return ErrInterruptRequested
 		}
 
 		// Drop the bucket itself.

--- a/btcd.go
+++ b/btcd.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -265,6 +266,11 @@ func btcdMain(serverChan chan<- *server) error {
 	// Create server and start it.
 	server, err := newServer(cfg.Listeners, cfg.AgentBlacklist,
 		cfg.AgentWhitelist, db, activeNetParams.Params, interrupt)
+	if err != nil && errors.Is(err, indexers.ErrInterruptRequested) {
+		btcdLog.Infof("Unable to start server on %v: %v",
+			cfg.Listeners, err)
+		return nil
+	}
 	if err != nil {
 		// TODO: this logging could do with some beautifying.
 		btcdLog.Errorf("Unable to start server on %v: %v",


### PR DESCRIPTION
## Change Description

Fixes #2530 by returning nil instead of error when `newServer` returns error because an interrupt was received.

## Steps to Test

1. Sync btcd up to some height, then stop the node;
2. Start btcd with --dropcfindex, btcd will stop after dropping the index;
3. Start btcd again and send ctrl+c after seeing a log containing `[INF] INDX: Catching up indexes from height`;
4. The status code should be zero with the patch, and not zero without the patch.

## Pull Request Checklist
### Testing
- [X] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [X] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [X] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [X] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [X] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
