### PR TITLE
btcec: reduce allocations

### DIFF
--- a/btcec/bench_test.go
+++ b/btcec/bench_test.go
@@ -174,21 +174,32 @@ func BenchmarkFieldNormalize(b *testing.B) {
 	}
 }
 
+var PubSink PublicKey
+
 // BenchmarkParseCompressedPubKey benchmarks how long it takes to decompress and
 // validate a compressed public key from a byte array.
 func BenchmarkParseCompressedPubKey(b *testing.B) {
-	rawPk, _ := hex.DecodeString("0234f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6")
+	pubs := "0234f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c6"
+	pubb := hexToBytes(pubs)
+	var pub PublicKey
 
-	var (
-		pk  *PublicKey
-		err error
-	)
-
-	b.ReportAllocs()
-	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
-		pk, err = ParsePubKey(rawPk)
+	for b.Loop() {
+		pub2, _ := ParsePubKey(pubb)
+		pub = *pub2
 	}
-	_ = pk
-	_ = err
+
+	PubSink = pub
+}
+
+func BenchmarkParseUncompressedPubKey(b *testing.B) {
+	pubs := "0434f9460f0e4f08393d192b3c5133a6ba099aa0ad9fd54ebccfacdfa239ff49c60b71ea9bd730fd8923f6d25a7a91e7dd7728a960686cb5a901bb419e0f2ca232"
+	pubb := hexToBytes(pubs)
+	var pub PublicKey
+
+	for b.Loop() {
+		pub2, _ := ParsePubKey(pubb)
+		pub = *pub2
+	}
+
+	PubSink = pub
 }

--- a/btcec/ecdsa/bench_test.go
+++ b/btcec/ecdsa/bench_test.go
@@ -85,21 +85,49 @@ func BenchmarkSigVerify(b *testing.B) {
 	)
 
 	// Double sha256 of []byte{0x01, 0x02, 0x03, 0x04}
-	msgHash := fromHex("8de472e2399610baaa7f84840547cd409434e31f5d3bd71e4d947f283874f9c0")
+	msgHash := fromHex("8de472e2399610baaa7f84840547cd409434e31f5d3bd71e4d947f283874f9c0").Bytes()
 	sig := NewSignature(
 		hexToModNScalar("fef45d2892953aa5bbcdb057b5e98b208f1617a7498af7eb765574e29b5d9c2c"),
 		hexToModNScalar("d47563f52aac6b04b55de236b7c515eb9311757db01e02cff079c3ca6efb063f"),
 	)
 
-	if !sig.Verify(msgHash.Bytes(), pubKey) {
+	if !sig.Verify(msgHash, pubKey) {
 		b.Errorf("Signature failed to verify")
 		return
 	}
 	b.StartTimer()
 
 	for i := 0; i < b.N; i++ {
-		sig.Verify(msgHash.Bytes(), pubKey)
+		sig.Verify(msgHash, pubKey)
 	}
+}
+
+var SigSink Signature
+
+func BenchmarkParseDERSignature(b *testing.B) {
+	sigders := "3045022100fef45d2892953aa5bbcdb057b5e98b208f1617a7498af7eb765574e29b5d9c2c02202b8a9c0ad55394fb4aa21dc9483aea13279d6768ff2a9d6bcf589ac2613b3b02"
+	sigder := hexToBytes(sigders)
+	var sig Signature
+
+	for b.Loop() {
+		sig2, _ := ParseDERSignature(sigder)
+		sig = *sig2
+	}
+
+	SigSink = sig
+}
+
+func BenchmarkParseBERSignature(b *testing.B) {
+	sigders := "3045022100fef45d2892953aa5bbcdb057b5e98b208f1617a7498af7eb765574e29b5d9c2c02202b8a9c0ad55394fb4aa21dc9483aea13279d6768ff2a9d6bcf589ac2613b3b02"
+	sigder := hexToBytes(sigders)
+	var sig Signature
+
+	for b.Loop() {
+		sig2, _ := ParseSignature(sigder)
+		sig = *sig2
+	}
+
+	SigSink = sig
 }
 
 // BenchmarkSign benchmarks how long it takes to sign a message.

