### PR TITLE
psbt: compact witness utxo scripts after parsing

### DIFF
--- a/psbt/strict_tx_values_test.go
+++ b/psbt/strict_tx_values_test.go
@@ -240,7 +240,9 @@ func TestParsesWitnessUtxoTxOutStrictly(t *testing.T) {
 		strictnessPSBTWithWitnessUtxo(t, txOutBytes),
 	), false)
 	require.NoError(t, err)
-	require.Equal(t, pkScript, packet.Inputs[0].WitnessUtxo.PkScript)
+	script := packet.Inputs[0].WitnessUtxo.PkScript
+	require.Equal(t, pkScript, script)
+	require.Equal(t, len(script), cap(script))
 
 	malformedTxOut := append(append([]byte{}, txOutBytes...), 0x00)
 	_, err = NewFromRawBytes(bytes.NewReader(

--- a/psbt/utils.go
+++ b/psbt/utils.go
@@ -315,6 +315,13 @@ func readTxOut(txout []byte) (*wire.TxOut, error) {
 		return nil, err
 	}
 
+	// wire.ReadTxOut stores PkScript in an internal 4 MiB script slab.
+	// Compact it before storing the TxOut in the PSBT so tiny witness
+	// scripts do not retain the full slab.
+	script := make([]byte, len(txOut.PkScript))
+	copy(script, txOut.PkScript)
+	txOut.PkScript = script
+
 	return txOut, nil
 }
 


### PR DESCRIPTION
wire.ReadTxOut returns PkScript slices backed by its internal 4 MiB script slab. PSBT inputs keep parsed WitnessUtxo values, so small scripts could otherwise keep the whole slab live.

Copy the script before storing the TxOut and assert the parsed witness script has compact capacity.

Fix https://github.com/btcsuite/btcd/pull/2558/changes#r3510704991

