### PR TITLE
btcec/schnorr: reject s >= group order in ParseSignature

### DIFF
--- a/btcec/schnorr/signature.go
+++ b/btcec/schnorr/signature.go
@@ -91,7 +91,10 @@ func ParseSignature(sig []byte) (*Signature, error) {
 		return nil, signatureError(ecdsa_schnorr.ErrSigRTooBig, str)
 	}
 	var s btcec.ModNScalar
-	s.SetByteSlice(sig[32:64])
+	if overflow := s.SetByteSlice(sig[32:64]); overflow {
+		str := "invalid signature: s >= group order"
+		return nil, signatureError(ecdsa_schnorr.ErrSigSTooBig, str)
+	}
 
 	// Return the signature.
 	return NewSignature(&r, &s), nil

--- a/btcec/schnorr/signature_test.go
+++ b/btcec/schnorr/signature_test.go
@@ -291,3 +291,41 @@ func TestSchnorrSignNoMutate(t *testing.T) {
 		t.Fatalf("private key modified: %v", err)
 	}
 }
+
+// TestParseSignatureComponentRange ensures ParseSignature enforces the BIP-340
+// range restrictions on both the r and s components, in particular that an s
+// value greater than or equal to the group order n is rejected rather than
+// silently reduced modulo n.
+func TestParseSignatureComponentRange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		sig  string
+		err  error
+	}{
+		{
+			name: "r == p",
+			sig:  "fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d09",
+			err:  ecdsa_schnorr.ErrSigRTooBig,
+		},
+		{
+			name: "s == n",
+			sig:  "4e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd41fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+			err:  ecdsa_schnorr.ErrSigSTooBig,
+		},
+		{
+			name: "s > n",
+			sig:  "4e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd41fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364142",
+			err:  ecdsa_schnorr.ErrSigSTooBig,
+		},
+	}
+
+	for _, test := range tests {
+		_, err := ParseSignature(decodeHex(test.sig))
+		if !errors.Is(err, test.err) {
+			t.Errorf("%s: mismatched err -- got %v, want %v",
+				test.name, err, test.err)
+		}
+	}
+}


### PR DESCRIPTION
### Change Description

`schnorr.ParseSignature` documents that it enforces the BIP-340 requirement that the `s` component lie in the range `[0, n-1]`, alongside the range check it already performs on `r`:

```go
// - The r component must be in the valid range for secp256k1 field elements
// - The s component must be in the valid range for secp256k1 scalars
```

The `r` check is implemented correctly (overflow → `ErrSigRTooBig`), but for `s` the overflow return value of `ModNScalar.SetByteSlice` was discarded:

```go
var s btcec.ModNScalar
s.SetByteSlice(sig[32:64])
```

Because `SetByteSlice` reduces its input modulo `n` and reports the overflow via its return value, an encoding with `s >= n` was **silently reduced modulo n and accepted** instead of being rejected. This diverges from:

- the function's own documented contract (and the inline comment stating `s` is enforced to be in `[0, n-1]`);
- **BIP-340**, whose verification algorithm requires *"fail if s >= n"*;
- the reference implementation in `decred/dcrd/dcrec/secp256k1/schnorr` — of which this file is a port — which rejects the same input with `ErrSigSTooBig`. The `ErrSigSTooBig` error kind is already defined in the imported `schnorr` package but was unused here, which is what tipped me off that the check was dropped during the port.

The fix mirrors the existing `r` check exactly:

```go
var s btcec.ModNScalar
if overflow := s.SetByteSlice(sig[32:64]); overflow {
	str := "invalid signature: s >= group order"
	return nil, signatureError(ecdsa_schnorr.ErrSigSTooBig, str)
}
```

`ParseSignature` is on the taproot signature-validation path (`txscript` key-path and script-path spends), so this also brings btcd's strictness in line with Bitcoin Core, which rejects non-canonical (`s >= n`) Schnorr encodings.

### Test

Adds `TestParseSignatureComponentRange`, reusing the reference `s == n` and `s > n` vectors. The test fails before this change (both encodings are accepted, returning `nil`) and passes after. Verified by reverting the one-line fix while keeping the test:

```
--- FAIL: TestParseSignatureComponentRange
    signature_test.go: s == n: mismatched err -- got <nil>, want ErrSigSTooBig
    signature_test.go: s > n:  mismatched err -- got <nil>, want ErrSigSTooBig
```

`go build ./... && go test ./...` and `go vet ./...` are green across the whole `btcec` module.

### Notes

This is intentionally minimal and independent of the other open schnorr PRs (#2546, #2501) — neither touches the `s`-range check in `ParseSignature` (I checked their diffs). Happy to rebase or fold this into #2546 if a maintainer prefers.