--- a/btcec/ecdsa/signature.go
+++ b/btcec/ecdsa/signature.go
@@ -18,8 +18,20 @@ import (
 var (
 	errNegativeValue          = errors.New("value may be interpreted as negative")
 	errExcessivelyPaddedValue = errors.New("value is excessively padded")
-	errHighS                  = errors.New("non-canonical signature: S value not in low-S form")
-	errNoHeaderMagic          = errors.New("malformed signature: no header magic")
+)
+
+// Errors returned by parseSig.
+var (
+	errNegativeR          = errors.New("negative R")
+	errNegativeS          = errors.New("negative S")
+	errExcessivelyPaddedR = errors.New("excessively padded R")
+	errExcessivelyPaddedS = errors.New("excessively padded S")
+	errNoHeaderMagic      = errors.New("malformed signature: no header magic")
+)
+
+// Errors returned by VerifyLowS.
+var (
+	errHighS = errors.New("non-canonical signature: S value not in low-S form")
 )
 
 // Signature is a type representing an ecdsa signature.
@@ -128,9 +140,9 @@ func parseSig(sigStr []byte, der bool) (*Signature, error) {
 	if der {
 		switch err := canonicalPadding(rBytes); err {
 		case errNegativeValue:
-			return nil, errors.New("signature R is negative")
+			return nil, errNegativeR
 		case errExcessivelyPaddedValue:
-			return nil, errors.New("signature R is excessively padded")
+			return nil, errExcessivelyPaddedR
 		}
 	}
 
@@ -175,9 +187,9 @@ func parseSig(sigStr []byte, der bool) (*Signature, error) {
 	if der {
 		switch err := canonicalPadding(sBytes); err {
 		case errNegativeValue:
-			return nil, errors.New("signature S is negative")
+			return nil, errNegativeS
 		case errExcessivelyPaddedValue:
-			return nil, errors.New("signature S is excessively padded")
+			return nil, errExcessivelyPaddedS
 		}
 	}
 

--- a/btcec/ecdsa/signature.go
+++ b/btcec/ecdsa/signature.go
@@ -81,7 +81,7 @@ func canonicalPadding(b []byte) error {
 	}
 }
 
-func parseSig(sigStr []byte, der bool) (*Signature, error) {
+func parseSig(sig *Signature, sigStr []byte, der bool) error {
 	// Originally this code used encoding/asn1 in order to parse the
 	// signature, but a number of problems were found with this approach.
 	// Despite the fact that signatures are stored as DER, the difference
@@ -95,16 +95,16 @@ func parseSig(sigStr []byte, der bool) (*Signature, error) {
 	// The signature must adhere to the minimum and maximum allowed length.
 	totalSigLen := len(sigStr)
 	if totalSigLen < MinSigLen {
-		return nil, errors.New("malformed signature: too short")
+		return errors.New("malformed signature: too short")
 	}
 	if der && totalSigLen > MaxSigLen {
-		return nil, errors.New("malformed signature: too long")
+		return errors.New("malformed signature: too long")
 	}
 
 	// 0x30
 	index := 0
 	if sigStr[index] != 0x30 {
-		return nil, errNoHeaderMagic
+		return errNoHeaderMagic
 	}
 	index++
 	// length of remaining message
@@ -114,15 +114,14 @@ func parseSig(sigStr []byte, der bool) (*Signature, error) {
 	// siglen should be less than the entire message and greater than
 	// the minimal message size.
 	if int(siglen+2) > len(sigStr) || int(siglen+2) < MinSigLen {
-		return nil, errors.New("malformed signature: bad length")
+		return errors.New("malformed signature: bad length")
 	}
 	// trim the slice we're working on so we only look at what matters.
 	sigStr = sigStr[:siglen+2]
 
 	// 0x02
 	if sigStr[index] != 0x02 {
-		return nil,
-			errors.New("malformed signature: no 1st int marker")
+		return errors.New("malformed signature: no 1st int marker")
 	}
 	index++
 
@@ -132,7 +131,7 @@ func parseSig(sigStr []byte, der bool) (*Signature, error) {
 	// hence the -3. We assume that the length must be at least one byte.
 	index++
 	if rLen <= 0 || rLen > len(sigStr)-index-3 {
-		return nil, errors.New("malformed signature: bogus R length")
+		return errors.New("malformed signature: bogus R length")
 	}
 
 	// Then R itself.
@@ -140,9 +139,9 @@ func parseSig(sigStr []byte, der bool) (*Signature, error) {
 	if der {
 		switch err := canonicalPadding(rBytes); err {
 		case errNegativeValue:
-			return nil, errNegativeR
+			return errNegativeR
 		case errExcessivelyPaddedValue:
-			return nil, errExcessivelyPaddedR
+			return errExcessivelyPaddedR
 		}
 	}
 
@@ -157,20 +156,20 @@ func parseSig(sigStr []byte, der bool) (*Signature, error) {
 	var r btcec.ModNScalar
 	if len(rBytes) > 32 {
 		str := "invalid signature: R is larger than 256 bits"
-		return nil, errors.New(str)
+		return errors.New(str)
 	}
 	if overflow := r.SetByteSlice(rBytes); overflow {
 		str := "invalid signature: R >= group order"
-		return nil, errors.New(str)
+		return errors.New(str)
 	}
 	if r.IsZero() {
 		str := "invalid signature: R is 0"
-		return nil, errors.New(str)
+		return errors.New(str)
 	}
 	index += rLen
 	// 0x02. length already checked in previous if.
 	if sigStr[index] != 0x02 {
-		return nil, errors.New("malformed signature: no 2nd int marker")
+		return errors.New("malformed signature: no 2nd int marker")
 	}
 	index++
 
@@ -179,7 +178,7 @@ func parseSig(sigStr []byte, der bool) (*Signature, error) {
 	index++
 	// S should be the rest of the string.
 	if sLen <= 0 || sLen > len(sigStr)-index {
-		return nil, errors.New("malformed signature: bogus S length")
+		return errors.New("malformed signature: bogus S length")
 	}
 
 	// Then S itself.
@@ -187,9 +186,9 @@ func parseSig(sigStr []byte, der bool) (*Signature, error) {
 	if der {
 		switch err := canonicalPadding(sBytes); err {
 		case errNegativeValue:
-			return nil, errNegativeS
+			return errNegativeS
 		case errExcessivelyPaddedValue:
-			return nil, errExcessivelyPaddedS
+			return errExcessivelyPaddedS
 		}
 	}
 
@@ -204,39 +203,65 @@ func parseSig(sigStr []byte, der bool) (*Signature, error) {
 	var s btcec.ModNScalar
 	if len(sBytes) > 32 {
 		str := "invalid signature: S is larger than 256 bits"
-		return nil, errors.New(str)
+		return errors.New(str)
 	}
 	if overflow := s.SetByteSlice(sBytes); overflow {
 		str := "invalid signature: S >= group order"
-		return nil, errors.New(str)
+		return errors.New(str)
 	}
 	if s.IsZero() {
 		str := "invalid signature: S is 0"
-		return nil, errors.New(str)
+		return errors.New(str)
 	}
 	index += sLen
 
 	// sanity check length parsing
 	if index != len(sigStr) {
-		return nil, fmt.Errorf("malformed signature: bad final length %v != %v",
+		return fmt.Errorf("malformed signature: bad final length %v != %v",
 			index, len(sigStr))
 	}
 
-	return NewSignature(&r, &s), nil
+	sig2 := secp_ecdsa.NewSignature(&r, &s)
+	*sig = *sig2
+	return nil
+}
+
+// parseBERSig exists to make ParseSignature eligible to inlining and
+// therefore avoid allocation.
+//
+//go:noinline
+func parseBERSig(sig *Signature, sigb []byte) error {
+	return parseSig(sig, sigb, false)
 }
 
 // ParseSignature parses a signature in BER format for the curve type `curve'
 // into a Signature type, performing some basic sanity checks.  If parsing
 // according to the more strict DER format is needed, use ParseDERSignature.
 func ParseSignature(sigStr []byte) (*Signature, error) {
-	return parseSig(sigStr, false)
+	sig := new(Signature)
+	if err := parseBERSig(sig, sigStr); err != nil {
+		return nil, err
+	}
+	return sig, nil
+}
+
+// parseDERSig exists to make ParseDERSignature eligible to inlining and
+// therefore avoid allocation.
+//
+//go:noinline
+func parseDERSig(sig *Signature, sigb []byte) error {
+	return parseSig(sig, sigb, true)
 }
 
 // ParseDERSignature parses a signature in DER format for the curve type
 // `curve` into a Signature type.  If parsing according to the less strict
 // BER format is needed, use ParseSignature.
 func ParseDERSignature(sigStr []byte) (*Signature, error) {
-	return parseSig(sigStr, true)
+	sig := new(Signature)
+	if err := parseDERSig(sig, sigStr); err != nil {
+		return nil, err
+	}
+	return sig, nil
 }
 
 // SignCompact produces a compact signature of the data in hash with the given
@@ -273,8 +298,8 @@ func Sign(key *btcec.PrivateKey, hash []byte) *Signature {
 // and uses a canonical low-S value. It returns nil if the signature is valid;
 // otherwise it returns the encountered error.
 func VerifyLowS(sigStr []byte) error {
-	sig, err := parseSig(sigStr, true)
-	if err != nil {
+	sig := new(Signature)
+	if err := parseSig(sig, sigStr, true); err != nil {
 		return err
 	}
 	sValue := sig.S()

--- a/btcec/ecdsa/signature_test.go
+++ b/btcec/ecdsa/signature_test.go
@@ -822,6 +822,26 @@ func TestVerifyLowS(t *testing.T) {
 			sig:     hexToBytes("404502200d309104bc47fecb3e23fadbabb26d3495ae1b48c1b14e8886b3f4f1c8ab122f02210085d04c97c30f69063b820a139cf17473d8e89ed587f7fa669e78175f798431fc"),
 			wantErr: errNoHeaderMagic,
 		},
+		{
+			name:    "Excessively padded R",
+			sig:     hexToBytes("30460221000d309104bc47fecb3e23fadbabb26d3495ae1b48c1b14e8886b3f4f1c8ab122f02210085d04c97c30f69063b820a139cf17473d8e89ed587f7fa669e78175f798431fc"),
+			wantErr: errExcessivelyPaddedR,
+		},
+		{
+			name:    "Excessively padded S",
+			sig:     hexToBytes("304602200d309104bc47fecb3e23fadbabb26d3495ae1b48c1b14e8886b3f4f1c8ab122f0222000085d04c97c30f69063b820a139cf17473d8e89ed587f7fa669e78175f798431fc"),
+			wantErr: errExcessivelyPaddedS,
+		},
+		{
+			name:    "Negative R",
+			sig:     hexToBytes("304502208d309104bc47fecb3e23fadbabb26d3495ae1b48c1b14e8886b3f4f1c8ab122f02210085d04c97c30f69063b820a139cf17473d8e89ed587f7fa669e78175f798431fc"),
+			wantErr: errNegativeR,
+		},
+		{
+			name:    "Negative S",
+			sig:     hexToBytes("304402200d309104bc47fecb3e23fadbabb26d3495ae1b48c1b14e8886b3f4f1c8ab122f022085d04c97c30f69063b820a139cf17473d8e89ed587f7fa669e78175f798431fc"),
+			wantErr: errNegativeS,
+		},
 	}
 
 	for _, test := range signatureTests {

--- a/btcec/pubkey.go
+++ b/btcec/pubkey.go
@@ -30,11 +30,26 @@ func IsCompressedPubKey(pubKey []byte) bool {
 		(pubKey[0]&^byte(0x1) == pubkeyCompressed)
 }
 
+// parsePubKey is here because without it ParsePubKey is not inlined, causing
+// allocations to happen.
+func parsePubKey(pub *PublicKey, pubb []byte) error {
+	pub2, err := secp.ParsePubKey(pubb)
+	if err != nil {
+		return err
+	}
+	*pub = *pub2
+	return nil
+}
+
 // ParsePubKey parses a public key for a koblitz curve from a bytestring into a
 // ecdsa.Publickey, verifying that it is valid. It supports compressed,
 // uncompressed and hybrid signature formats.
 func ParsePubKey(pubKeyStr []byte) (*PublicKey, error) {
-	return secp.ParsePubKey(pubKeyStr)
+	pub := new(PublicKey)
+	if err := parsePubKey(pub, pubKeyStr); err != nil {
+		return nil, err
+	}
+	return pub, nil
 }
 
 // PublicKey is an ecdsa.PublicKey with additional functions to

--- a/btcec/schnorr/bench_test.go
+++ b/btcec/schnorr/bench_test.go
@@ -108,6 +108,36 @@ func BenchmarkSigVerify(b *testing.B) {
 	testOk = ok
 }
 
+var PubSink btcec.PublicKey
+
+func BenchmarkParsePubKey(b *testing.B) {
+	pubs := "d2e670a19c6d753d1a6d8b20bd045df8a08fb162cf508956c31268c6d81ffdab"
+	pubb := hexToBytes(pubs)
+	var pub btcec.PublicKey
+
+	for b.Loop() {
+		pub2, _ := ParsePubKey(pubb)
+		pub = *pub2
+	}
+
+	PubSink = pub
+}
+
+var SigSink Signature
+
+func BenchmarkParseSignature(b *testing.B) {
+	sigS := "7289004e8052d8bc317e4f308d20b35c0236a39314fb1a47ff7ca7e79199bb9500fd1a5fb87677119280b73fb7d281e88bddc94ba7fbfd12d06cae944f4f9e5f"
+	sigB := hexToBytes(sigS)
+	var sig Signature
+
+	for b.Loop() {
+		sig2, _ := ParseSignature(sigB)
+		sig = *sig2
+	}
+
+	SigSink = sig
+}
+
 // Used to ensure the compiler doesn't optimize away the benchmark.
 var (
 	testSig *Signature

--- a/btcec/schnorr/pubkey.go
+++ b/btcec/schnorr/pubkey.go
@@ -62,3 +62,9 @@ func SerializePubKey(pub *btcec.PublicKey) []byte {
 	pBytes := pub.SerializeCompressed()
 	return pBytes[1:]
 }
+
+func serializePubKey32(out32 []byte, pub *btcec.PublicKey) {
+	var point secp.JacobianPoint
+	pub.AsJacobian(&point)
+	copy(out32, point.X.Bytes()[:])
+}

--- a/btcec/schnorr/pubkey.go
+++ b/btcec/schnorr/pubkey.go
@@ -17,18 +17,17 @@ const (
 	PubKeyBytesLen = 32
 )
 
-// ParsePubKey parses a public key for a koblitz curve from a bytestring into a
-// btcec.Publickey, verifying that it is valid. It only supports public keys in
-// the BIP-340 32-byte format.
-func ParsePubKey(pubKeyStr []byte) (*btcec.PublicKey, error) {
+// parsePubKey is here because without it ParsePubKey is not inlined, which
+// causes allocations because it returns a pointer to [btcec.PublicKey].
+func parsePubKey(pub *btcec.PublicKey, pubKeyStr []byte) error {
 	if pubKeyStr == nil {
 		err := fmt.Errorf("nil pubkey byte string")
-		return nil, err
+		return err
 	}
 	if len(pubKeyStr) != PubKeyBytesLen {
 		err := fmt.Errorf("bad pubkey byte string size (want %v, have %v)",
 			PubKeyBytesLen, len(pubKeyStr))
-		return nil, err
+		return err
 	}
 
 	// We'll manually prepend the compressed byte so we can re-use the
@@ -37,7 +36,23 @@ func ParsePubKey(pubKeyStr []byte) (*btcec.PublicKey, error) {
 	keyCompressed[0] = secp.PubKeyFormatCompressedEven
 	copy(keyCompressed[1:], pubKeyStr)
 
-	return btcec.ParsePubKey(keyCompressed[:])
+	pub2, err := btcec.ParsePubKey(keyCompressed[:])
+	if err != nil {
+		return err
+	}
+	*pub = *pub2
+	return nil
+}
+
+// ParsePubKey parses a public key for a koblitz curve from a bytestring into a
+// btcec.Publickey, verifying that it is valid. It only supports public keys in
+// the BIP-340 32-byte format.
+func ParsePubKey(pubKeyStr []byte) (*btcec.PublicKey, error) {
+	pub := new(btcec.PublicKey)
+	if err := parsePubKey(pub, pubKeyStr); err != nil {
+		return nil, err
+	}
+	return pub, nil
 }
 
 // SerializePubKey serializes a public key as specified by BIP 340. Public keys

--- a/btcec/schnorr/signature.go
+++ b/btcec/schnorr/signature.go
@@ -166,10 +166,11 @@ func schnorrVerify(sig *Signature, hash []byte, pubKeyBytes []byte) error {
 	// e = int(tagged_hash("BIP0340/challenge", bytes(r) || bytes(P) || M)) mod n.
 	var rBytes [32]byte
 	sig.r.PutBytesUnchecked(rBytes[:])
-	pBytes := SerializePubKey(pubKey)
+	var pBytes [32]byte
+	serializePubKey32(pBytes[:], pubKey)
 
 	commitment := chainhash.TaggedHash(
-		chainhash.TagBIP0340Challenge, rBytes[:], pBytes, hash,
+		chainhash.TagBIP0340Challenge, rBytes[:], pBytes[:], hash,
 	)
 
 	var e btcec.ModNScalar
@@ -226,8 +227,9 @@ func schnorrVerify(sig *Signature, hash []byte, pubKeyBytes []byte) error {
 // Verify returns whether or not the signature is valid for the provided hash
 // and secp256k1 public key.
 func (sig *Signature) Verify(hash []byte, pubKey *btcec.PublicKey) bool {
-	pubkeyBytes := SerializePubKey(pubKey)
-	return schnorrVerify(sig, hash, pubkeyBytes) == nil
+	var pubkeyBytes [32]byte
+	serializePubKey32(pubkeyBytes[:], pubKey)
+	return schnorrVerify(sig, hash, pubkeyBytes[:]) == nil
 }
 
 // zeroArray zeroes the memory of a scalar array.
@@ -304,9 +306,10 @@ func schnorrSign(privKey, nonce *btcec.ModNScalar, pubKey *btcec.PublicKey, hash
 	// Step 12.
 	//
 	// e = tagged_hash("BIP0340/challenge", bytes(R) || bytes(P) || m) mod n
-	pBytes := SerializePubKey(pubKey)
+	var pBytes [32]byte
+	serializePubKey32(pBytes[:], pubKey)
 	commitment := chainhash.TaggedHash(
-		chainhash.TagBIP0340Challenge, R.X.Bytes()[:], pBytes, hash,
+		chainhash.TagBIP0340Challenge, R.X.Bytes()[:], pBytes[:], hash,
 	)
 
 	var e btcec.ModNScalar
@@ -328,7 +331,7 @@ func schnorrSign(privKey, nonce *btcec.ModNScalar, pubKey *btcec.PublicKey, hash
 	//
 	// If Verify(bytes(P), m, sig) fails, abort.
 	if !opts.fastSign {
-		if err := schnorrVerify(sig, hash, pBytes); err != nil {
+		if err := schnorrVerify(sig, hash, pBytes[:]); err != nil {
 			return nil, err
 		}
 	}

--- a/btcec/schnorr/signature.go
+++ b/btcec/schnorr/signature.go
@@ -62,23 +62,20 @@ func (sig Signature) Serialize() []byte {
 	return b[:]
 }
 
-// ParseSignature parses a signature according to the BIP-340 specification and
-// enforces the following additional restrictions specific to secp256k1:
-//
-// - The r component must be in the valid range for secp256k1 field elements
-// - The s component must be in the valid range for secp256k1 scalars
-func ParseSignature(sig []byte) (*Signature, error) {
+// parseSignature exists to make ParseSignature eligible to inlining and
+// therefore avoid allocations.
+func parseSignature(sig *Signature, sigb []byte) error {
 	// The signature must be the correct length.
-	sigLen := len(sig)
+	sigLen := len(sigb)
 	if sigLen < SignatureSize {
 		str := fmt.Sprintf("malformed signature: too short: %d < %d", sigLen,
 			SignatureSize)
-		return nil, signatureError(ecdsa_schnorr.ErrSigTooShort, str)
+		return signatureError(ecdsa_schnorr.ErrSigTooShort, str)
 	}
 	if sigLen > SignatureSize {
 		str := fmt.Sprintf("malformed signature: too long: %d > %d", sigLen,
 			SignatureSize)
-		return nil, signatureError(ecdsa_schnorr.ErrSigTooLong, str)
+		return signatureError(ecdsa_schnorr.ErrSigTooLong, str)
 	}
 
 	// The signature is validly encoded at this point, however, enforce
@@ -86,15 +83,31 @@ func ParseSignature(sig []byte) (*Signature, error) {
 	// the range [0, n-1] since valid Schnorr signatures are required to be in
 	// that range per spec.
 	var r btcec.FieldVal
-	if overflow := r.SetByteSlice(sig[0:32]); overflow {
+	if overflow := r.SetByteSlice(sigb[0:32]); overflow {
 		str := "invalid signature: r >= field prime"
-		return nil, signatureError(ecdsa_schnorr.ErrSigRTooBig, str)
+		return signatureError(ecdsa_schnorr.ErrSigRTooBig, str)
 	}
 	var s btcec.ModNScalar
-	s.SetByteSlice(sig[32:64])
+	s.SetByteSlice(sigb[32:64])
 
-	// Return the signature.
-	return NewSignature(&r, &s), nil
+	// Return the normalized signature.
+	sig.r = r
+	sig.s = s
+	sig.r.Normalize()
+	return nil
+}
+
+// ParseSignature parses a signature according to the BIP-340 specification and
+// enforces the following additional restrictions specific to secp256k1:
+//
+// - The r component must be in the valid range for secp256k1 field elements
+// - The s component must be in the valid range for secp256k1 scalars
+func ParseSignature(sig []byte) (*Signature, error) {
+	s := new(Signature)
+	if err := parseSignature(s, sig); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
 // IsEqual compares this Signature instance to the one passed, returning true

--- a/chainhash/hash.go
+++ b/chainhash/hash.go
@@ -154,10 +154,9 @@ func NewHash(newHash []byte) (*Hash, error) {
 	return &sh, err
 }
 
-// TaggedHash implements the tagged hash scheme described in BIP-340. We use
-// sha-256 to bind a message hash to a specific context using a tag:
-// sha256(sha256(tag) || sha256(tag) || msg).
-func TaggedHash(tag []byte, msgs ...[]byte) *Hash {
+// taggedHash is here to make TaggedHash eligible to inlining and therefore
+// reducing allocations.
+func taggedHash(hash *Hash, tag []byte, msgs ...[]byte) {
 	// Check to see if we've already pre-computed the hash of the tag. If
 	// so then this'll save us an extra sha256 hash.
 	shaTag, ok := precomputedTags[string(tag)]
@@ -174,13 +173,22 @@ func TaggedHash(tag []byte, msgs ...[]byte) *Hash {
 		h.Write(msg)
 	}
 
-	taggedHash := h.Sum(nil)
+	var tagHash [32]byte
+	h.Sum(tagHash[:0])
 
 	// The function can't error out since the above hash is guaranteed to
 	// be 32 bytes.
-	hash, _ := NewHash(taggedHash)
+	hash2, _ := NewHash(tagHash[:])
+	*hash = *hash2
+}
 
-	return hash
+// TaggedHash implements the tagged hash scheme described in BIP-340. We use
+// sha-256 to bind a message hash to a specific context using a tag:
+// sha256(sha256(tag) || sha256(tag) || msg).
+func TaggedHash(tag []byte, msgs ...[]byte) *Hash {
+	var hash Hash
+	taggedHash(&hash, tag, msgs...)
+	return &hash
 }
 
 // NewHashFromStr creates a Hash from a hash string.  The string should be


### PR DESCRIPTION
## Change Description

I've optimized public key parsing, signature parsing and signature verification
for both ECDSA and Schnorr, the following are the improvements in the benchmarks
before and after.

Obs: using the following patches for both benchmarks:

https://github.com/golang/go/pull/79708: big.Int.ModInverse allocation zeroing.
https://github.com/decred/dcrd/pull/3714: Public Key parsing and ModNScalar
modulo inverse allocation zeroing.

To avoid forgetting to update the dependencies in the future, even after approval, I think we should wait for upstream releases of both Go and `dcrec/secp256k1` containing the patches mentioned above, so that when this code is merged, the benchmark report the exact same results in respect of allocation count.

```
goos: linux
goarch: amd64
pkg: github.com/btcsuite/btcd/btcec/v2
cpu: Intel(R) Core(TM) i5-10310U CPU @ 1.70GHz
                          │ /tmp/BeforeOpts │          /tmp/WithAllOpts          │
                          │     sec/op      │   sec/op     vs base               │
ParseCompressedPubKey-8         17.40µ ± 0%   17.33µ ± 0%  -0.35% (p=0.000 n=60)
ParseUncompressedPubKey-8       362.4n ± 1%   327.4n ± 0%  -9.66% (n=60)
geomean                         2.511µ        2.382µ       -5.12%

                          │ /tmp/BeforeOpts │        /tmp/WithAllOpts        │
                          │      B/op       │   B/op     vs base             │
ParseCompressedPubKey-8          80.00 ± 0%   0.00 ± 0%  -100.00% (n=60)
ParseUncompressedPubKey-8        80.00 ± 0%   0.00 ± 0%  -100.00% (n=60)
geomean                          80.00                   ?               ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                          │ /tmp/BeforeOpts │        /tmp/WithAllOpts         │
                          │    allocs/op    │ allocs/op   vs base             │
ParseCompressedPubKey-8          1.000 ± 0%   0.000 ± 0%  -100.00% (n=60)
ParseUncompressedPubKey-8        1.000 ± 0%   0.000 ± 0%  -100.00% (n=60)
geomean                          1.000                    ?               ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

pkg: github.com/btcsuite/btcd/btcec/v2/ecdsa
                    │ /tmp/BeforeOpts │          /tmp/WithAllOpts           │
                    │     sec/op      │   sec/op     vs base                │
SigVerify-8               215.9µ ± 0%   215.9µ ± 0%        ~ (p=0.281 n=60)
ParseDERSignature-8      109.15n ± 1%   76.74n ± 0%  -29.69% (n=60)
ParseBERSignature-8      107.35n ± 1%   75.61n ± 0%  -29.57% (n=60)
geomean                   1.363µ        1.078µ       -20.88%

                    │ /tmp/BeforeOpts │            /tmp/WithAllOpts             │
                    │      B/op       │    B/op     vs base                     │
SigVerify-8              0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=60) ¹
ParseDERSignature-8      64.00 ± 0%      0.00 ± 0%  -100.00% (n=60)
ParseBERSignature-8      64.00 ± 0%      0.00 ± 0%  -100.00% (n=60)
geomean                             ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

                    │ /tmp/BeforeOpts │            /tmp/WithAllOpts             │
                    │    allocs/op    │ allocs/op   vs base                     │
SigVerify-8              0.000 ± 0%     0.000 ± 0%         ~ (p=1.000 n=60) ¹
ParseDERSignature-8      1.000 ± 0%     0.000 ± 0%  -100.00% (n=60)
ParseBERSignature-8      1.000 ± 0%     0.000 ± 0%  -100.00% (n=60)
geomean                             ²               ?                       ² ³
¹ all samples are equal
² summaries must be >0 to compute geomean
³ ratios must be >0 to compute geomean

pkg: github.com/btcsuite/btcd/btcec/v2/schnorr
                 │ /tmp/BeforeOpts │          /tmp/WithAllOpts           │
                 │     sec/op      │   sec/op     vs base                │
SigVerify-8            252.1µ ± 0%   251.7µ ± 0%   -0.17% (p=0.000 n=60)
ParsePubKey-8          17.43µ ± 0%   17.37µ ± 0%   -0.34% (p=0.000 n=60)
ParseSignature-8      129.35n ± 1%   86.78n ± 0%  -32.91% (n=60)
geomean                8.284µ        7.240µ       -12.60%

                 │ /tmp/BeforeOpts │        /tmp/WithAllOpts        │
                 │      B/op       │   B/op     vs base             │
SigVerify-8             240.0 ± 0%    0.0 ± 0%  -100.00% (n=60)
ParsePubKey-8           80.00 ± 0%   0.00 ± 0%  -100.00% (n=60)
ParseSignature-8        80.00 ± 0%   0.00 ± 0%  -100.00% (n=60)
geomean                 115.4                   ?               ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                 │ /tmp/BeforeOpts │        /tmp/WithAllOpts         │
                 │    allocs/op    │ allocs/op   vs base             │
SigVerify-8             5.000 ± 0%   0.000 ± 0%  -100.00% (n=60)
ParsePubKey-8           1.000 ± 0%   0.000 ± 0%  -100.00% (n=60)
ParseSignature-8        1.000 ± 0%   0.000 ± 0%  -100.00% (n=60)
geomean                 1.710                    ?               ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```

In summary:

Schnorr signature parsing time:         ~-33%
ECDSA signature parsing time:           ~-30%
Uncompressed public key parsing time:   ~-9.5%

But all the procedures in the benchmarks above are not doing allocations
anymore, reducing the frequency between garbage collection cycles that must scan
all the reachable heap (that is considerably large in production).

Now we have more CPU available to perform block verification.

## Steps to Test
Steps for reviewers to follow to test the change.

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
