### PR TITLE
netsync: avoid clock tick race in sync state test

### DIFF
--- a/netsync/manager_test.go
+++ b/netsync/manager_test.go
@@ -869,9 +869,10 @@ func syncSendHeaders(t *testing.T, sm *SyncManager,
 
 	t.Helper()
 
-	// Record the progress time set by startIBD so we can verify
-	// that handleHeadersMsg advances it.
-	progressBefore := sm.lastProgressTime
+	// Reset the progress time to a zero sentinel so the assertion below
+	// verifies that handleHeadersMsg writes it without depending on the
+	// system clock advancing between calls to time.Now.
+	sm.lastProgressTime = time.Time{}
 
 	headers := wire.NewMsgHeaders()
 	for _, block := range blocks {
@@ -887,7 +888,7 @@ func syncSendHeaders(t *testing.T, sm *SyncManager,
 	_, bestHeaderHeight := sm.chain.BestHeader()
 	require.Equal(t, int32(totalBlocks), bestHeaderHeight)
 
-	require.True(t, sm.lastProgressTime.After(progressBefore),
+	require.False(t, sm.lastProgressTime.IsZero(),
 		"handleHeadersMsg should update lastProgressTime")
 
 	wantRequested := make(map[chainhash.Hash]struct{}, len(blocks))


### PR DESCRIPTION
## Change Description
`TestSyncStateMachine` checked that `handleHeadersMsg` advanced `lastProgressTime` by comparing it against the timestamp written by `startSync`. Those two writes can happen within the same clock tick, so the handler can update the field while `time.After` still reports false.

Reset `lastProgressTime` to the zero value before delivering headers and assert that the handler writes a non-zero value. This keeps the test focused on the behavior under test without depending on adjacent time.Now calls producing distinct timestamps.

## Steps to Test
```
go test ./netsync -run TestSyncStateMachine -count=50
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [ ] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
