### PR TITLE
rpcclient: add cookie file parsing tests

### DIFF
--- a/rpcclient/cookiefile_test.go
+++ b/rpcclient/cookiefile_test.go
@@ -1,0 +1,102 @@
+package rpcclient
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestReadCookieFile ensures cookie credentials are parsed from the first line
+// without altering valid password contents, and invalid cookie files return an
+// error without partial credentials.
+func TestReadCookieFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		filename     string
+		contents     string
+		wantUsername string
+		wantPassword string
+		expectError  bool
+	}{
+		{
+			name:         "standard credentials",
+			filename:     ".cookie",
+			contents:     "__cookie__:secret\n",
+			wantUsername: "__cookie__",
+			wantPassword: "secret",
+		},
+		{
+			name:         "password containing colons",
+			filename:     ".cookie",
+			contents:     "__cookie__:secret:with:colons\n",
+			wantUsername: "__cookie__",
+			wantPassword: "secret:with:colons",
+		},
+		{
+			name:         "CRLF line ending",
+			filename:     ".cookie",
+			contents:     "__cookie__:secret\r\n",
+			wantUsername: "__cookie__",
+			wantPassword: "secret",
+		},
+		{
+			name:        "empty file",
+			filename:    ".cookie",
+			expectError: true,
+		},
+		{
+			name:        "missing separator",
+			filename:    ".cookie",
+			contents:    "__cookie__\n",
+			expectError: true,
+		},
+		{
+			name:     "scanner token too long",
+			filename: ".cookie",
+			contents: strings.Repeat(
+				"a", bufio.MaxScanTokenSize+1,
+			),
+			expectError: true,
+		},
+		{
+			name:        "missing file",
+			expectError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			dir := t.TempDir()
+			cookiePath := filepath.Join(dir, "missing.cookie")
+			if test.filename != "" {
+				cookiePath = filepath.Join(dir, test.filename)
+				err := os.WriteFile(
+					cookiePath,
+					[]byte(test.contents),
+					0o600,
+				)
+				require.NoError(t, err)
+			}
+
+			username, password, err := readCookieFile(cookiePath)
+			if test.expectError {
+				require.Error(t, err)
+				require.Empty(t, username)
+				require.Empty(t, password)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, test.wantUsername, username)
+			require.Equal(t, test.wantPassword, password)
+		})
+	}
+}


### PR DESCRIPTION
## Change Description

Add unit tests for the RPC client's cookie file parser.

The tests cover successful parsing of standard credentials, passwords containing additional colons, and CRLF line endings. They also exercise the empty file, malformed input, oversized scanner token, and missing file error paths.

This raises `readCookieFile` statement coverage to 100% without changing production behavior.


## Steps to Test

Run:

```bash
go test ./rpcclient -count=1
go test -race ./rpcclient -run '^TestReadCookieFile' -count=1
go vet ./rpcclient
```

## Pull Request Checklist
### Testing
- [x] Your PR passes all CI checks.
- [x] Tests covering the positive and negative (error paths) are included.
- [x] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
