### PR TITLE
wire: replace 4 MiB script slab with tiered arena allocator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 	golang.org/x/crypto v0.40.0
 	golang.org/x/sys v0.35.0
-	pgregory.net/rapid v1.2.0
+	pgregory.net/rapid v1.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,6 @@ github.com/btcsuite/btcd/address/v2 v2.0.0 h1:UVu8Hal6Siu4XastFe+JX5JkeBYONbDUIY
 github.com/btcsuite/btcd/address/v2 v2.0.0/go.mod h1:htJK1AtaeK3bKNfZY63ep2oN8LbrI6qvmPGe1vekb3I=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0 h1:KioMXOWa76b86sTZZOmbzv/ldaQCmB8KFAyn5PbB8E8=
 github.com/btcsuite/btcd/btcec/v2 v2.5.0/go.mod h1:+K/MYXcLBtHEQjRbjHuJChuybk4LCgjdjgRwil+e+Kk=
-github.com/btcsuite/btcd/btcutil/v2 v2.0.0 h1:77pgf/4tjWaSBLdos8yiWVWL3rSphxWNqkLwcyONExA=
-github.com/btcsuite/btcd/btcutil/v2 v2.0.0/go.mod h1:ZF8MMdsx1JGgvHJUanxbigekSO+8bN/ai34LBk/lg3c=
 github.com/btcsuite/btcd/chaincfg/v2 v2.0.0 h1:M/RTtXfXA9odC1RUEOyZFXj/NXKVHPYZXVjb60xTOok=
 github.com/btcsuite/btcd/chaincfg/v2 v2.0.0/go.mod h1:rHgHIXYYfn70m25a+BJ9f9z7VZAsTiDQGB2XYaippGQ=
 github.com/btcsuite/btcd/chainhash/v2 v2.0.0 h1:PMLlSloHJuEeB80XG9EjpXWNEKAZAMLl6YHZ6YsEuoA=
@@ -14,8 +12,6 @@ github.com/btcsuite/btcd/txscript/v2 v2.0.0 h1:pEmmHaC8eRx6KSB63zSVJD7qrit9/c9cL
 github.com/btcsuite/btcd/txscript/v2 v2.0.0/go.mod h1:pZXabc11Xr9nz/18kXY3yErdAajYc3gi28Zqb3KqlFo=
 github.com/btcsuite/btcd/v2transport v1.0.1 h1:pIyyyBCPwd087K3Wdb/9tIvUubAQdzTJghjPgzTQVsE=
 github.com/btcsuite/btcd/v2transport v1.0.1/go.mod h1:N6H0HGSElVVJKntzaYHYVbW71DtWDLMw2yhwVRO3ZOE=
-github.com/btcsuite/btcd/wire/v2 v2.0.0 h1:mYSKzZZ0a1sK+aMhXzfDSVsSzRkWkU3x2U04TFRS2z8=
-github.com/btcsuite/btcd/wire/v2 v2.0.0/go.mod h1:bGxkPkk8IiDvUo1D96wE03llBIk7p2MdWYRyAQwLmqM=
 github.com/btcsuite/btclog v1.0.0 h1:sEkpKJMmfGiyZjADwEIgB1NSwMyfdD1FB8v6+w1T0Ns=
 github.com/btcsuite/btclog v1.0.0/go.mod h1:w7xnGOhwT3lmrS4H3b/D1XAXxvh+tbhUm8xeHN2y3TQ=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd h1:R/opQEbFEy9JGkIguV40SvRY1uliPX8ifOvi6ICsFCw=
@@ -123,5 +119,5 @@ gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-pgregory.net/rapid v1.2.0 h1:keKAYRcjm+e1F0oAuU5F5+YPAWcyxNNRK2wud503Gnk=
-pgregory.net/rapid v1.2.0/go.mod h1:PY5XlDGj0+V1FCq0o192FdRhpKHGTRIWBgqjDBTrq04=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=

--- a/wire/arena.go
+++ b/wire/arena.go
@@ -1,0 +1,269 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"errors"
+	"sync"
+)
+
+// This file implements a small bump allocator ("script arena") used to stage
+// variable-length scripts and witness items while a transaction is being
+// decoded from the wire.  Once a transaction is fully decoded, all of its
+// scripts are copied into a single exactly-sized allocation and the arena
+// memory becomes dead, so the arena is strictly transient: no arena memory
+// ever escapes a decode call.  That property is what makes reuse safe without
+// any reference counting.
+//
+// The arena replaces the previous fixed 4 MiB script slab.  The slab approach
+// suffered from memory amplification: decoding even a tiny transaction pinned
+// a full 4 MiB buffer for the duration of the decode, a pool miss allocated
+// and zeroed 4 MiB, and the channel-based free list could retain hundreds of
+// megabytes indefinitely since channels are invisible to the garbage
+// collector's pressure heuristics.
+//
+// The arena instead draws fixed-size chunks from a ladder of size classes
+// backed by sync.Pool and bump-allocates scripts out of them.  A decode only
+// touches memory proportional to the scripts it actually contains: typical
+// transactions are served entirely by a single 16 KiB chunk while full blocks
+// walk up to the larger classes.  Because the chunk pools are sync.Pools,
+// idle chunks are released back to the runtime across garbage collection
+// cycles instead of being pinned forever.
+
+const (
+	// scriptArenaMaxAlloc is the maximum total number of bytes that may be
+	// bump-allocated from a script arena between rewinds.  Since the arena
+	// is rewound for each transaction, this bounds the staged script data
+	// of a single transaction.  It intentionally matches the size of the
+	// script slab it replaced in order to preserve the existing decode
+	// limits: no valid transaction can contain more script data than the
+	// maximum block payload, so anything beyond this is malformed.
+	scriptArenaMaxAlloc = 1 << 22
+
+	// txScriptChunkClass is the chunk size class used as the starting
+	// point when decoding standalone transactions.  See
+	// scriptChunkClasses.
+	txScriptChunkClass = 0
+
+	// blockScriptChunkClass is the chunk size class used as the starting
+	// point when decoding full blocks.  See scriptChunkClasses.
+	blockScriptChunkClass = 2
+)
+
+// scriptChunkClasses defines the ladder of chunk sizes that back script
+// arenas.  The classes were chosen so that the overwhelmingly common cases
+// are served by the first chunk borrowed:
+//
+//   - 16 KiB covers virtually all standalone transactions seen on the
+//     network, which typically carry well under 1 KiB of script data.
+//   - 128 KiB covers large non-standard transactions (the standardness
+//     limit for a transaction is 100 KB).
+//   - 1 MiB covers the script data of typical full blocks.
+//   - 4 MiB covers the worst case: total script data in a message is
+//     bounded by scriptArenaMaxAlloc, and a single witness item is bounded
+//     by maxWitnessItemSize, so the largest class can always satisfy any
+//     single allocation.
+var scriptChunkClasses = [...]int{
+	16 << 10,
+	128 << 10,
+	1 << 20,
+	1 << 22,
+}
+
+// scriptChunkPools holds one sync.Pool per chunk size class.  Unlike the
+// previous channel-based free list, sync.Pool cooperates with the garbage
+// collector, so chunk memory held by the pools is reclaimed when it goes
+// unused instead of being retained indefinitely.
+var scriptChunkPools = func() [len(scriptChunkClasses)]*sync.Pool {
+	var pools [len(scriptChunkClasses)]*sync.Pool
+	for i := range scriptChunkClasses {
+		size := scriptChunkClasses[i]
+		pools[i] = &sync.Pool{
+			New: func() interface{} {
+				b := make([]byte, size)
+				return &b
+			},
+		}
+	}
+	return pools
+}()
+
+// putScriptChunk returns a chunk to the pool for its size class.  Chunks are
+// only ever created by the class pools, so their lengths always match a class
+// size exactly.
+func putScriptChunk(chunk *[]byte) {
+	for i, size := range scriptChunkClasses {
+		if len(*chunk) == size {
+			scriptChunkPools[i].Put(chunk)
+			return
+		}
+	}
+}
+
+// errScriptArenaFull is returned by alloc when satisfying the request would
+// push the total bytes allocated since the last rewind beyond
+// scriptArenaMaxAlloc.
+var errScriptArenaFull = errors.New("script arena capacity exceeded")
+
+// scriptArena is a bump allocator for transient script buffers used during
+// transaction decoding.  Allocations are carved out of fixed-size chunks
+// drawn from the tiered chunk pools, and the entire arena is freed at once
+// via release (or recycled via rewind), so individual allocations carry no
+// bookkeeping at all.
+//
+// The zero value is not usable; arenas must be obtained via
+// borrowScriptArena and returned via release.  Arenas are not safe for
+// concurrent use, mirroring the decode paths they serve.
+type scriptArena struct {
+	// chunks holds every chunk currently borrowed from the class pools,
+	// in the order they were acquired.  The last entry backs cur.
+	chunks []*[]byte
+
+	// cur is the chunk allocations are currently served from and off is
+	// the bump offset within it.
+	cur []byte
+	off int
+
+	// used tracks the total bytes handed out since the last rewind.  It
+	// is capped at scriptArenaMaxAlloc to preserve the per-transaction
+	// decode limit previously enforced by the fixed slab size.
+	used int
+
+	// class is the size class index the next chunk will be drawn from
+	// (at minimum) when the current chunk is exhausted.
+	class int
+}
+
+// scriptArenaPool recycles the arena structs themselves so that decoding a
+// message does not allocate any bookkeeping state in the steady state.
+var scriptArenaPool = sync.Pool{
+	New: func() interface{} {
+		return new(scriptArena)
+	},
+}
+
+// borrowScriptArena returns an arena that will serve its first allocation
+// from a chunk of the given starting size class.  Chunks are borrowed
+// lazily, so an arena that never allocates never touches the chunk pools.
+// The returned arena must be handed back via release.
+func borrowScriptArena(startClass int) *scriptArena {
+	a := scriptArenaPool.Get().(*scriptArena)
+	a.class = startClass
+	return a
+}
+
+// remaining returns the number of bytes that may still be allocated before
+// the arena reaches its total capacity.
+func (a *scriptArena) remaining() int {
+	return scriptArenaMaxAlloc - a.used
+}
+
+// alloc returns a slice of exactly n bytes carved from the arena.  The
+// returned slice has its capacity clamped to its length so that appends by
+// callers can never bleed into neighboring allocations.  The contents are
+// not zeroed; callers are expected to fully overwrite the buffer (the decode
+// path fills every allocation with io.ReadFull).
+//
+// alloc fails with errScriptArenaFull once the total bytes handed out since
+// the last rewind would exceed scriptArenaMaxAlloc.
+func (a *scriptArena) alloc(n int) ([]byte, error) {
+	if n > a.remaining() {
+		return nil, errScriptArenaFull
+	}
+	if n > len(a.cur)-a.off {
+		a.grow(n)
+	}
+
+	end := a.off + n
+	s := a.cur[a.off:end:end]
+	a.off = end
+	a.used += n
+
+	return s, nil
+}
+
+// grow borrows a new chunk large enough to hold n bytes and makes it the
+// current chunk.  The new chunk comes from the next size class in the ladder
+// so repeated growth converges to the largest class in a constant number of
+// steps.  Any request is satisfiable because callers bound n by the arena
+// capacity, which equals the largest class size.
+func (a *scriptArena) grow(n int) {
+	class := a.class
+	if class >= len(scriptChunkClasses) {
+		class = len(scriptChunkClasses) - 1
+	}
+	for class < len(scriptChunkClasses)-1 && scriptChunkClasses[class] < n {
+		class++
+	}
+
+	chunk := scriptChunkPools[class].Get().(*[]byte)
+	a.chunks = append(a.chunks, chunk)
+	a.cur = *chunk
+	a.off = 0
+	a.class = class + 1
+}
+
+// rewind resets the arena so previously allocated memory is reused from the
+// start, invalidating every slice handed out since the last rewind.  It is
+// called between transactions while decoding a block: each transaction copies
+// its scripts into a single exactly-sized allocation before decoding of the
+// next one begins, so the staged data is already dead by the time rewind
+// runs.
+//
+// To keep the reused footprint minimal, only the largest chunk is retained;
+// smaller chunks acquired while the arena was warming up are returned to
+// their pools.
+func (a *scriptArena) rewind() {
+	a.used = 0
+	a.off = 0
+
+	if len(a.chunks) == 0 {
+		return
+	}
+
+	// Find the largest chunk, return the rest, and continue serving
+	// allocations from it.
+	largest := 0
+	for i := 1; i < len(a.chunks); i++ {
+		if len(*a.chunks[i]) > len(*a.chunks[largest]) {
+			largest = i
+		}
+	}
+	keep := a.chunks[largest]
+	for i, chunk := range a.chunks {
+		if i != largest {
+			putScriptChunk(chunk)
+		}
+		a.chunks[i] = nil
+	}
+
+	a.chunks = append(a.chunks[:0], keep)
+	a.cur = *keep
+
+	// The next grow should pick up where the retained chunk's class
+	// leaves off.
+	for i, size := range scriptChunkClasses {
+		if size == len(*keep) {
+			a.class = i + 1
+			break
+		}
+	}
+}
+
+// release returns every chunk to its class pool and recycles the arena
+// struct itself.  All slices previously returned by alloc are invalidated.
+func (a *scriptArena) release() {
+	for i, chunk := range a.chunks {
+		putScriptChunk(chunk)
+		a.chunks[i] = nil
+	}
+	a.chunks = a.chunks[:0]
+	a.cur = nil
+	a.off = 0
+	a.used = 0
+	a.class = 0
+
+	scriptArenaPool.Put(a)
+}

--- a/wire/arena.go
+++ b/wire/arena.go
@@ -42,6 +42,12 @@ const (
 	// maximum block payload, so anything beyond this is malformed.
 	scriptArenaMaxAlloc = 1 << 22
 
+	// maxScriptChunkSize is the size of the largest chunk class.  It
+	// must be at least scriptArenaMaxAlloc so that any single allocation
+	// passing the arena capacity check can be satisfied by one chunk;
+	// the compile-time assertion below enforces the coupling.
+	maxScriptChunkSize = 1 << 22
+
 	// txScriptChunkClass is the chunk size class used as the starting
 	// point when decoding standalone transactions.  See
 	// scriptChunkClasses.
@@ -69,8 +75,14 @@ var scriptChunkClasses = [...]int{
 	16 << 10,
 	128 << 10,
 	1 << 20,
-	1 << 22,
+	maxScriptChunkSize,
 }
+
+// Compile-time assertion that the largest chunk class can satisfy any single
+// allocation that passes the arena capacity check.  grow relies on this: if
+// scriptArenaMaxAlloc were raised past maxScriptChunkSize, allocSlow could
+// select a chunk smaller than the requested allocation and panic slicing it.
+var _ [maxScriptChunkSize - scriptArenaMaxAlloc]byte
 
 // scriptChunkFixedCaps is the number of chunks per size class that are
 // retained in a small bounded free list rather than being subject to GC
@@ -137,7 +149,7 @@ var scriptChunkPools = func() [len(scriptChunkClasses)]*chunkClassPool {
 
 // putScriptChunk returns a chunk to the pool for its size class.  Chunks are
 // only ever created by the class pools, so their lengths always match a class
-// size exactly.
+// size exactly; anything else indicates internal corruption.
 func putScriptChunk(chunk *[]byte) {
 	for i, size := range scriptChunkClasses {
 		if len(*chunk) == size {
@@ -145,6 +157,8 @@ func putScriptChunk(chunk *[]byte) {
 			return
 		}
 	}
+
+	panic("putScriptChunk: chunk size matches no class")
 }
 
 // errScriptArenaFull is returned by alloc when satisfying the request would
@@ -197,9 +211,11 @@ var scriptArenaPool = sync.Pool{
 }
 
 // borrowScriptArena returns an arena that will serve its first allocation
-// from a chunk of the given starting size class.  Chunks are borrowed
-// lazily, so an arena that never allocates never touches the chunk pools.
-// The returned arena must be handed back via release.
+// from a chunk of the given starting size class.  The startClass must be a
+// valid index into scriptChunkClasses; all callers pass one of the
+// *ScriptChunkClass constants.  Chunks are borrowed lazily, so an arena
+// that never allocates never touches the chunk pools.  The returned arena
+// must be handed back via release.
 //
 // Forgetting to call release is safe in the memory sense: the chunks are
 // ordinary garbage collected slices, so an abandoned arena is simply
@@ -243,8 +259,9 @@ func (a *scriptArena) alloc(n int) ([]byte, error) {
 }
 
 // allocSlow services an allocation that does not fit in the current chunk
-// by growing first.  It is kept out of line so the common in-chunk alloc
-// path stays small enough to inline.
+// by growing first.  It is kept separate so the common in-chunk alloc path
+// stays small; alloc itself still lands just past the compiler's inlining
+// budget due to the call here, which is left as a future optimization.
 func (a *scriptArena) allocSlow(n int) ([]byte, error) {
 	a.grow(n)
 
@@ -346,7 +363,7 @@ func (a *scriptArena) rewindSlow() {
 // no-op rather than double-inserting the arena into the pool, which would
 // hand the same arena to two concurrent decodes.  A released arena also
 // rejects any further alloc calls with errScriptArenaFull (used is poisoned
-// to the capacity limit) so a stale reference held past release fails
+// past the capacity limit) so a stale reference held past release fails
 // loudly instead of silently carving memory out of chunks that another
 // decode may now own.
 func (a *scriptArena) release() {
@@ -365,8 +382,9 @@ func (a *scriptArena) release() {
 
 	// Poison the capacity so any alloc through a stale reference fails
 	// with errScriptArenaFull rather than succeeding against recycled
-	// memory.
-	a.used = scriptArenaMaxAlloc
+	// memory.  One past the limit makes remaining negative, so even a
+	// zero-length alloc is rejected.
+	a.used = scriptArenaMaxAlloc + 1
 	a.dead = true
 
 	scriptArenaPool.Put(a)

--- a/wire/arena.go
+++ b/wire/arena.go
@@ -72,18 +72,63 @@ var scriptChunkClasses = [...]int{
 	1 << 22,
 }
 
-// scriptChunkPools holds one sync.Pool per chunk size class.  Unlike the
-// previous channel-based free list, sync.Pool cooperates with the garbage
-// collector, so chunk memory held by the pools is reclaimed when it goes
-// unused instead of being retained indefinitely.
-var scriptChunkPools = func() [len(scriptChunkClasses)]*sync.Pool {
-	var pools [len(scriptChunkClasses)]*sync.Pool
+// scriptChunkFixedCaps is the number of chunks per size class that are
+// retained in a small bounded free list rather than being subject to GC
+// reclamation.  The large classes are the expensive ones to re-create (a
+// pool miss zeroes the whole chunk), and only a handful are ever live at
+// once since block decode concurrency is bounded, so pinning a few of them
+// buys stable block decode performance for at most 16*1 MiB + 8*4 MiB =
+// 48 MiB, and only once block traffic has actually warmed them.  The 1 MiB
+// class gets the deepest list since every block decode starts there, while
+// the 4 MiB class only serves the rare transaction that stages more than
+// 1 MiB of script data.  The small classes cost well under a microsecond
+// to re-create, so they are left entirely to the GC-cooperating sync.Pool.
+var scriptChunkFixedCaps = [len(scriptChunkClasses)]int{0, 0, 16, 8}
+
+// chunkClassPool hands out chunks of a single size class.  It layers a
+// small bounded free list (fixed) in front of a sync.Pool: the fixed list
+// gives deterministic reuse for the handful of chunks that stay hot, while
+// the sync.Pool absorbs bursts beyond it and lets the garbage collector
+// reclaim that overflow when it goes idle.  The previous design was a single
+// channel free list holding up to 125 four-MiB slabs (~524 MB) that the GC
+// could never reclaim.
+type chunkClassPool struct {
+	fixed chan *[]byte
+	pool  sync.Pool
+}
+
+// get returns a chunk for this class, preferring the bounded free list.
+func (p *chunkClassPool) get() *[]byte {
+	select {
+	case chunk := <-p.fixed:
+		return chunk
+	default:
+	}
+	return p.pool.Get().(*[]byte)
+}
+
+// put returns a chunk to this class, refilling the bounded free list first
+// and spilling the rest into the sync.Pool.
+func (p *chunkClassPool) put(chunk *[]byte) {
+	select {
+	case p.fixed <- chunk:
+	default:
+		p.pool.Put(chunk)
+	}
+}
+
+// scriptChunkPools holds one pool per chunk size class.
+var scriptChunkPools = func() [len(scriptChunkClasses)]*chunkClassPool {
+	var pools [len(scriptChunkClasses)]*chunkClassPool
 	for i := range scriptChunkClasses {
 		size := scriptChunkClasses[i]
-		pools[i] = &sync.Pool{
-			New: func() interface{} {
-				b := make([]byte, size)
-				return &b
+		pools[i] = &chunkClassPool{
+			fixed: make(chan *[]byte, scriptChunkFixedCaps[i]),
+			pool: sync.Pool{
+				New: func() interface{} {
+					b := make([]byte, size)
+					return &b
+				},
 			},
 		}
 	}
@@ -96,7 +141,7 @@ var scriptChunkPools = func() [len(scriptChunkClasses)]*sync.Pool {
 func putScriptChunk(chunk *[]byte) {
 	for i, size := range scriptChunkClasses {
 		if len(*chunk) == size {
-			scriptChunkPools[i].Put(chunk)
+			scriptChunkPools[i].put(chunk)
 			return
 		}
 	}
@@ -134,6 +179,13 @@ type scriptArena struct {
 	// class is the size class index the next chunk will be drawn from
 	// (at minimum) when the current chunk is exhausted.
 	class int
+
+	// dead marks an arena that has been released.  A dead arena rejects
+	// all allocations and ignores rewinds until it is borrowed again, so
+	// a stale reference held past release fails loudly with a decode
+	// error instead of silently carving memory out of chunks that
+	// another decode may now own.
+	dead bool
 }
 
 // scriptArenaPool recycles the arena structs themselves so that decoding a
@@ -148,9 +200,15 @@ var scriptArenaPool = sync.Pool{
 // from a chunk of the given starting size class.  Chunks are borrowed
 // lazily, so an arena that never allocates never touches the chunk pools.
 // The returned arena must be handed back via release.
+//
+// Forgetting to call release is safe in the memory sense: the chunks are
+// ordinary garbage collected slices, so an abandoned arena is simply
+// reclaimed by the GC and only the pooling benefit is lost.
 func borrowScriptArena(startClass int) *scriptArena {
 	a := scriptArenaPool.Get().(*scriptArena)
 	a.class = startClass
+	a.used = 0
+	a.dead = false
 	return a
 }
 
@@ -173,12 +231,25 @@ func (a *scriptArena) alloc(n int) ([]byte, error) {
 		return nil, errScriptArenaFull
 	}
 	if n > len(a.cur)-a.off {
-		a.grow(n)
+		return a.allocSlow(n)
 	}
 
 	end := a.off + n
 	s := a.cur[a.off:end:end]
 	a.off = end
+	a.used += n
+
+	return s, nil
+}
+
+// allocSlow services an allocation that does not fit in the current chunk
+// by growing first.  It is kept out of line so the common in-chunk alloc
+// path stays small enough to inline.
+func (a *scriptArena) allocSlow(n int) ([]byte, error) {
+	a.grow(n)
+
+	s := a.cur[:n:n]
+	a.off = n
 	a.used += n
 
 	return s, nil
@@ -198,7 +269,7 @@ func (a *scriptArena) grow(n int) {
 		class++
 	}
 
-	chunk := scriptChunkPools[class].Get().(*[]byte)
+	chunk := scriptChunkPools[class].get()
 	a.chunks = append(a.chunks, chunk)
 	a.cur = *chunk
 	a.off = 0
@@ -216,13 +287,29 @@ func (a *scriptArena) grow(n int) {
 // smaller chunks acquired while the arena was warming up are returned to
 // their pools.
 func (a *scriptArena) rewind() {
-	a.used = 0
-	a.off = 0
-
-	if len(a.chunks) == 0 {
+	// A released arena stays dead: rewinding must not resurrect its
+	// capacity, otherwise a stale reference could allocate out of chunks
+	// that have already been handed to another decode.
+	if a.dead {
 		return
 	}
 
+	a.used = 0
+	a.off = 0
+
+	// The common case by far is a single chunk (a transaction that fit
+	// its starting class), where cur already points at it and resetting
+	// the offsets above is all that's needed.
+	if len(a.chunks) <= 1 {
+		return
+	}
+
+	a.rewindSlow()
+}
+
+// rewindSlow handles the multi-chunk case of rewind, kept out of line so
+// the hot single-chunk rewind path stays small enough to inline.
+func (a *scriptArena) rewindSlow() {
 	// Find the largest chunk, return the rest, and continue serving
 	// allocations from it.
 	largest := 0
@@ -254,7 +341,19 @@ func (a *scriptArena) rewind() {
 
 // release returns every chunk to its class pool and recycles the arena
 // struct itself.  All slices previously returned by alloc are invalidated.
+//
+// release is idempotent: a second call on an already released arena is a
+// no-op rather than double-inserting the arena into the pool, which would
+// hand the same arena to two concurrent decodes.  A released arena also
+// rejects any further alloc calls with errScriptArenaFull (used is poisoned
+// to the capacity limit) so a stale reference held past release fails
+// loudly instead of silently carving memory out of chunks that another
+// decode may now own.
 func (a *scriptArena) release() {
+	if a.dead {
+		return
+	}
+
 	for i, chunk := range a.chunks {
 		putScriptChunk(chunk)
 		a.chunks[i] = nil
@@ -262,8 +361,13 @@ func (a *scriptArena) release() {
 	a.chunks = a.chunks[:0]
 	a.cur = nil
 	a.off = 0
-	a.used = 0
 	a.class = 0
+
+	// Poison the capacity so any alloc through a stale reference fails
+	// with errScriptArenaFull rather than succeeding against recycled
+	// memory.
+	a.used = scriptArenaMaxAlloc
+	a.dead = true
 
 	scriptArenaPool.Put(a)
 }

--- a/wire/arena.go
+++ b/wire/arena.go
@@ -54,8 +54,10 @@ const (
 	txScriptChunkClass = 0
 
 	// blockScriptChunkClass is the chunk size class used as the starting
-	// point when decoding full blocks.  See scriptChunkClasses.
-	blockScriptChunkClass = 2
+	// point when decoding full blocks. The arena is rewound between each
+	// transaction, so blocks have the same initial requirement as standalone
+	// transactions and grow only when an individual transaction requires it.
+	blockScriptChunkClass = txScriptChunkClass
 )
 
 // scriptChunkClasses defines the ladder of chunk sizes that back script
@@ -66,7 +68,7 @@ const (
 //     network, which typically carry well under 1 KiB of script data.
 //   - 128 KiB covers large non-standard transactions (the standardness
 //     limit for a transaction is 100 KB).
-//   - 1 MiB covers the script data of typical full blocks.
+//   - 1 MiB covers transactions with unusually large aggregate script data.
 //   - 4 MiB covers the worst case: total script data in a message is
 //     bounded by scriptArenaMaxAlloc, and a single witness item is bounded
 //     by maxWitnessItemSize, so the largest class can always satisfy any
@@ -91,10 +93,11 @@ var _ [maxScriptChunkSize - scriptArenaMaxAlloc]byte
 // once since block decode concurrency is bounded, so pinning a few of them
 // buys stable block decode performance for at most 16*1 MiB + 8*4 MiB =
 // 48 MiB, and only once block traffic has actually warmed them.  The 1 MiB
-// class gets the deepest list since every block decode starts there, while
-// the 4 MiB class only serves the rare transaction that stages more than
-// 1 MiB of script data.  The small classes cost well under a microsecond
-// to re-create, so they are left entirely to the GC-cooperating sync.Pool.
+// class gets the deepest list to absorb concurrent decodes of transactions
+// with large aggregate script data, while the 4 MiB class only serves the
+// rare transaction that stages more than 1 MiB. The small classes cost well
+// under a microsecond to re-create, so they are left entirely to the
+// GC-cooperating sync.Pool.
 var scriptChunkFixedCaps = [len(scriptChunkClasses)]int{0, 0, 16, 8}
 
 // chunkClassPool hands out chunks of a single size class.  It layers a
@@ -194,11 +197,10 @@ type scriptArena struct {
 	// (at minimum) when the current chunk is exhausted.
 	class int
 
-	// dead marks an arena that has been released.  A dead arena rejects
-	// all allocations and ignores rewinds until it is borrowed again, so
-	// a stale reference held past release fails loudly with a decode
-	// error instead of silently carving memory out of chunks that
-	// another decode may now own.
+	// dead marks an arena that has been released. A dead arena rejects all
+	// allocations and ignores rewinds until the arena is borrowed again.
+	// Arenas have a single lexical owner and references must not be retained
+	// after release.
 	dead bool
 }
 
@@ -359,13 +361,10 @@ func (a *scriptArena) rewindSlow() {
 // release returns every chunk to its class pool and recycles the arena
 // struct itself.  All slices previously returned by alloc are invalidated.
 //
-// release is idempotent: a second call on an already released arena is a
-// no-op rather than double-inserting the arena into the pool, which would
-// hand the same arena to two concurrent decodes.  A released arena also
-// rejects any further alloc calls with errScriptArenaFull (used is poisoned
-// past the capacity limit) so a stale reference held past release fails
-// loudly instead of silently carving memory out of chunks that another
-// decode may now own.
+// release is idempotent until the arena is borrowed again: a second call on
+// an already released arena is a no-op rather than double-inserting it into
+// the pool. A released arena also rejects further allocations until it is
+// borrowed again. Callers must not retain an arena reference after release.
 func (a *scriptArena) release() {
 	if a.dead {
 		return

--- a/wire/arena.go
+++ b/wire/arena.go
@@ -42,6 +42,12 @@ const (
 	// maximum block payload, so anything beyond this is malformed.
 	scriptArenaMaxAlloc = 1 << 22
 
+	// maxScriptChunkSize is the size of the largest chunk class.  It
+	// must be at least scriptArenaMaxAlloc so that any single allocation
+	// passing the arena capacity check can be satisfied by one chunk;
+	// the compile-time assertion below enforces the coupling.
+	maxScriptChunkSize = 1 << 22
+
 	// txScriptChunkClass is the chunk size class used as the starting
 	// point when decoding standalone transactions.  See
 	// scriptChunkClasses.
@@ -69,21 +75,72 @@ var scriptChunkClasses = [...]int{
 	16 << 10,
 	128 << 10,
 	1 << 20,
-	1 << 22,
+	maxScriptChunkSize,
 }
 
-// scriptChunkPools holds one sync.Pool per chunk size class.  Unlike the
-// previous channel-based free list, sync.Pool cooperates with the garbage
-// collector, so chunk memory held by the pools is reclaimed when it goes
-// unused instead of being retained indefinitely.
-var scriptChunkPools = func() [len(scriptChunkClasses)]*sync.Pool {
-	var pools [len(scriptChunkClasses)]*sync.Pool
+// Compile-time assertion that the largest chunk class can satisfy any single
+// allocation that passes the arena capacity check.  grow relies on this: if
+// scriptArenaMaxAlloc were raised past maxScriptChunkSize, allocSlow could
+// select a chunk smaller than the requested allocation and panic slicing it.
+var _ [maxScriptChunkSize - scriptArenaMaxAlloc]byte
+
+// scriptChunkFixedCaps is the number of chunks per size class that are
+// retained in a small bounded free list rather than being subject to GC
+// reclamation.  The large classes are the expensive ones to re-create (a
+// pool miss zeroes the whole chunk), and only a handful are ever live at
+// once since block decode concurrency is bounded, so pinning a few of them
+// buys stable block decode performance for at most 16*1 MiB + 8*4 MiB =
+// 48 MiB, and only once block traffic has actually warmed them.  The 1 MiB
+// class gets the deepest list since every block decode starts there, while
+// the 4 MiB class only serves the rare transaction that stages more than
+// 1 MiB of script data.  The small classes cost well under a microsecond
+// to re-create, so they are left entirely to the GC-cooperating sync.Pool.
+var scriptChunkFixedCaps = [len(scriptChunkClasses)]int{0, 0, 16, 8}
+
+// chunkClassPool hands out chunks of a single size class.  It layers a
+// small bounded free list (fixed) in front of a sync.Pool: the fixed list
+// gives deterministic reuse for the handful of chunks that stay hot, while
+// the sync.Pool absorbs bursts beyond it and lets the garbage collector
+// reclaim that overflow when it goes idle.  The previous design was a single
+// channel free list holding up to 125 four-MiB slabs (~524 MB) that the GC
+// could never reclaim.
+type chunkClassPool struct {
+	fixed chan *[]byte
+	pool  sync.Pool
+}
+
+// get returns a chunk for this class, preferring the bounded free list.
+func (p *chunkClassPool) get() *[]byte {
+	select {
+	case chunk := <-p.fixed:
+		return chunk
+	default:
+	}
+	return p.pool.Get().(*[]byte)
+}
+
+// put returns a chunk to this class, refilling the bounded free list first
+// and spilling the rest into the sync.Pool.
+func (p *chunkClassPool) put(chunk *[]byte) {
+	select {
+	case p.fixed <- chunk:
+	default:
+		p.pool.Put(chunk)
+	}
+}
+
+// scriptChunkPools holds one pool per chunk size class.
+var scriptChunkPools = func() [len(scriptChunkClasses)]*chunkClassPool {
+	var pools [len(scriptChunkClasses)]*chunkClassPool
 	for i := range scriptChunkClasses {
 		size := scriptChunkClasses[i]
-		pools[i] = &sync.Pool{
-			New: func() interface{} {
-				b := make([]byte, size)
-				return &b
+		pools[i] = &chunkClassPool{
+			fixed: make(chan *[]byte, scriptChunkFixedCaps[i]),
+			pool: sync.Pool{
+				New: func() interface{} {
+					b := make([]byte, size)
+					return &b
+				},
 			},
 		}
 	}
@@ -92,14 +149,16 @@ var scriptChunkPools = func() [len(scriptChunkClasses)]*sync.Pool {
 
 // putScriptChunk returns a chunk to the pool for its size class.  Chunks are
 // only ever created by the class pools, so their lengths always match a class
-// size exactly.
+// size exactly; anything else indicates internal corruption.
 func putScriptChunk(chunk *[]byte) {
 	for i, size := range scriptChunkClasses {
 		if len(*chunk) == size {
-			scriptChunkPools[i].Put(chunk)
+			scriptChunkPools[i].put(chunk)
 			return
 		}
 	}
+
+	panic("putScriptChunk: chunk size matches no class")
 }
 
 // errScriptArenaFull is returned by alloc when satisfying the request would
@@ -134,6 +193,13 @@ type scriptArena struct {
 	// class is the size class index the next chunk will be drawn from
 	// (at minimum) when the current chunk is exhausted.
 	class int
+
+	// dead marks an arena that has been released.  A dead arena rejects
+	// all allocations and ignores rewinds until it is borrowed again, so
+	// a stale reference held past release fails loudly with a decode
+	// error instead of silently carving memory out of chunks that
+	// another decode may now own.
+	dead bool
 }
 
 // scriptArenaPool recycles the arena structs themselves so that decoding a
@@ -145,12 +211,20 @@ var scriptArenaPool = sync.Pool{
 }
 
 // borrowScriptArena returns an arena that will serve its first allocation
-// from a chunk of the given starting size class.  Chunks are borrowed
-// lazily, so an arena that never allocates never touches the chunk pools.
-// The returned arena must be handed back via release.
+// from a chunk of the given starting size class.  The startClass must be a
+// valid index into scriptChunkClasses; all callers pass one of the
+// *ScriptChunkClass constants.  Chunks are borrowed lazily, so an arena
+// that never allocates never touches the chunk pools.  The returned arena
+// must be handed back via release.
+//
+// Forgetting to call release is safe in the memory sense: the chunks are
+// ordinary garbage collected slices, so an abandoned arena is simply
+// reclaimed by the GC and only the pooling benefit is lost.
 func borrowScriptArena(startClass int) *scriptArena {
 	a := scriptArenaPool.Get().(*scriptArena)
 	a.class = startClass
+	a.used = 0
+	a.dead = false
 	return a
 }
 
@@ -173,12 +247,26 @@ func (a *scriptArena) alloc(n int) ([]byte, error) {
 		return nil, errScriptArenaFull
 	}
 	if n > len(a.cur)-a.off {
-		a.grow(n)
+		return a.allocSlow(n)
 	}
 
 	end := a.off + n
 	s := a.cur[a.off:end:end]
 	a.off = end
+	a.used += n
+
+	return s, nil
+}
+
+// allocSlow services an allocation that does not fit in the current chunk
+// by growing first.  It is kept separate so the common in-chunk alloc path
+// stays small; alloc itself still lands just past the compiler's inlining
+// budget due to the call here, which is left as a future optimization.
+func (a *scriptArena) allocSlow(n int) ([]byte, error) {
+	a.grow(n)
+
+	s := a.cur[:n:n]
+	a.off = n
 	a.used += n
 
 	return s, nil
@@ -198,7 +286,7 @@ func (a *scriptArena) grow(n int) {
 		class++
 	}
 
-	chunk := scriptChunkPools[class].Get().(*[]byte)
+	chunk := scriptChunkPools[class].get()
 	a.chunks = append(a.chunks, chunk)
 	a.cur = *chunk
 	a.off = 0
@@ -216,13 +304,29 @@ func (a *scriptArena) grow(n int) {
 // smaller chunks acquired while the arena was warming up are returned to
 // their pools.
 func (a *scriptArena) rewind() {
-	a.used = 0
-	a.off = 0
-
-	if len(a.chunks) == 0 {
+	// A released arena stays dead: rewinding must not resurrect its
+	// capacity, otherwise a stale reference could allocate out of chunks
+	// that have already been handed to another decode.
+	if a.dead {
 		return
 	}
 
+	a.used = 0
+	a.off = 0
+
+	// The common case by far is a single chunk (a transaction that fit
+	// its starting class), where cur already points at it and resetting
+	// the offsets above is all that's needed.
+	if len(a.chunks) <= 1 {
+		return
+	}
+
+	a.rewindSlow()
+}
+
+// rewindSlow handles the multi-chunk case of rewind, kept out of line so
+// the hot single-chunk rewind path stays small enough to inline.
+func (a *scriptArena) rewindSlow() {
 	// Find the largest chunk, return the rest, and continue serving
 	// allocations from it.
 	largest := 0
@@ -254,7 +358,19 @@ func (a *scriptArena) rewind() {
 
 // release returns every chunk to its class pool and recycles the arena
 // struct itself.  All slices previously returned by alloc are invalidated.
+//
+// release is idempotent: a second call on an already released arena is a
+// no-op rather than double-inserting the arena into the pool, which would
+// hand the same arena to two concurrent decodes.  A released arena also
+// rejects any further alloc calls with errScriptArenaFull (used is poisoned
+// past the capacity limit) so a stale reference held past release fails
+// loudly instead of silently carving memory out of chunks that another
+// decode may now own.
 func (a *scriptArena) release() {
+	if a.dead {
+		return
+	}
+
 	for i, chunk := range a.chunks {
 		putScriptChunk(chunk)
 		a.chunks[i] = nil
@@ -262,8 +378,14 @@ func (a *scriptArena) release() {
 	a.chunks = a.chunks[:0]
 	a.cur = nil
 	a.off = 0
-	a.used = 0
 	a.class = 0
+
+	// Poison the capacity so any alloc through a stale reference fails
+	// with errScriptArenaFull rather than succeeding against recycled
+	// memory.  One past the limit makes remaining negative, so even a
+	// zero-length alloc is rejected.
+	a.used = scriptArenaMaxAlloc + 1
+	a.dead = true
 
 	scriptArenaPool.Put(a)
 }

--- a/wire/arena_rapid_test.go
+++ b/wire/arena_rapid_test.go
@@ -1,0 +1,295 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// poisonScriptChunkPools scribbles a poison pattern over chunks sitting in
+// the class pools.  Any decoded message that still aliases arena memory
+// (rather than owning an exact-size copy of its scripts) will have its
+// contents corrupted by this, so re-verifying a message after poisoning
+// proves that no arena memory escaped the decode.
+func poisonScriptChunkPools() {
+	for _, pool := range scriptChunkPools {
+		// Pull a handful of chunks out of each pool, poison them, and
+		// put them back.  This reaches the chunks released by recent
+		// decodes on this P.
+		var chunks []*[]byte
+		for i := 0; i < 4; i++ {
+			chunks = append(chunks, pool.get())
+		}
+		for _, chunk := range chunks {
+			for i := range *chunk {
+				(*chunk)[i] = 0xaa
+			}
+			pool.put(chunk)
+		}
+	}
+}
+
+// genScript returns a rapid generator for a non-nil script of up to maxLen
+// bytes.  Zero-length scripts are always non-nil so that decoded messages,
+// which never produce nil scripts, compare equal structurally.
+func genScript(rt *rapid.T, label string, maxLen int) []byte {
+	n := rapid.IntRange(0, maxLen).Draw(rt, label+"Len")
+	s := make([]byte, n)
+	for i := 0; i < n; i++ {
+		s[i] = byte(rapid.IntRange(0, 255).Draw(rt, label+"Byte"))
+	}
+	return s
+}
+
+// genMsgTx generates a structurally valid random transaction.  Script and
+// witness sizes are biased small like real traffic but occasionally exceed
+// the 16 KiB starting chunk class so the arena growth path is exercised.
+func genMsgTx(rt *rapid.T) *MsgTx {
+	tx := NewMsgTx(int32(rapid.IntRange(0, 2).Draw(rt, "version")))
+
+	// Most generated scripts are small, but roughly one in ten draws
+	// from a range that overflows the first chunk class.
+	scriptMax := 512
+	if rapid.IntRange(0, 9).Draw(rt, "bigScripts") == 0 {
+		scriptMax = 3 * scriptChunkClasses[0]
+	}
+
+	numIn := rapid.IntRange(1, 6).Draw(rt, "numIn")
+	hasWitness := rapid.Bool().Draw(rt, "hasWitness")
+	for i := 0; i < numIn; i++ {
+		ti := &TxIn{
+			PreviousOutPoint: OutPoint{
+				Index: uint32(rapid.IntRange(0, 1<<30).Draw(
+					rt, "prevIndex",
+				)),
+			},
+			SignatureScript: genScript(rt, "sigScript", scriptMax),
+			Sequence: uint32(
+				rapid.IntRange(0, 1<<30).Draw(rt, "sequence"),
+			),
+		}
+		for j := range ti.PreviousOutPoint.Hash {
+			ti.PreviousOutPoint.Hash[j] = byte(
+				rapid.IntRange(0, 255).Draw(rt, "prevHash"),
+			)
+		}
+
+		// When the transaction is witnessy every input carries a
+		// (possibly empty) non-nil witness stack, matching what the
+		// decoder produces.
+		if hasWitness {
+			numItems := rapid.IntRange(0, 3).Draw(rt, "numWitness")
+			ti.Witness = make(TxWitness, numItems)
+			for j := 0; j < numItems; j++ {
+				ti.Witness[j] = genScript(
+					rt, "witnessItem", scriptMax,
+				)
+			}
+		}
+
+		tx.AddTxIn(ti)
+	}
+
+	// A witness marker with zero total witness items is rejected by the
+	// decoder (and never produced by the encoder), so force at least one
+	// item when the transaction claims to be witnessy.
+	if hasWitness && !tx.HasWitness() {
+		tx.TxIn[0].Witness = TxWitness{
+			genScript(rt, "forcedWitness", scriptMax),
+		}
+	}
+
+	numOut := rapid.IntRange(0, 6).Draw(rt, "numOut")
+	for i := 0; i < numOut; i++ {
+		tx.AddTxOut(&TxOut{
+			Value: int64(
+				rapid.IntRange(0, 1<<40).Draw(rt, "value"),
+			),
+			PkScript: genScript(rt, "pkScript", scriptMax),
+		})
+	}
+
+	tx.LockTime = uint32(rapid.IntRange(0, 1<<30).Draw(rt, "lockTime"))
+
+	return tx
+}
+
+// TestScriptArenaPropertyTxRoundTrip checks two properties over random
+// transactions: serialize/deserialize is the identity, and the decoded
+// transaction owns all of its memory (poisoning the arena chunk pools after
+// the decode must not change it).
+func TestScriptArenaPropertyTxRoundTrip(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		tx := genMsgTx(rt)
+
+		var wireBuf bytes.Buffer
+		require.NoError(rt, tx.Serialize(&wireBuf))
+
+		var decoded MsgTx
+		err := decoded.Deserialize(bytes.NewReader(wireBuf.Bytes()))
+		require.NoError(rt, err)
+
+		var reserialized bytes.Buffer
+		require.NoError(rt, decoded.Serialize(&reserialized))
+		require.Equal(rt, wireBuf.Bytes(), reserialized.Bytes())
+
+		// If the decoded transaction aliased arena memory, poisoning
+		// the pools would corrupt its scripts and the second
+		// serialization would differ.
+		poisonScriptChunkPools()
+
+		var afterPoison bytes.Buffer
+		require.NoError(rt, decoded.Serialize(&afterPoison))
+		require.Equal(rt, wireBuf.Bytes(), afterPoison.Bytes())
+	})
+}
+
+// TestScriptArenaPropertyBlockRoundTrip checks the same round-trip and
+// ownership properties for full blocks, which share a single arena across
+// all of their transactions.
+func TestScriptArenaPropertyBlockRoundTrip(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		block := &MsgBlock{Header: blockOne.Header}
+		numTxs := rapid.IntRange(1, 8).Draw(rt, "numTxs")
+		for i := 0; i < numTxs; i++ {
+			block.AddTransaction(genMsgTx(rt))
+		}
+
+		var wireBuf bytes.Buffer
+		require.NoError(rt, block.Serialize(&wireBuf))
+
+		var decoded MsgBlock
+		err := decoded.Deserialize(bytes.NewReader(wireBuf.Bytes()))
+		require.NoError(rt, err)
+
+		var reserialized bytes.Buffer
+		require.NoError(rt, decoded.Serialize(&reserialized))
+		require.Equal(rt, wireBuf.Bytes(), reserialized.Bytes())
+
+		poisonScriptChunkPools()
+
+		var afterPoison bytes.Buffer
+		require.NoError(rt, decoded.Serialize(&afterPoison))
+		require.Equal(rt, wireBuf.Bytes(), afterPoison.Bytes())
+	})
+}
+
+// TestScriptArenaPropertyAllocator drives the raw allocator with random
+// alloc/rewind sequences against a simple model, checking capacity
+// accounting and that live allocations never alias one another.
+func TestScriptArenaPropertyAllocator(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		startClass := rapid.IntRange(
+			0, len(scriptChunkClasses)-1,
+		).Draw(rt, "startClass")
+
+		ar := borrowScriptArena(startClass)
+		defer ar.release()
+
+		type allocation struct {
+			s      []byte
+			marker byte
+		}
+		var live []allocation
+		modelUsed := 0
+
+		verifyLive := func() {
+			for _, a := range live {
+				count := bytes.Count(a.s, []byte{a.marker})
+				require.Equal(rt, len(a.s), count)
+			}
+		}
+
+		steps := rapid.IntRange(1, 60).Draw(rt, "steps")
+		for i := 0; i < steps; i++ {
+			if rapid.IntRange(0, 9).Draw(rt, "op") == 0 {
+				verifyLive()
+				ar.rewind()
+				live = live[:0]
+				modelUsed = 0
+				require.LessOrEqual(rt, len(ar.chunks), 1)
+				continue
+			}
+
+			n := rapid.IntRange(0, 300_000).Draw(rt, "n")
+			s, err := ar.alloc(n)
+
+			// The model predicts exactly when allocation fails.
+			if n > scriptArenaMaxAlloc-modelUsed {
+				require.ErrorIs(
+					rt, err, errScriptArenaFull,
+				)
+				continue
+			}
+			require.NoError(rt, err)
+			require.Len(rt, s, n)
+			require.Equal(rt, n, cap(s))
+			modelUsed += n
+			require.Equal(
+				rt, scriptArenaMaxAlloc-modelUsed,
+				ar.remaining(),
+			)
+
+			marker := byte(len(live) % 251)
+			for j := range s {
+				s[j] = marker
+			}
+			live = append(live, allocation{s: s, marker: marker})
+		}
+		verifyLive()
+	})
+}
+
+// TestReadTxOutOwnedScript ensures the script returned by the exported
+// ReadTxOut owns its memory: the arena used to stage it is recycled when
+// ReadTxOut returns, so a script still aliasing arena memory would be
+// corrupted by the pool poisoning below.
+func TestReadTxOutOwnedScript(t *testing.T) {
+	orig := blockOne.Transactions[0].TxOut[0]
+	var buf bytes.Buffer
+	require.NoError(t, WriteTxOut(&buf, 0, 0, orig))
+
+	var txOut TxOut
+	require.NoError(t, ReadTxOut(bytes.NewReader(buf.Bytes()), 0, 0, &txOut))
+	require.Equal(t, orig.PkScript, txOut.PkScript)
+
+	poisonScriptChunkPools()
+
+	require.Equal(t, orig.PkScript, txOut.PkScript)
+}
+
+// TestScriptArenaReleaseSafety exercises the misuse guards: double release
+// is a no-op, and a released arena refuses to allocate even after a rewind.
+func TestScriptArenaReleaseSafety(t *testing.T) {
+	ar := borrowScriptArena(txScriptChunkClass)
+	_, err := ar.alloc(128)
+	require.NoError(t, err)
+
+	ar.release()
+
+	// Allocating through a stale reference must fail loudly.
+	_, err = ar.alloc(1)
+	require.ErrorIs(t, err, errScriptArenaFull)
+
+	// A rewind must not resurrect a released arena.
+	ar.rewind()
+	_, err = ar.alloc(1)
+	require.ErrorIs(t, err, errScriptArenaFull)
+
+	// Double release must be a no-op rather than double-inserting the
+	// arena into the pool.
+	ar.release()
+
+	// A fresh borrow resets the poisoned state.
+	fresh := borrowScriptArena(txScriptChunkClass)
+	defer fresh.release()
+	s, err := fresh.alloc(32)
+	require.NoError(t, err)
+	require.Len(t, s, 32)
+}

--- a/wire/arena_rapid_test.go
+++ b/wire/arena_rapid_test.go
@@ -1,0 +1,278 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"pgregory.net/rapid"
+)
+
+// poisonScriptChunkPools scribbles a poison pattern over chunks sitting in
+// the class pools.  Any decoded message that still aliases arena memory
+// (rather than owning an exact-size copy of its scripts) will have its
+// contents corrupted by this, so re-verifying a message after poisoning
+// proves that no arena memory escaped the decode.
+func poisonScriptChunkPools() {
+	for _, pool := range scriptChunkPools {
+		// Pull a handful of chunks out of each pool, poison them, and
+		// put them back.  This reaches the chunks released by recent
+		// decodes on this P.
+		var chunks []*[]byte
+		for i := 0; i < 4; i++ {
+			chunks = append(chunks, pool.get())
+		}
+		for _, chunk := range chunks {
+			for i := range *chunk {
+				(*chunk)[i] = 0xaa
+			}
+			pool.put(chunk)
+		}
+	}
+}
+
+// genScript returns a rapid generator for a non-nil script of up to maxLen
+// bytes.  Zero-length scripts are always non-nil so that decoded messages,
+// which never produce nil scripts, compare equal structurally.
+func genScript(rt *rapid.T, label string, maxLen int) []byte {
+	n := rapid.IntRange(0, maxLen).Draw(rt, label+"Len")
+	s := make([]byte, n)
+	for i := 0; i < n; i++ {
+		s[i] = byte(rapid.IntRange(0, 255).Draw(rt, label+"Byte"))
+	}
+	return s
+}
+
+// genMsgTx generates a structurally valid random transaction.  Script and
+// witness sizes are biased small like real traffic but occasionally exceed
+// the 16 KiB starting chunk class so the arena growth path is exercised.
+func genMsgTx(rt *rapid.T) *MsgTx {
+	tx := NewMsgTx(int32(rapid.IntRange(0, 2).Draw(rt, "version")))
+
+	// Most generated scripts are small, but roughly one in ten draws
+	// from a range that overflows the first chunk class.
+	scriptMax := 512
+	if rapid.IntRange(0, 9).Draw(rt, "bigScripts") == 0 {
+		scriptMax = 3 * scriptChunkClasses[0]
+	}
+
+	numIn := rapid.IntRange(1, 6).Draw(rt, "numIn")
+	hasWitness := rapid.Bool().Draw(rt, "hasWitness")
+	for i := 0; i < numIn; i++ {
+		ti := &TxIn{
+			PreviousOutPoint: OutPoint{
+				Index: uint32(rapid.IntRange(0, 1<<30).Draw(
+					rt, "prevIndex",
+				)),
+			},
+			SignatureScript: genScript(rt, "sigScript", scriptMax),
+			Sequence: uint32(
+				rapid.IntRange(0, 1<<30).Draw(rt, "sequence"),
+			),
+		}
+		for j := range ti.PreviousOutPoint.Hash {
+			ti.PreviousOutPoint.Hash[j] = byte(
+				rapid.IntRange(0, 255).Draw(rt, "prevHash"),
+			)
+		}
+
+		// When the transaction is witnessy every input carries a
+		// (possibly empty) non-nil witness stack, matching what the
+		// decoder produces.
+		if hasWitness {
+			numItems := rapid.IntRange(0, 3).Draw(rt, "numWitness")
+			ti.Witness = make(TxWitness, numItems)
+			for j := 0; j < numItems; j++ {
+				ti.Witness[j] = genScript(
+					rt, "witnessItem", scriptMax,
+				)
+			}
+		}
+
+		tx.AddTxIn(ti)
+	}
+
+	// A witness marker with zero total witness items is rejected by the
+	// decoder (and never produced by the encoder), so force at least one
+	// item when the transaction claims to be witnessy.
+	if hasWitness && !tx.HasWitness() {
+		tx.TxIn[0].Witness = TxWitness{
+			genScript(rt, "forcedWitness", scriptMax),
+		}
+	}
+
+	numOut := rapid.IntRange(0, 6).Draw(rt, "numOut")
+	for i := 0; i < numOut; i++ {
+		tx.AddTxOut(&TxOut{
+			Value: int64(
+				rapid.IntRange(0, 1<<40).Draw(rt, "value"),
+			),
+			PkScript: genScript(rt, "pkScript", scriptMax),
+		})
+	}
+
+	tx.LockTime = uint32(rapid.IntRange(0, 1<<30).Draw(rt, "lockTime"))
+
+	return tx
+}
+
+// TestScriptArenaPropertyTxRoundTrip checks two properties over random
+// transactions: serialize/deserialize is the identity, and the decoded
+// transaction owns all of its memory (poisoning the arena chunk pools after
+// the decode must not change it).
+func TestScriptArenaPropertyTxRoundTrip(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		tx := genMsgTx(rt)
+
+		var wireBuf bytes.Buffer
+		require.NoError(rt, tx.Serialize(&wireBuf))
+
+		var decoded MsgTx
+		err := decoded.Deserialize(bytes.NewReader(wireBuf.Bytes()))
+		require.NoError(rt, err)
+
+		var reserialized bytes.Buffer
+		require.NoError(rt, decoded.Serialize(&reserialized))
+		require.Equal(rt, wireBuf.Bytes(), reserialized.Bytes())
+
+		// If the decoded transaction aliased arena memory, poisoning
+		// the pools would corrupt its scripts and the second
+		// serialization would differ.
+		poisonScriptChunkPools()
+
+		var afterPoison bytes.Buffer
+		require.NoError(rt, decoded.Serialize(&afterPoison))
+		require.Equal(rt, wireBuf.Bytes(), afterPoison.Bytes())
+	})
+}
+
+// TestScriptArenaPropertyBlockRoundTrip checks the same round-trip and
+// ownership properties for full blocks, which share a single arena across
+// all of their transactions.
+func TestScriptArenaPropertyBlockRoundTrip(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		block := &MsgBlock{Header: blockOne.Header}
+		numTxs := rapid.IntRange(1, 8).Draw(rt, "numTxs")
+		for i := 0; i < numTxs; i++ {
+			block.AddTransaction(genMsgTx(rt))
+		}
+
+		var wireBuf bytes.Buffer
+		require.NoError(rt, block.Serialize(&wireBuf))
+
+		var decoded MsgBlock
+		err := decoded.Deserialize(bytes.NewReader(wireBuf.Bytes()))
+		require.NoError(rt, err)
+
+		var reserialized bytes.Buffer
+		require.NoError(rt, decoded.Serialize(&reserialized))
+		require.Equal(rt, wireBuf.Bytes(), reserialized.Bytes())
+
+		poisonScriptChunkPools()
+
+		var afterPoison bytes.Buffer
+		require.NoError(rt, decoded.Serialize(&afterPoison))
+		require.Equal(rt, wireBuf.Bytes(), afterPoison.Bytes())
+	})
+}
+
+// TestScriptArenaPropertyAllocator drives the raw allocator with random
+// alloc/rewind sequences against a simple model, checking capacity
+// accounting and that live allocations never alias one another.
+func TestScriptArenaPropertyAllocator(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		startClass := rapid.IntRange(
+			0, len(scriptChunkClasses)-1,
+		).Draw(rt, "startClass")
+
+		ar := borrowScriptArena(startClass)
+		defer ar.release()
+
+		type allocation struct {
+			s      []byte
+			marker byte
+		}
+		var live []allocation
+		modelUsed := 0
+
+		verifyLive := func() {
+			for _, a := range live {
+				for _, b := range a.s {
+					require.Equal(rt, a.marker, b)
+				}
+			}
+		}
+
+		steps := rapid.IntRange(1, 60).Draw(rt, "steps")
+		for i := 0; i < steps; i++ {
+			if rapid.IntRange(0, 9).Draw(rt, "op") == 0 {
+				verifyLive()
+				ar.rewind()
+				live = live[:0]
+				modelUsed = 0
+				require.LessOrEqual(rt, len(ar.chunks), 1)
+				continue
+			}
+
+			n := rapid.IntRange(0, 300_000).Draw(rt, "n")
+			s, err := ar.alloc(n)
+
+			// The model predicts exactly when allocation fails.
+			if n > scriptArenaMaxAlloc-modelUsed {
+				require.ErrorIs(
+					rt, err, errScriptArenaFull,
+				)
+				continue
+			}
+			require.NoError(rt, err)
+			require.Len(rt, s, n)
+			require.Equal(rt, n, cap(s))
+			modelUsed += n
+			require.Equal(
+				rt, scriptArenaMaxAlloc-modelUsed,
+				ar.remaining(),
+			)
+
+			marker := byte(len(live) % 251)
+			for j := range s {
+				s[j] = marker
+			}
+			live = append(live, allocation{s: s, marker: marker})
+		}
+		verifyLive()
+	})
+}
+
+// TestScriptArenaReleaseSafety exercises the misuse guards: double release
+// is a no-op, and a released arena refuses to allocate even after a rewind.
+func TestScriptArenaReleaseSafety(t *testing.T) {
+	ar := borrowScriptArena(txScriptChunkClass)
+	_, err := ar.alloc(128)
+	require.NoError(t, err)
+
+	ar.release()
+
+	// Allocating through a stale reference must fail loudly.
+	_, err = ar.alloc(1)
+	require.ErrorIs(t, err, errScriptArenaFull)
+
+	// A rewind must not resurrect a released arena.
+	ar.rewind()
+	_, err = ar.alloc(1)
+	require.ErrorIs(t, err, errScriptArenaFull)
+
+	// Double release must be a no-op rather than double-inserting the
+	// arena into the pool.
+	ar.release()
+
+	// A fresh borrow resets the poisoned state.
+	fresh := borrowScriptArena(txScriptChunkClass)
+	defer fresh.release()
+	s, err := fresh.alloc(32)
+	require.NoError(t, err)
+	require.Len(t, s, 32)
+}

--- a/wire/arena_rapid_test.go
+++ b/wire/arena_rapid_test.go
@@ -201,9 +201,8 @@ func TestScriptArenaPropertyAllocator(t *testing.T) {
 
 		verifyLive := func() {
 			for _, a := range live {
-				for _, b := range a.s {
-					require.Equal(rt, a.marker, b)
-				}
+				count := bytes.Count(a.s, []byte{a.marker})
+				require.Equal(rt, len(a.s), count)
 			}
 		}
 
@@ -245,6 +244,24 @@ func TestScriptArenaPropertyAllocator(t *testing.T) {
 		}
 		verifyLive()
 	})
+}
+
+// TestReadTxOutOwnedScript ensures the script returned by the exported
+// ReadTxOut owns its memory: the arena used to stage it is recycled when
+// ReadTxOut returns, so a script still aliasing arena memory would be
+// corrupted by the pool poisoning below.
+func TestReadTxOutOwnedScript(t *testing.T) {
+	orig := blockOne.Transactions[0].TxOut[0]
+	var buf bytes.Buffer
+	require.NoError(t, WriteTxOut(&buf, 0, 0, orig))
+
+	var txOut TxOut
+	require.NoError(t, ReadTxOut(bytes.NewReader(buf.Bytes()), 0, 0, &txOut))
+	require.Equal(t, orig.PkScript, txOut.PkScript)
+
+	poisonScriptChunkPools()
+
+	require.Equal(t, orig.PkScript, txOut.PkScript)
 }
 
 // TestScriptArenaReleaseSafety exercises the misuse guards: double release

--- a/wire/arena_rapid_test.go
+++ b/wire/arena_rapid_test.go
@@ -264,8 +264,9 @@ func TestReadTxOutOwnedScript(t *testing.T) {
 	require.Equal(t, orig.PkScript, txOut.PkScript)
 }
 
-// TestScriptArenaReleaseSafety exercises the misuse guards: double release
-// is a no-op, and a released arena refuses to allocate even after a rewind.
+// TestScriptArenaReleaseSafety exercises the misuse guards within a single
+// ownership interval: double release is a no-op, and a released arena refuses
+// to allocate even after a rewind.
 func TestScriptArenaReleaseSafety(t *testing.T) {
 	ar := borrowScriptArena(txScriptChunkClass)
 	_, err := ar.alloc(128)

--- a/wire/arena_rapid_test.go
+++ b/wire/arena_rapid_test.go
@@ -12,25 +12,12 @@ import (
 	"pgregory.net/rapid"
 )
 
-// poisonScriptChunkPools scribbles a poison pattern over chunks sitting in
-// the class pools.  Any decoded message that still aliases arena memory
-// (rather than owning an exact-size copy of its scripts) will have its
-// contents corrupted by this, so re-verifying a message after poisoning
-// proves that no arena memory escaped the decode.
-func poisonScriptChunkPools() {
-	for _, pool := range scriptChunkPools {
-		// Pull a handful of chunks out of each pool, poison them, and
-		// put them back.  This reaches the chunks released by recent
-		// decodes on this P.
-		var chunks []*[]byte
-		for i := 0; i < 4; i++ {
-			chunks = append(chunks, pool.get())
-		}
-		for _, chunk := range chunks {
-			for i := range *chunk {
-				(*chunk)[i] = 0xaa
-			}
-			pool.put(chunk)
+// poisonScriptArena scribbles over the exact chunks used by a decode. A
+// decoded transaction that still aliases its staging arena will be corrupted.
+func poisonScriptArena(ar *scriptArena) {
+	for _, chunk := range ar.chunks {
+		for i := range *chunk {
+			(*chunk)[i] = 0xaa
 		}
 	}
 }
@@ -122,8 +109,8 @@ func genMsgTx(rt *rapid.T) *MsgTx {
 
 // TestScriptArenaPropertyTxRoundTrip checks two properties over random
 // transactions: serialize/deserialize is the identity, and the decoded
-// transaction owns all of its memory (poisoning the arena chunk pools after
-// the decode must not change it).
+// transaction owns all of its memory after its exact staging chunks are
+// overwritten.
 func TestScriptArenaPropertyTxRoundTrip(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
 		tx := genMsgTx(rt)
@@ -131,18 +118,25 @@ func TestScriptArenaPropertyTxRoundTrip(t *testing.T) {
 		var wireBuf bytes.Buffer
 		require.NoError(rt, tx.Serialize(&wireBuf))
 
+		ar := borrowScriptArena(txScriptChunkClass)
+		defer ar.release()
+
+		buf := binarySerializer.Borrow()
+		defer binarySerializer.Return(buf)
+
 		var decoded MsgTx
-		err := decoded.Deserialize(bytes.NewReader(wireBuf.Bytes()))
+		err := decoded.btcDecode(
+			bytes.NewReader(wireBuf.Bytes()), 0, WitnessEncoding, buf, ar,
+		)
 		require.NoError(rt, err)
 
 		var reserialized bytes.Buffer
 		require.NoError(rt, decoded.Serialize(&reserialized))
 		require.Equal(rt, wireBuf.Bytes(), reserialized.Bytes())
 
-		// If the decoded transaction aliased arena memory, poisoning
-		// the pools would corrupt its scripts and the second
-		// serialization would differ.
-		poisonScriptChunkPools()
+		// Overwrite the exact chunks used by this decode rather than
+		// relying on a later pool lookup to return the same chunks.
+		poisonScriptArena(ar)
 
 		var afterPoison bytes.Buffer
 		require.NoError(rt, decoded.Serialize(&afterPoison))
@@ -150,9 +144,8 @@ func TestScriptArenaPropertyTxRoundTrip(t *testing.T) {
 	})
 }
 
-// TestScriptArenaPropertyBlockRoundTrip checks the same round-trip and
-// ownership properties for full blocks, which share a single arena across
-// all of their transactions.
+// TestScriptArenaPropertyBlockRoundTrip checks round-trip stability for full
+// blocks, including the rewinds performed while transactions share an arena.
 func TestScriptArenaPropertyBlockRoundTrip(t *testing.T) {
 	rapid.Check(t, func(rt *rapid.T) {
 		block := &MsgBlock{Header: blockOne.Header}
@@ -172,11 +165,15 @@ func TestScriptArenaPropertyBlockRoundTrip(t *testing.T) {
 		require.NoError(rt, decoded.Serialize(&reserialized))
 		require.Equal(rt, wireBuf.Bytes(), reserialized.Bytes())
 
-		poisonScriptChunkPools()
+		// Decode the serialized block again to exercise arena reuse, then
+		// verify the first decoded block remains stable.
+		var again MsgBlock
+		err = again.Deserialize(bytes.NewReader(reserialized.Bytes()))
+		require.NoError(rt, err)
 
-		var afterPoison bytes.Buffer
-		require.NoError(rt, decoded.Serialize(&afterPoison))
-		require.Equal(rt, wireBuf.Bytes(), afterPoison.Bytes())
+		var afterReuse bytes.Buffer
+		require.NoError(rt, decoded.Serialize(&afterReuse))
+		require.Equal(rt, wireBuf.Bytes(), afterReuse.Bytes())
 	})
 }
 
@@ -247,9 +244,7 @@ func TestScriptArenaPropertyAllocator(t *testing.T) {
 }
 
 // TestReadTxOutOwnedScript ensures the script returned by the exported
-// ReadTxOut owns its memory: the arena used to stage it is recycled when
-// ReadTxOut returns, so a script still aliasing arena memory would be
-// corrupted by the pool poisoning below.
+// ReadTxOut has an exact-sized backing allocation owned by the output.
 func TestReadTxOutOwnedScript(t *testing.T) {
 	orig := blockOne.Transactions[0].TxOut[0]
 	var buf bytes.Buffer
@@ -258,10 +253,7 @@ func TestReadTxOutOwnedScript(t *testing.T) {
 	var txOut TxOut
 	require.NoError(t, ReadTxOut(bytes.NewReader(buf.Bytes()), 0, 0, &txOut))
 	require.Equal(t, orig.PkScript, txOut.PkScript)
-
-	poisonScriptChunkPools()
-
-	require.Equal(t, orig.PkScript, txOut.PkScript)
+	require.Equal(t, len(txOut.PkScript), cap(txOut.PkScript))
 }
 
 // TestScriptArenaReleaseSafety exercises the misuse guards within a single

--- a/wire/arena_rapid_test.go
+++ b/wire/arena_rapid_test.go
@@ -6,6 +6,7 @@ package wire
 
 import (
 	"bytes"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -246,6 +247,24 @@ func TestScriptArenaPropertyAllocator(t *testing.T) {
 // TestReadTxOutOwnedScript ensures the script returned by the exported
 // ReadTxOut has an exact-sized backing allocation owned by the output.
 func TestReadTxOutOwnedScript(t *testing.T) {
+	class := txScriptChunkClass
+	size := scriptChunkClasses[class]
+	testPool := &chunkClassPool{
+		fixed: make(chan *[]byte, 1),
+		pool: sync.Pool{
+			New: func() interface{} {
+				chunk := make([]byte, size)
+				return &chunk
+			},
+		},
+	}
+
+	origPool := scriptChunkPools[class]
+	scriptChunkPools[class] = testPool
+	t.Cleanup(func() {
+		scriptChunkPools[class] = origPool
+	})
+
 	orig := blockOne.Transactions[0].TxOut[0]
 	var buf bytes.Buffer
 	require.NoError(t, WriteTxOut(&buf, 0, 0, orig))
@@ -254,6 +273,15 @@ func TestReadTxOutOwnedScript(t *testing.T) {
 	require.NoError(t, ReadTxOut(bytes.NewReader(buf.Bytes()), 0, 0, &txOut))
 	require.Equal(t, orig.PkScript, txOut.PkScript)
 	require.Equal(t, len(txOut.PkScript), cap(txOut.PkScript))
+
+	// ReadTxOut releases its staging arena before returning. Pull the exact
+	// chunk back out of the isolated pool and overwrite it to ensure the
+	// returned script does not alias staging memory.
+	chunk := testPool.get()
+	for i := range *chunk {
+		(*chunk)[i] = 0xaa
+	}
+	require.Equal(t, orig.PkScript, txOut.PkScript)
 }
 
 // TestScriptArenaReleaseSafety exercises the misuse guards within a single

--- a/wire/arena_rapid_test.go
+++ b/wire/arena_rapid_test.go
@@ -96,9 +96,7 @@ func genMsgTx(rt *rapid.T) *MsgTx {
 	numOut := rapid.IntRange(0, 6).Draw(rt, "numOut")
 	for i := 0; i < numOut; i++ {
 		tx.AddTxOut(&TxOut{
-			Value: int64(
-				rapid.IntRange(0, 1<<40).Draw(rt, "value"),
-			),
+			Value:    rapid.Int64Range(0, 1<<40).Draw(rt, "value"),
 			PkScript: genScript(rt, "pkScript", scriptMax),
 		})
 	}

--- a/wire/arena_test.go
+++ b/wire/arena_test.go
@@ -1,0 +1,255 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"math/rand"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestScriptArenaAlloc ensures basic allocation invariants: exact lengths,
+// capacity clamped to length, and no overlap between consecutive
+// allocations.
+func TestScriptArenaAlloc(t *testing.T) {
+	ar := borrowScriptArena(txScriptChunkClass)
+	defer ar.release()
+
+	sizes := []int{0, 1, 25, 512, 1000, 33}
+	allocs := make([][]byte, 0, len(sizes))
+	for _, size := range sizes {
+		s, err := ar.alloc(size)
+		require.NoError(t, err)
+		require.Len(t, s, size)
+		require.Equal(t, size, cap(s))
+
+		// Fill the allocation with a marker so overlap with any
+		// other allocation is detectable below.
+		for i := range s {
+			s[i] = byte(len(allocs))
+		}
+		allocs = append(allocs, s)
+	}
+
+	// Every allocation must still hold its own marker; a bump allocator
+	// bug that handed out overlapping memory would have clobbered one of
+	// the earlier allocations.
+	for marker, s := range allocs {
+		for _, b := range s {
+			require.Equal(t, byte(marker), b)
+		}
+	}
+}
+
+// TestScriptArenaGrowth ensures the arena walks up the chunk size class
+// ladder as demand grows and that a single allocation larger than the next
+// class skips ahead to a class that fits it.
+func TestScriptArenaGrowth(t *testing.T) {
+	ar := borrowScriptArena(txScriptChunkClass)
+	defer ar.release()
+
+	// The first allocation draws the starting class.
+	_, err := ar.alloc(100)
+	require.NoError(t, err)
+	require.Len(t, ar.chunks, 1)
+	require.Equal(t, scriptChunkClasses[0], len(*ar.chunks[0]))
+
+	// Exhausting the first chunk must borrow the next class up.
+	_, err = ar.alloc(scriptChunkClasses[0])
+	require.NoError(t, err)
+	require.Len(t, ar.chunks, 2)
+	require.Equal(t, scriptChunkClasses[1], len(*ar.chunks[1]))
+
+	// An allocation bigger than the next class in the ladder must skip
+	// ahead to one that fits it in a single chunk.
+	_, err = ar.alloc(scriptChunkClasses[2] + 1)
+	require.NoError(t, err)
+	require.Len(t, ar.chunks, 3)
+	require.Equal(
+		t, scriptChunkClasses[len(scriptChunkClasses)-1],
+		len(*ar.chunks[2]),
+	)
+}
+
+// TestScriptArenaCapacity ensures the arena enforces the per-transaction
+// staging limit that the fixed slab previously provided.
+func TestScriptArenaCapacity(t *testing.T) {
+	ar := borrowScriptArena(blockScriptChunkClass)
+	defer ar.release()
+
+	// Fill the arena right up to its capacity.
+	_, err := ar.alloc(scriptArenaMaxAlloc - 1)
+	require.NoError(t, err)
+	require.Equal(t, 1, ar.remaining())
+
+	_, err = ar.alloc(1)
+	require.NoError(t, err)
+	require.Equal(t, 0, ar.remaining())
+
+	// The next allocation must fail, and a rewind must restore the full
+	// capacity.
+	_, err = ar.alloc(1)
+	require.ErrorIs(t, err, errScriptArenaFull)
+
+	ar.rewind()
+	require.Equal(t, scriptArenaMaxAlloc, ar.remaining())
+
+	_, err = ar.alloc(1)
+	require.NoError(t, err)
+}
+
+// TestScriptArenaRewind ensures rewinding recycles the memory of the largest
+// chunk in place and returns the smaller warm-up chunks to their pools.
+func TestScriptArenaRewind(t *testing.T) {
+	ar := borrowScriptArena(txScriptChunkClass)
+	defer ar.release()
+
+	// Grow through two classes.
+	_, err := ar.alloc(scriptChunkClasses[0])
+	require.NoError(t, err)
+	_, err = ar.alloc(scriptChunkClasses[0])
+	require.NoError(t, err)
+	require.Len(t, ar.chunks, 2)
+	largest := *ar.chunks[1]
+
+	ar.rewind()
+
+	// Only the largest chunk survives the rewind and subsequent
+	// allocations are served from its start.
+	require.Len(t, ar.chunks, 1)
+	s, err := ar.alloc(8)
+	require.NoError(t, err)
+	require.Equal(t, &largest[0], &s[0])
+}
+
+// TestScriptArenaDecodeGrowth decodes a transaction whose script data
+// overflows the starting chunk class for standalone transactions, ensuring
+// the decode path grows the arena transparently rather than erroring like
+// the old fixed-buffer bounds check would have.
+func TestScriptArenaDecodeGrowth(t *testing.T) {
+	// Build a transaction with a signature script comfortably larger
+	// than the 16 KiB starting chunk.
+	bigScript := make([]byte, 3*scriptChunkClasses[0])
+	rng := rand.New(rand.NewSource(1337))
+	rng.Read(bigScript)
+
+	tx := NewMsgTx(1)
+	tx.AddTxIn(&TxIn{
+		PreviousOutPoint: OutPoint{Index: 0xffffffff},
+		SignatureScript:  bigScript,
+		Sequence:         0xffffffff,
+	})
+	tx.AddTxOut(NewTxOut(0, []byte{0x51}))
+
+	var buf bytes.Buffer
+	require.NoError(t, tx.Serialize(&buf))
+
+	var decoded MsgTx
+	require.NoError(t, decoded.Deserialize(bytes.NewReader(buf.Bytes())))
+	require.Equal(t, bigScript, decoded.TxIn[0].SignatureScript)
+}
+
+// TestScriptArenaConcurrentDecode exercises the chunk pools from many
+// goroutines at once to give the race detector a chance to catch unsound
+// sharing between arenas.
+func TestScriptArenaConcurrentDecode(t *testing.T) {
+	// Serialize one small and one multi-input transaction as shared
+	// decode inputs.
+	var smallTxBuf, multiTxBuf bytes.Buffer
+	require.NoError(t, blockOne.Transactions[0].Serialize(&smallTxBuf))
+	require.NoError(t, multiTx.Serialize(&multiTxBuf))
+
+	const numWorkers = 16
+	const decodesPerWorker = 200
+
+	var wg sync.WaitGroup
+	errs := make(chan error, numWorkers)
+	for w := 0; w < numWorkers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < decodesPerWorker; i++ {
+				var tx1, tx2 MsgTx
+				err := tx1.Deserialize(
+					bytes.NewReader(smallTxBuf.Bytes()),
+				)
+				if err != nil {
+					errs <- err
+					return
+				}
+				err = tx2.Deserialize(
+					bytes.NewReader(multiTxBuf.Bytes()),
+				)
+				if err != nil {
+					errs <- err
+					return
+				}
+
+				// Verify the decoded scripts match the
+				// originals so cross-arena aliasing would
+				// surface as corruption.
+				if !bytes.Equal(
+					tx2.TxIn[0].SignatureScript,
+					multiTx.TxIn[0].SignatureScript,
+				) {
+					errs <- errScriptArenaFull
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}
+
+// TestScriptArenaRandomizedAllocations drives the arena with a deterministic
+// random allocation/rewind pattern and checks that live allocations never
+// alias each other.
+func TestScriptArenaRandomizedAllocations(t *testing.T) {
+	rng := rand.New(rand.NewSource(42))
+
+	for round := 0; round < 50; round++ {
+		startClass := rng.Intn(len(scriptChunkClasses))
+		ar := borrowScriptArena(startClass)
+
+		for rewinds := 0; rewinds < 4; rewinds++ {
+			var live [][]byte
+			for ar.remaining() > 0 && rng.Float64() > 0.05 {
+				n := rng.Intn(64 << 10)
+				if n > ar.remaining() {
+					n = ar.remaining()
+				}
+
+				s, err := ar.alloc(n)
+				require.NoError(t, err)
+				require.Len(t, s, n)
+
+				marker := byte(len(live))
+				for i := range s {
+					s[i] = marker
+				}
+				live = append(live, s)
+			}
+
+			// All live allocations must retain their markers.
+			for marker, s := range live {
+				for _, b := range s {
+					require.Equal(t, byte(marker), b)
+				}
+			}
+
+			ar.rewind()
+			require.LessOrEqual(t, len(ar.chunks), 1)
+		}
+
+		ar.release()
+	}
+}

--- a/wire/arena_test.go
+++ b/wire/arena_test.go
@@ -6,6 +6,7 @@ package wire
 
 import (
 	"bytes"
+	"fmt"
 	"math/rand"
 	"sync"
 	"testing"
@@ -40,9 +41,9 @@ func TestScriptArenaAlloc(t *testing.T) {
 	// bug that handed out overlapping memory would have clobbered one of
 	// the earlier allocations.
 	for marker, s := range allocs {
-		for _, b := range s {
-			require.Equal(t, byte(marker), b)
-		}
+		require.Equal(
+			t, len(s), bytes.Count(s, []byte{byte(marker)}),
+		)
 	}
 }
 
@@ -197,7 +198,9 @@ func TestScriptArenaConcurrentDecode(t *testing.T) {
 					tx2.TxIn[0].SignatureScript,
 					multiTx.TxIn[0].SignatureScript,
 				) {
-					errs <- errScriptArenaFull
+					errs <- fmt.Errorf("cross-arena " +
+						"aliasing: decoded script " +
+						"mismatch")
 					return
 				}
 			}
@@ -241,9 +244,10 @@ func TestScriptArenaRandomizedAllocations(t *testing.T) {
 
 			// All live allocations must retain their markers.
 			for marker, s := range live {
-				for _, b := range s {
-					require.Equal(t, byte(marker), b)
-				}
+				require.Equal(
+					t, len(s),
+					bytes.Count(s, []byte{byte(marker)}),
+				)
 			}
 
 			ar.rewind()

--- a/wire/arena_test.go
+++ b/wire/arena_test.go
@@ -130,8 +130,7 @@ func TestScriptArenaRewind(t *testing.T) {
 
 // TestScriptArenaDecodeGrowth decodes a transaction whose script data
 // overflows the starting chunk class for standalone transactions, ensuring
-// the decode path grows the arena transparently rather than erroring like
-// the old fixed-buffer bounds check would have.
+// the decode path grows the arena transparently.
 func TestScriptArenaDecodeGrowth(t *testing.T) {
 	// Build a transaction with a signature script comfortably larger
 	// than the 16 KiB starting chunk.

--- a/wire/bench_parallel_test.go
+++ b/wire/bench_parallel_test.go
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"compress/bzip2"
+	"io"
+	"os"
+	"testing"
+)
+
+// smallTxBytes returns the serialization of a typical small transaction,
+// mirroring the payload used by BenchmarkDeserializeTxSmall.
+func smallTxBytes() []byte {
+	return []byte{
+		0x01, 0x00, 0x00, 0x00, // Version
+		0x01, // Varint for number of input transactions
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // Previous output hash
+		0xff, 0xff, 0xff, 0xff, // Previous output index
+		0x07,                                     // Varint for length of signature script
+		0x04, 0xff, 0xff, 0x00, 0x1d, 0x01, 0x04, // Signature script
+		0xff, 0xff, 0xff, 0xff, // Sequence
+		0x01,                                           // Varint for number of output transactions
+		0x00, 0xf2, 0x05, 0x2a, 0x01, 0x00, 0x00, 0x00, // Transaction amount
+		0x43, // Varint for length of pk script
+		0x41, // OP_DATA_65
+		0x04, 0x96, 0xb5, 0x38, 0xe8, 0x53, 0x51, 0x9c,
+		0x72, 0x6a, 0x2c, 0x91, 0xe6, 0x1e, 0xc1, 0x16,
+		0x00, 0xae, 0x13, 0x90, 0x81, 0x3a, 0x62, 0x7c,
+		0x66, 0xfb, 0x8b, 0xe7, 0x94, 0x7b, 0xe6, 0x3c,
+		0x52, 0xda, 0x75, 0x89, 0x37, 0x95, 0x15, 0xd4,
+		0xe0, 0xa6, 0x04, 0xf8, 0x14, 0x17, 0x81, 0xe6,
+		0x22, 0x94, 0x72, 0x11, 0x66, 0xbf, 0x62, 0x1e,
+		0x73, 0xa8, 0x2c, 0xbf, 0x23, 0x42, 0xc8, 0x58,
+		0xee,                   // 65-byte signature
+		0xac,                   // OP_CHECKSIG
+		0x00, 0x00, 0x00, 0x00, // Lock time
+	}
+}
+
+// BenchmarkDeserializeTxSmallParallel measures small transaction decoding
+// with all CPUs decoding concurrently, which models many peers relaying
+// mempool transactions at once.  This stresses contention on the shared
+// script staging pool as well as the transient memory borrowed per decode.
+func BenchmarkDeserializeTxSmallParallel(b *testing.B) {
+	buf := smallTxBytes()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		r := bytes.NewReader(buf)
+		var tx MsgTx
+		for pb.Next() {
+			r.Seek(0, 0)
+			if err := tx.Deserialize(r); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkDeserializeTxLargeParallel measures concurrent decoding of a
+// very large transaction, exercising the staging buffer growth path from
+// every CPU at once.
+func BenchmarkDeserializeTxLargeParallel(b *testing.B) {
+	fi, err := os.Open("testdata/megatx.bin.bz2")
+	if err != nil {
+		b.Fatalf("Failed to read transaction data: %v", err)
+	}
+	defer fi.Close()
+	buf, err := io.ReadAll(bzip2.NewReader(fi))
+	if err != nil {
+		b.Fatalf("Failed to read transaction data: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		r := bytes.NewReader(buf)
+		var tx MsgTx
+		for pb.Next() {
+			r.Seek(0, 0)
+			if err := tx.Deserialize(r); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}
+
+// BenchmarkDeserializeBlockParallel measures concurrent decoding of a full
+// mainnet block from every CPU at once, which models parallel block
+// download during initial block sync.
+func BenchmarkDeserializeBlockParallel(b *testing.B) {
+	buf, err := os.ReadFile(
+		"testdata/block-00000000000000000021868c2cefc52a480d173c849412fe81c4e5ab806f94ab.blk",
+	)
+	if err != nil {
+		b.Fatalf("Failed to read block data: %v", err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		r := bytes.NewReader(buf)
+		var block MsgBlock
+		for pb.Next() {
+			r.Seek(0, 0)
+			if err := block.Deserialize(r); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+}

--- a/wire/bench_parallel_test.go
+++ b/wire/bench_parallel_test.go
@@ -60,7 +60,8 @@ func BenchmarkDeserializeTxSmallParallel(b *testing.B) {
 		for pb.Next() {
 			r.Seek(0, 0)
 			if err := tx.Deserialize(r); err != nil {
-				b.Fatal(err)
+				b.Error(err)
+				return
 			}
 		}
 	})
@@ -89,7 +90,8 @@ func BenchmarkDeserializeTxLargeParallel(b *testing.B) {
 		for pb.Next() {
 			r.Seek(0, 0)
 			if err := tx.Deserialize(r); err != nil {
-				b.Fatal(err)
+				b.Error(err)
+				return
 			}
 		}
 	})
@@ -115,7 +117,8 @@ func BenchmarkDeserializeBlockParallel(b *testing.B) {
 		for pb.Next() {
 			r.Seek(0, 0)
 			if err := block.Deserialize(r); err != nil {
-				b.Fatal(err)
+				b.Error(err)
+				return
 			}
 		}
 	})

--- a/wire/bench_test.go
+++ b/wire/bench_test.go
@@ -445,8 +445,7 @@ func BenchmarkReadTxOut(b *testing.B) {
 func BenchmarkReadTxOutBuf(b *testing.B) {
 	b.ReportAllocs()
 
-	scriptBuffer := scriptPool.Borrow()
-	sbuf := scriptBuffer[:]
+	ar := borrowScriptArena(txScriptChunkClass)
 	buffer := binarySerializer.Borrow()
 	buf := []byte{
 		0x00, 0xf2, 0x05, 0x2a, 0x01, 0x00, 0x00, 0x00, // Transaction amount
@@ -467,10 +466,11 @@ func BenchmarkReadTxOutBuf(b *testing.B) {
 	var txOut TxOut
 	for i := 0; i < b.N; i++ {
 		r.Seek(0, 0)
-		readTxOutBuf(r, 0, 0, &txOut, buffer, sbuf)
+		ar.rewind()
+		readTxOutBuf(r, 0, 0, &txOut, buffer, ar)
 	}
 	binarySerializer.Return(buffer)
-	scriptPool.Return(scriptBuffer)
+	ar.release()
 }
 
 // BenchmarkWriteTxOut performs a benchmark on how long it takes to write
@@ -502,8 +502,7 @@ func BenchmarkWriteTxOutBuf(b *testing.B) {
 func BenchmarkReadTxIn(b *testing.B) {
 	b.ReportAllocs()
 
-	scriptBuffer := scriptPool.Borrow()
-	sbuf := scriptBuffer[:]
+	ar := borrowScriptArena(txScriptChunkClass)
 	buffer := binarySerializer.Borrow()
 	buf := []byte{
 		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -519,10 +518,11 @@ func BenchmarkReadTxIn(b *testing.B) {
 	var txIn TxIn
 	for i := 0; i < b.N; i++ {
 		r.Seek(0, 0)
-		readTxInBuf(r, 0, 0, &txIn, buffer, sbuf)
+		ar.rewind()
+		readTxInBuf(r, 0, 0, &txIn, buffer, ar)
 	}
 	binarySerializer.Return(buffer)
-	scriptPool.Return(scriptBuffer)
+	ar.release()
 }
 
 // BenchmarkWriteTxIn performs a benchmark on how long it takes to write

--- a/wire/common.go
+++ b/wire/common.go
@@ -5,6 +5,7 @@
 package wire
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/binary"
 	"fmt"
@@ -22,8 +23,41 @@ const (
 	// binaryFreeListMaxItems is the number of buffers to keep in the free
 	// list to use for binary serialization and deserialization.
 	binaryFreeListMaxItems = 1024
+
+	// defaultReadBufferSize bounds speculative allocation when a reader does
+	// not expose the number of bytes it has remaining.
+	defaultReadBufferSize = 4096
 )
 
+// readBytes reads count bytes without allocating the full claimed size until
+// the reader proves that the bytes are available. Buffered message decoders
+// expose their remaining length, which preserves the single allocation fast
+// path for complete payloads. Streaming readers grow in small increments as
+// data arrives.
+func readBytes(r io.Reader, count uint64) ([]byte, error) {
+	if count == 0 {
+		return []byte{}, nil
+	}
+
+	type lenReader interface {
+		Len() int
+	}
+
+	if lr, ok := r.(lenReader); ok && count <= uint64(lr.Len()) {
+		result := make([]byte, count)
+		n, err := io.ReadFull(r, result)
+		return result[:n], err
+	}
+
+	var result bytes.Buffer
+	result.Grow(int(min(count, defaultReadBufferSize)))
+	n, err := io.CopyN(&result, r, int64(count))
+	if err == io.EOF && n > 0 {
+		err = io.ErrUnexpectedEOF
+	}
+
+	return result.Bytes(), err
+}
 var (
 	// littleEndian is a convenience variable since binary.LittleEndian is
 	// quite long.
@@ -663,8 +697,7 @@ func readVarStringBuf(r io.Reader, pver uint32, buf []byte) (string, error) {
 		return "", messageError("ReadVarString", str)
 	}
 
-	str := make([]byte, count)
-	_, err = io.ReadFull(r, str)
+	str, err := readBytes(r, count)
 	if err != nil {
 		return "", err
 	}
@@ -744,11 +777,11 @@ func ReadVarBytesBuf(r io.Reader, pver uint32, buf []byte, maxAllowed uint32,
 		return nil, messageError("ReadVarBytes", str)
 	}
 
-	bytes := make([]byte, count)
-	_, err = io.ReadFull(r, bytes)
+	bytes, err := readBytes(r, count)
 	if err != nil {
 		return nil, err
 	}
+
 	return bytes, nil
 }
 

--- a/wire/common.go
+++ b/wire/common.go
@@ -27,6 +27,10 @@ const (
 	// defaultReadBufferSize bounds speculative allocation when a reader does
 	// not expose the number of bytes it has remaining.
 	defaultReadBufferSize = 4096
+
+	// defaultStreamingElementCap bounds speculative vector allocation when a
+	// reader does not expose the number of bytes it has remaining.
+	defaultStreamingElementCap = 128
 )
 
 // readBytes reads count bytes without allocating the full claimed size until
@@ -78,17 +82,26 @@ func readerRemaining(r io.Reader) (uint64, bool) {
 func validateElementCount(r io.Reader, count,
 	minElementSize uint64) error {
 
+	_, err := canPreallocateElements(r, count, minElementSize)
+	return err
+}
+
+// canPreallocateElements reports whether a reader proves that the minimum
+// encoding for count elements is already buffered. Readers without a
+// measurable remainder must grow element storage as decoding makes progress.
+func canPreallocateElements(r io.Reader, count,
+	minElementSize uint64) (bool, error) {
+
 	remaining, ok := readerRemaining(r)
 	if !ok || minElementSize == 0 {
-		return nil
+		return false, nil
 	}
 
-	requiredBytes := count * minElementSize
-	if requiredBytes <= remaining {
-		return nil
+	if count <= remaining/minElementSize {
+		return true, nil
 	}
 
-	return elementCountError(remaining)
+	return false, elementCountError(remaining)
 }
 
 // elementCountError preserves the short-read error returned by the element

--- a/wire/common.go
+++ b/wire/common.go
@@ -39,11 +39,8 @@ func readBytes(r io.Reader, count uint64) ([]byte, error) {
 		return []byte{}, nil
 	}
 
-	type lenReader interface {
-		Len() int
-	}
-
-	if lr, ok := r.(lenReader); ok && count <= uint64(lr.Len()) {
+	remaining, known := readerRemaining(r)
+	if known && count <= remaining {
 		result := make([]byte, count)
 		n, err := io.ReadFull(r, result)
 		return result[:n], err
@@ -58,6 +55,52 @@ func readBytes(r io.Reader, count uint64) ([]byte, error) {
 
 	return result.Bytes(), err
 }
+
+// readerRemaining returns the number of buffered bytes exposed by the concrete
+// readers used by wire decoders. Other readers use the staged streaming path.
+func readerRemaining(r io.Reader) (uint64, bool) {
+	switch r := r.(type) {
+	case *bytes.Buffer:
+		return uint64(r.Len()), true
+
+	case *bytes.Reader:
+		return uint64(r.Len()), true
+
+	default:
+		return 0, false
+	}
+}
+
+// validateElementCount ensures a buffered payload has enough bytes remaining
+// to encode the claimed number of elements before a decoder allocates for the
+// count. The framed wire path passes a bytes.Buffer to each message decoder,
+// while callers without a measurable remainder retain streaming semantics.
+func validateElementCount(r io.Reader, count,
+	minElementSize uint64) error {
+
+	remaining, ok := readerRemaining(r)
+	if !ok || minElementSize == 0 {
+		return nil
+	}
+
+	requiredBytes := count * minElementSize
+	if requiredBytes <= remaining {
+		return nil
+	}
+
+	return elementCountError(remaining)
+}
+
+// elementCountError preserves the short-read error returned by the element
+// decoder when the claimed vector cannot fit in the remaining payload.
+func elementCountError(remaining uint64) error {
+	if remaining == 0 {
+		return io.EOF
+	}
+
+	return io.ErrUnexpectedEOF
+}
+
 var (
 	// littleEndian is a convenience variable since binary.LittleEndian is
 	// quite long.

--- a/wire/decode_budget_bench_test.go
+++ b/wire/decode_budget_bench_test.go
@@ -118,4 +118,49 @@ func BenchmarkTruncatedDecodeBudget(b *testing.B) {
 			}
 		}
 	})
+
+	b.Run("streaming_transaction_inputs", func(b *testing.B) {
+		payload := benchmarkCountPayload(
+			b, make([]byte, 4), maxTxInPerMessage,
+		)
+
+		ar := borrowScriptArena(txScriptChunkClass)
+		ar.release()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			reader := &readSizeRecorder{
+				reader: bytes.NewReader(payload),
+			}
+			var msg MsgTx
+			err := msg.BtcDecode(
+				reader, ProtocolVersion, WitnessEncoding,
+			)
+			if err == nil {
+				b.Fatal("expected a truncated transaction input error")
+			}
+		}
+	})
+
+	b.Run("streaming_filter_checkpoints", func(b *testing.B) {
+		payload := benchmarkCountPayload(
+			b, make([]byte, 33), maxCFHeadersLen,
+		)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			reader := &readSizeRecorder{
+				reader: bytes.NewReader(payload),
+			}
+			var msg MsgCFCheckpt
+			err := msg.BtcDecode(
+				reader, ProtocolVersion, BaseEncoding,
+			)
+			if err == nil {
+				b.Fatal("expected a truncated checkpoint error")
+			}
+		}
+	})
 }

--- a/wire/decode_budget_bench_test.go
+++ b/wire/decode_budget_bench_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"testing"
+)
+
+func benchmarkCountPayload(b *testing.B, prefix []byte, count uint64) []byte {
+	b.Helper()
+
+	var payload bytes.Buffer
+	if _, err := payload.Write(prefix); err != nil {
+		b.Fatalf("unable to write payload prefix: %v", err)
+	}
+	if err := WriteVarInt(&payload, ProtocolVersion, count); err != nil {
+		b.Fatalf("unable to write element count: %v", err)
+	}
+
+	return payload.Bytes()
+}
+
+// BenchmarkTruncatedDecodeBudget measures allocation when a length or element
+// count is present without the bytes needed to satisfy it.
+func BenchmarkTruncatedDecodeBudget(b *testing.B) {
+	b.Run("message_payload", func(b *testing.B) {
+		header := makeHeader(
+			MainNet, CmdBlock, MaxProtocolMessageLength, 0,
+		)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, _, _, err := ReadMessageN(
+				bytes.NewReader(header), ProtocolVersion, MainNet,
+			)
+			if err == nil {
+				b.Fatal("expected a truncated payload error")
+			}
+		}
+	})
+
+	b.Run("variable_bytes", func(b *testing.B) {
+		payload := benchmarkCountPayload(
+			b, nil, MaxProtocolMessageLength,
+		)
+		payload = append(payload, 0x01)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			_, err := ReadVarBytes(
+				bytes.NewReader(payload), ProtocolVersion,
+				MaxMessagePayload, "payload",
+			)
+			if err == nil {
+				b.Fatal("expected a truncated byte payload error")
+			}
+		}
+	})
+
+	b.Run("inventory", func(b *testing.B) {
+		payload := benchmarkCountPayload(b, nil, MaxInvPerMsg)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var msg MsgInv
+			err := msg.BtcDecode(
+				bytes.NewReader(payload), ProtocolVersion, BaseEncoding,
+			)
+			if err == nil {
+				b.Fatal("expected a truncated inventory error")
+			}
+		}
+	})
+
+	b.Run("merkle_hashes", func(b *testing.B) {
+		payload := benchmarkCountPayload(
+			b, make([]byte, MaxBlockHeaderPayload+4), maxTxPerBlock,
+		)
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var msg MsgMerkleBlock
+			err := msg.BtcDecode(
+				bytes.NewReader(payload), ProtocolVersion, BaseEncoding,
+			)
+			if err == nil {
+				b.Fatal("expected a truncated merkle block error")
+			}
+		}
+	})
+
+	b.Run("transaction_inputs", func(b *testing.B) {
+		payload := benchmarkCountPayload(
+			b, make([]byte, 4), maxTxInPerMessage,
+		)
+
+		// Prewarm the script arena so the comparison isolates the count-sized
+		// transaction input allocation changed by this patch.
+		ar := borrowScriptArena(txScriptChunkClass)
+		ar.release()
+
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var msg MsgTx
+			err := msg.BtcDecode(
+				bytes.NewReader(payload), ProtocolVersion, WitnessEncoding,
+			)
+			if err == nil {
+				b.Fatal("expected a truncated transaction input error")
+			}
+		}
+	})
+}

--- a/wire/decode_budget_test.go
+++ b/wire/decode_budget_test.go
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"io"
+	"testing"
+)
+
+// TestTruncatedVariableBytesBudget ensures inner length prefixes grow memory
+// with bytes delivered rather than with the claimed length.
+func TestTruncatedVariableBytesBudget(t *testing.T) {
+	var encoded bytes.Buffer
+	if err := WriteVarInt(&encoded, ProtocolVersion, MaxMessagePayload); err != nil {
+		t.Fatalf("unable to encode length: %v", err)
+	}
+	prefix := encoded.Bytes()
+
+	truncated := append(bytes.Clone(prefix), 0x01)
+	reader := &readSizeRecorder{reader: bytes.NewReader(truncated)}
+	decoded, err := ReadVarBytes(
+		reader, ProtocolVersion, MaxMessagePayload,
+		"payload",
+	)
+	if err == nil {
+		t.Fatal("expected a truncated byte payload error")
+	}
+	if decoded != nil {
+		t.Fatalf("decoded %d bytes on error", len(decoded))
+	}
+	if reader.max > defaultReadBufferSize {
+		t.Fatalf("byte payload read requested %d bytes, want at most %d",
+			reader.max, defaultReadBufferSize)
+	}
+
+	reader = &readSizeRecorder{reader: bytes.NewReader(truncated)}
+	decodedString, err := ReadVarString(
+		reader, ProtocolVersion,
+	)
+	if err == nil {
+		t.Fatal("expected a truncated string error")
+	}
+	if decodedString != "" {
+		t.Fatalf("decoded %d string bytes on error", len(decodedString))
+	}
+	if reader.max > defaultReadBufferSize {
+		t.Fatalf("string payload read requested %d bytes, want at most %d",
+			reader.max, defaultReadBufferSize)
+	}
+
+	result, err := readBytes(
+		&readSizeRecorder{reader: bytes.NewReader([]byte{0x01})},
+		MaxMessagePayload,
+	)
+	if err == nil {
+		t.Fatal("expected a truncated direct read error")
+	}
+	if len(result) != 1 {
+		t.Fatalf("direct read returned %d bytes, want 1", len(result))
+	}
+	if capacity := cap(result); capacity > defaultReadBufferSize {
+		t.Fatalf("direct read reserved %d bytes, want at most %d", capacity,
+			defaultReadBufferSize)
+	}
+}
+
+type readSizeRecorder struct {
+	reader io.Reader
+	max    int
+}
+
+type inflatedLenReader struct {
+	reader io.Reader
+	length int
+}
+
+func (r *inflatedLenReader) Read(p []byte) (int, error) {
+	return r.reader.Read(p)
+}
+
+func (r *inflatedLenReader) Len() int {
+	return r.length
+}
+
+func (r *readSizeRecorder) Read(p []byte) (int, error) {
+	if len(p) > r.max {
+		r.max = len(p)
+	}
+
+	return r.reader.Read(p)
+}
+
+// TestTruncatedMessagePayloadBudget ensures the v1 frame reader does not
+// reserve or request the full payload after receiving only its header.
+func TestTruncatedMessagePayloadBudget(t *testing.T) {
+	header := makeHeader(
+		MainNet, CmdBlock, MaxProtocolMessageLength, 0,
+	)
+	reader := &readSizeRecorder{reader: bytes.NewReader(header)}
+	_, _, _, err := ReadMessageN(reader, ProtocolVersion, MainNet)
+	if err == nil {
+		t.Fatal("expected a truncated payload error")
+	}
+	if reader.max > defaultReadBufferSize {
+		t.Fatalf("payload read requested %d bytes, want at most %d",
+			reader.max, defaultReadBufferSize)
+	}
+
+	payload := append(makeHeader(MainNet, CmdPing, 8, 0), 0x01)
+	faultingReader := &inflatedLenReader{
+		reader: bytes.NewReader(payload),
+		length: len(payload) + 8,
+	}
+	totalBytes, _, _, err := ReadMessageN(
+		faultingReader, ProtocolVersion, MainNet,
+	)
+	if err == nil {
+		t.Fatal("expected a short payload error")
+	}
+	if totalBytes != len(payload) {
+		t.Fatalf("read counted %d bytes, want %d", totalBytes, len(payload))
+	}
+}

--- a/wire/decode_budget_test.go
+++ b/wire/decode_budget_test.go
@@ -10,6 +10,241 @@ import (
 	"testing"
 )
 
+func countPayload(t *testing.T, prefix []byte, count uint64) []byte {
+	t.Helper()
+
+	var payload bytes.Buffer
+	_, err := payload.Write(prefix)
+	if err != nil {
+		t.Fatalf("unable to write payload prefix: %v", err)
+	}
+	if err := WriteVarInt(&payload, ProtocolVersion, count); err != nil {
+		t.Fatalf("unable to write element count: %v", err)
+	}
+
+	return payload.Bytes()
+}
+
+// TestTruncatedVectorDecodeBudget ensures a legal maximum element count cannot
+// reserve the corresponding maximum slice when no elements follow it.
+func TestTruncatedVectorDecodeBudget(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload []byte
+		decode  func(io.Reader) (int, error)
+		maxCap  int
+	}{
+		{
+			name:    "inventory",
+			payload: countPayload(t, nil, MaxInvPerMsg),
+			decode: func(r io.Reader) (int, error) {
+				var msg MsgInv
+				err := msg.BtcDecode(r, ProtocolVersion, BaseEncoding)
+				return cap(msg.InvList), err
+			},
+			maxCap: 0,
+		},
+		{
+			name:    "getdata",
+			payload: countPayload(t, nil, MaxInvPerMsg),
+			decode: func(r io.Reader) (int, error) {
+				var msg MsgGetData
+				err := msg.BtcDecode(r, ProtocolVersion, BaseEncoding)
+				return cap(msg.InvList), err
+			},
+			maxCap: 0,
+		},
+		{
+			name:    "notfound",
+			payload: countPayload(t, nil, MaxInvPerMsg),
+			decode: func(r io.Reader) (int, error) {
+				var msg MsgNotFound
+				err := msg.BtcDecode(r, ProtocolVersion, BaseEncoding)
+				return cap(msg.InvList), err
+			},
+			maxCap: 0,
+		},
+		{
+			name:    "addresses",
+			payload: countPayload(t, nil, MaxAddrPerMsg),
+			decode: func(r io.Reader) (int, error) {
+				var msg MsgAddr
+				err := msg.BtcDecode(r, ProtocolVersion, BaseEncoding)
+				return cap(msg.AddrList), err
+			},
+			maxCap: 0,
+		},
+		{
+			name:    "addresses v2",
+			payload: countPayload(t, nil, MaxV2AddrPerMsg),
+			decode: func(r io.Reader) (int, error) {
+				var msg MsgAddrV2
+				err := msg.BtcDecode(r, ProtocolVersion, BaseEncoding)
+				return cap(msg.AddrList), err
+			},
+			maxCap: 0,
+		},
+		{
+			name:    "headers",
+			payload: countPayload(t, nil, MaxBlockHeadersPerMsg),
+			decode: func(r io.Reader) (int, error) {
+				var msg MsgHeaders
+				err := msg.BtcDecode(r, ProtocolVersion, BaseEncoding)
+				return cap(msg.Headers), err
+			},
+			maxCap: 0,
+		},
+		{
+			name: "getblocks locators",
+			payload: countPayload(
+				t, make([]byte, 4), MaxBlockLocatorsPerMsg,
+			),
+			decode: func(r io.Reader) (int, error) {
+				var msg MsgGetBlocks
+				err := msg.BtcDecode(r, ProtocolVersion, BaseEncoding)
+				return cap(msg.BlockLocatorHashes), err
+			},
+			maxCap: 0,
+		},
+		{
+			name: "getheaders locators",
+			payload: countPayload(
+				t, make([]byte, 4), MaxBlockLocatorsPerMsg,
+			),
+			decode: func(r io.Reader) (int, error) {
+				var msg MsgGetHeaders
+				err := msg.BtcDecode(r, ProtocolVersion, BaseEncoding)
+				return cap(msg.BlockLocatorHashes), err
+			},
+			maxCap: 0,
+		},
+		{
+			name: "compact filter headers",
+			payload: countPayload(
+				t, make([]byte, 65), MaxCFHeadersPerMsg,
+			),
+			decode: func(r io.Reader) (int, error) {
+				var msg MsgCFHeaders
+				err := msg.BtcDecode(r, ProtocolVersion, BaseEncoding)
+				return cap(msg.FilterHashes), err
+			},
+			maxCap: 0,
+		},
+		{
+			name: "compact filter checkpoints",
+			payload: countPayload(
+				t, make([]byte, 33), maxCFHeadersLen,
+			),
+			decode: func(r io.Reader) (int, error) {
+				var msg MsgCFCheckpt
+				err := msg.BtcDecode(r, ProtocolVersion, BaseEncoding)
+				return cap(msg.FilterHeaders), err
+			},
+			maxCap: 0,
+		},
+		{
+			name: "merkle block hashes",
+			payload: countPayload(
+				t, make([]byte, MaxBlockHeaderPayload+4),
+				maxTxPerBlock,
+			),
+			decode: func(r io.Reader) (int, error) {
+				var msg MsgMerkleBlock
+				err := msg.BtcDecode(r, ProtocolVersion, BaseEncoding)
+				return cap(msg.Hashes), err
+			},
+			maxCap: 0,
+		},
+		{
+			name: "block transactions",
+			payload: countPayload(
+				t, make([]byte, MaxBlockHeaderPayload), maxTxPerBlock,
+			),
+			decode: func(r io.Reader) (int, error) {
+				var msg MsgBlock
+				err := msg.BtcDecode(r, ProtocolVersion, BaseEncoding)
+				return cap(msg.Transactions), err
+			},
+			maxCap: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			capacity, err := test.decode(bytes.NewReader(test.payload))
+			if err == nil {
+				t.Fatal("expected a truncated payload error")
+			}
+			if capacity > test.maxCap {
+				t.Fatalf("decode reserved %d elements, want at most %d",
+					capacity, test.maxCap)
+			}
+		})
+	}
+}
+
+// TestTruncatedTxDecodeBudget covers each count-driven transaction slice.
+func TestTruncatedTxDecodeBudget(t *testing.T) {
+	t.Run("inputs", func(t *testing.T) {
+		payload := countPayload(t, make([]byte, 4), maxTxInPerMessage)
+		var msg MsgTx
+		err := msg.BtcDecode(
+			bytes.NewReader(payload), ProtocolVersion, WitnessEncoding,
+		)
+		if err == nil {
+			t.Fatal("expected a truncated input error")
+		}
+		if len(msg.TxIn) != 0 {
+			t.Fatalf("decode retained %d inputs", len(msg.TxIn))
+		}
+	})
+
+	inputPrefix := make([]byte, 4)
+	inputPrefix = append(inputPrefix, 1)
+	inputPrefix = append(inputPrefix, make([]byte, minTxInPayload)...)
+
+	t.Run("outputs", func(t *testing.T) {
+		payload := countPayload(t, inputPrefix, maxTxOutPerMessage)
+		var msg MsgTx
+		err := msg.BtcDecode(
+			bytes.NewReader(payload), ProtocolVersion, WitnessEncoding,
+		)
+		if err == nil {
+			t.Fatal("expected a truncated output error")
+		}
+		if len(msg.TxOut) != 0 {
+			t.Fatalf("decode retained %d outputs", len(msg.TxOut))
+		}
+	})
+
+	t.Run("witness items", func(t *testing.T) {
+		witnessPrefix := make([]byte, 4)
+		witnessPrefix = append(witnessPrefix, TxFlagMarker, WitnessFlag, 1)
+		witnessPrefix = append(witnessPrefix, make([]byte, minTxInPayload)...)
+		witnessPrefix = append(witnessPrefix, 0)
+		payload := countPayload(
+			t, witnessPrefix, maxWitnessItemsPerInput,
+		)
+
+		var msg MsgTx
+		err := msg.BtcDecode(
+			bytes.NewReader(payload), ProtocolVersion, WitnessEncoding,
+		)
+		if err == nil {
+			t.Fatal("expected a truncated witness error")
+		}
+		if len(msg.TxIn) != 1 {
+			t.Fatalf("decoded %d inputs, want 1", len(msg.TxIn))
+		}
+		if capacity := cap(msg.TxIn[0].Witness); capacity >
+			defaultTxInOutAlloc {
+
+			t.Fatalf("decode reserved %d witness items, want at most %d",
+				capacity, defaultTxInOutAlloc)
+		}
+	})
+}
+
 // TestTruncatedVariableBytesBudget ensures inner length prefixes grow memory
 // with bytes delivered rather than with the claimed length.
 func TestTruncatedVariableBytesBudget(t *testing.T) {

--- a/wire/decode_budget_test.go
+++ b/wire/decode_budget_test.go
@@ -8,6 +8,8 @@ import (
 	"bytes"
 	"io"
 	"testing"
+
+	"github.com/btcsuite/btcd/chainhash/v2"
 )
 
 func countPayload(t *testing.T, prefix []byte, count uint64) []byte {
@@ -357,5 +359,97 @@ func TestTruncatedMessagePayloadBudget(t *testing.T) {
 	}
 	if totalBytes != len(payload) {
 		t.Fatalf("read counted %d bytes, want %d", totalBytes, len(payload))
+	}
+}
+
+// TestStreamingTxDecodeBudget verifies that transaction vectors grow as a
+// reader without a measurable remainder supplies each element. The element
+// counts cross the initial streaming capacity to exercise backing slice
+// growth and final pointer wiring.
+func TestStreamingTxDecodeBudget(t *testing.T) {
+	const elementCount = defaultStreamingElementCap + 42
+
+	msg := NewMsgTx(2)
+	for i := 0; i < elementCount; i++ {
+		hash := chainhash.Hash{byte(i), byte(i >> 8)}
+		prevOut := NewOutPoint(&hash, uint32(i))
+		witness := make([][]byte, elementCount)
+		for j := range witness {
+			witness[j] = []byte{byte(i), byte(j)}
+		}
+
+		msg.AddTxIn(NewTxIn(
+			prevOut, []byte{0x01, byte(i)}, witness,
+		))
+	}
+	for i := 0; i < elementCount; i++ {
+		msg.AddTxOut(NewTxOut(
+			int64(i), []byte{0x02, byte(i)},
+		))
+	}
+
+	var encoded bytes.Buffer
+	if err := msg.Serialize(&encoded); err != nil {
+		t.Fatalf("unable to encode transaction: %v", err)
+	}
+
+	reader := &readSizeRecorder{
+		reader: bytes.NewReader(encoded.Bytes()),
+	}
+	var decoded MsgTx
+	if err := decoded.BtcDecode(
+		reader, ProtocolVersion, WitnessEncoding,
+	); err != nil {
+		t.Fatalf("unable to decode transaction: %v", err)
+	}
+
+	var reencoded bytes.Buffer
+	if err := decoded.Serialize(&reencoded); err != nil {
+		t.Fatalf("unable to re-encode transaction: %v", err)
+	}
+	if !bytes.Equal(encoded.Bytes(), reencoded.Bytes()) {
+		t.Fatal("streaming transaction decode changed the encoding")
+	}
+}
+
+// TestStreamingCFCheckptDecodeBudget verifies that compact filter checkpoint
+// hashes grow as a reader without a measurable remainder supplies them.
+func TestStreamingCFCheckptDecodeBudget(t *testing.T) {
+	const headerCount = defaultStreamingElementCap + 42
+
+	stopHash := chainhash.Hash{0x01, 0x02, 0x03}
+	msg := NewMsgCFCheckpt(GCSFilterRegular, &stopHash, headerCount)
+	for i := 0; i < headerCount; i++ {
+		header := chainhash.Hash{byte(i), byte(i >> 8), 0x04}
+		if err := msg.AddCFHeader(&header); err != nil {
+			t.Fatalf("unable to add filter header: %v", err)
+		}
+	}
+
+	var encoded bytes.Buffer
+	if err := msg.BtcEncode(
+		&encoded, ProtocolVersion, BaseEncoding,
+	); err != nil {
+		t.Fatalf("unable to encode checkpoint: %v", err)
+	}
+
+	reader := &readSizeRecorder{
+		reader: bytes.NewReader(encoded.Bytes()),
+	}
+	var decoded MsgCFCheckpt
+	if err := decoded.BtcDecode(
+		reader, ProtocolVersion, BaseEncoding,
+	); err != nil {
+		t.Fatalf("unable to decode checkpoint: %v", err)
+	}
+
+	var reencoded bytes.Buffer
+	if err := decoded.BtcEncode(
+		&reencoded, ProtocolVersion, BaseEncoding,
+	); err != nil {
+		t.Fatalf("unable to re-encode checkpoint: %v", err)
+	}
+	if !bytes.Equal(encoded.Bytes(), reencoded.Bytes()) {
+		t.Fatal("streaming checkpoint decode changed the encoding")
 	}
 }

--- a/wire/fuzz_test.go
+++ b/wire/fuzz_test.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package wire
+
+import (
+	"bytes"
+	"testing"
+)
+
+// FuzzTxDecode feeds arbitrary bytes to the transaction decoder, which
+// stages script data in the decode arena.  Inputs that decode successfully
+// must round-trip: re-serializing and re-decoding yields the same bytes,
+// which would fail if any script aliased recycled arena memory or if the
+// arena handed out overlapping allocations.
+func FuzzTxDecode(f *testing.F) {
+	// Seed with existing test vectors: the block one coinbase, the
+	// multi input/output transaction, and a witness transaction.
+	var seed bytes.Buffer
+	if err := blockOne.Transactions[0].Serialize(&seed); err != nil {
+		f.Fatal(err)
+	}
+	f.Add(seed.Bytes())
+
+	seed.Reset()
+	if err := multiTx.Serialize(&seed); err != nil {
+		f.Fatal(err)
+	}
+	f.Add(seed.Bytes())
+
+	f.Add(multiWitnessTxEncoded)
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var tx MsgTx
+		if err := tx.Deserialize(bytes.NewReader(data)); err != nil {
+			return
+		}
+
+		var first bytes.Buffer
+		if err := tx.Serialize(&first); err != nil {
+			t.Fatalf("serialize after decode: %v", err)
+		}
+
+		var again MsgTx
+		err := again.Deserialize(bytes.NewReader(first.Bytes()))
+		if err != nil {
+			t.Fatalf("re-decode of serialized tx: %v", err)
+		}
+
+		var second bytes.Buffer
+		if err := again.Serialize(&second); err != nil {
+			t.Fatalf("serialize after re-decode: %v", err)
+		}
+		if !bytes.Equal(first.Bytes(), second.Bytes()) {
+			t.Fatal("tx serialization is not a fixed point")
+		}
+	})
+}
+
+// FuzzBlockDecode feeds arbitrary bytes to the block decoder, which shares
+// a single decode arena across every transaction in the block, rewinding it
+// between transactions.  Successful decodes must round-trip byte for byte.
+func FuzzBlockDecode(f *testing.F) {
+	var seed bytes.Buffer
+	if err := blockOne.Serialize(&seed); err != nil {
+		f.Fatal(err)
+	}
+	f.Add(seed.Bytes())
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var block MsgBlock
+		if err := block.Deserialize(bytes.NewReader(data)); err != nil {
+			return
+		}
+
+		var first bytes.Buffer
+		if err := block.Serialize(&first); err != nil {
+			t.Fatalf("serialize after decode: %v", err)
+		}
+
+		var again MsgBlock
+		err := again.Deserialize(bytes.NewReader(first.Bytes()))
+		if err != nil {
+			t.Fatalf("re-decode of serialized block: %v", err)
+		}
+
+		var second bytes.Buffer
+		if err := again.Serialize(&second); err != nil {
+			t.Fatalf("serialize after re-decode: %v", err)
+		}
+		if !bytes.Equal(first.Bytes(), second.Bytes()) {
+			t.Fatal("block serialization is not a fixed point")
+		}
+	})
+}

--- a/wire/fuzz_test.go
+++ b/wire/fuzz_test.go
@@ -11,9 +11,8 @@ import (
 
 // FuzzTxDecode feeds arbitrary bytes to the transaction decoder, which
 // stages script data in the decode arena.  Inputs that decode successfully
-// must round-trip: re-serializing and re-decoding yields the same bytes,
-// which would fail if any script aliased recycled arena memory or if the
-// arena handed out overlapping allocations.
+// must round-trip: re-serializing and re-decoding yields the same bytes, and
+// the first decoded transaction remains stable after the second decode.
 func FuzzTxDecode(f *testing.F) {
 	// Seed with existing test vectors: the block one coinbase, the
 	// multi input/output transaction, and a witness transaction.
@@ -55,12 +54,21 @@ func FuzzTxDecode(f *testing.F) {
 		if !bytes.Equal(first.Bytes(), second.Bytes()) {
 			t.Fatal("tx serialization is not a fixed point")
 		}
+
+		var afterReuse bytes.Buffer
+		if err := tx.Serialize(&afterReuse); err != nil {
+			t.Fatalf("serialize first tx after re-decode: %v", err)
+		}
+		if !bytes.Equal(first.Bytes(), afterReuse.Bytes()) {
+			t.Fatal("first tx changed after arena reuse")
+		}
 	})
 }
 
 // FuzzBlockDecode feeds arbitrary bytes to the block decoder, which shares
 // a single decode arena across every transaction in the block, rewinding it
-// between transactions.  Successful decodes must round-trip byte for byte.
+// between transactions. Successful decodes must round-trip byte for byte, and
+// the first decoded block must remain stable after the second decode.
 func FuzzBlockDecode(f *testing.F) {
 	var seed bytes.Buffer
 	if err := blockOne.Serialize(&seed); err != nil {
@@ -91,6 +99,14 @@ func FuzzBlockDecode(f *testing.F) {
 		}
 		if !bytes.Equal(first.Bytes(), second.Bytes()) {
 			t.Fatal("block serialization is not a fixed point")
+		}
+
+		var afterReuse bytes.Buffer
+		if err := block.Serialize(&afterReuse); err != nil {
+			t.Fatalf("serialize first block after re-decode: %v", err)
+		}
+		if !bytes.Equal(first.Bytes(), afterReuse.Bytes()) {
+			t.Fatal("first block changed after arena reuse")
 		}
 	})
 }

--- a/wire/go.mod
+++ b/wire/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.40.0
+	pgregory.net/rapid v1.3.0
 )
 
 require (

--- a/wire/go.mod
+++ b/wire/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.40.0
+	pgregory.net/rapid v1.3.0
 )
 
 require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	pgregory.net/rapid v1.3.0 // indirect
 )

--- a/wire/go.mod
+++ b/wire/go.mod
@@ -13,4 +13,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	pgregory.net/rapid v1.3.0 // indirect
 )

--- a/wire/go.sum
+++ b/wire/go.sum
@@ -14,3 +14,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=

--- a/wire/message.go
+++ b/wire/message.go
@@ -672,10 +672,10 @@ func readMessageWithEncodingNInternal(r io.Reader, pver uint32,
 		return totalBytes, nil, nil, messageError("ReadMessage", str)
 	}
 
-	// Read payload.
-	payload := make([]byte, hdr.length)
-	n, err := io.ReadFull(r, payload)
-	totalBytes += n
+	// Read the payload as bytes arrive so a header cannot reserve the full
+	// claimed length on its own.
+	payload, err := readBytes(r, uint64(hdr.length))
+	totalBytes += len(payload)
 	if err != nil {
 		return totalBytes, nil, nil, err
 	}

--- a/wire/msgaddr.go
+++ b/wire/msgaddr.go
@@ -69,6 +69,11 @@ func (msg *MsgAddr) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) err
 			"[count %v, max %v]", count, MaxAddrPerMsg)
 		return messageError("MsgAddr.BtcDecode", str)
 	}
+	if err := validateElementCount(
+		r, count, minNetAddressPayload,
+	); err != nil {
+		return err
+	}
 
 	addrList := make([]NetAddress, count)
 	msg.AddrList = make([]*NetAddress, 0, count)

--- a/wire/msgaddrv2.go
+++ b/wire/msgaddrv2.go
@@ -32,6 +32,11 @@ func (m *MsgAddrV2) BtcDecode(r io.Reader, pver uint32,
 			" max %v]", count, MaxV2AddrPerMsg)
 		return messageError("MsgAddrV2.BtcDecode", str)
 	}
+	if err := validateElementCount(
+		r, count, minNetAddressV2Payload,
+	); err != nil {
+		return err
+	}
 
 	addrList := make([]NetAddressV2, count)
 	m.AddrList = make([]*NetAddressV2, 0, count)

--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -98,13 +98,17 @@ func (msg *MsgBlock) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) er
 		return messageError("MsgBlock.BtcDecode", str)
 	}
 
-	scriptBuf := scriptPool.Borrow()
-	defer scriptPool.Return(scriptBuf)
+	// A single arena is shared by every transaction in the block.  Each
+	// transaction's btcDecode rewinds it, which is safe because the
+	// scripts are copied into their final exactly-sized buffer before the
+	// next transaction is decoded.
+	ar := borrowScriptArena(blockScriptChunkClass)
+	defer ar.release()
 
 	msg.Transactions = make([]*MsgTx, 0, txCount)
 	for i := uint64(0); i < txCount; i++ {
 		tx := MsgTx{}
-		err := tx.btcDecode(r, pver, enc, buf, scriptBuf[:])
+		err := tx.btcDecode(r, pver, enc, buf, ar)
 		if err != nil {
 			return err
 		}
@@ -174,8 +178,8 @@ func (msg *MsgBlock) DeserializeTxLoc(r *bytes.Buffer) ([]TxLoc, error) {
 		return nil, messageError("MsgBlock.DeserializeTxLoc", str)
 	}
 
-	scriptBuf := scriptPool.Borrow()
-	defer scriptPool.Return(scriptBuf)
+	ar := borrowScriptArena(blockScriptChunkClass)
+	defer ar.release()
 
 	// Deserialize each transaction while keeping track of its location
 	// within the byte stream.
@@ -184,7 +188,7 @@ func (msg *MsgBlock) DeserializeTxLoc(r *bytes.Buffer) ([]TxLoc, error) {
 	for i := uint64(0); i < txCount; i++ {
 		txLocs[i].TxStart = fullLen - r.Len()
 		tx := MsgTx{}
-		err := tx.btcDecode(r, 0, WitnessEncoding, buf, scriptBuf[:])
+		err := tx.btcDecode(r, 0, WitnessEncoding, buf, ar)
 		if err != nil {
 			return nil, err
 		}

--- a/wire/msgblock.go
+++ b/wire/msgblock.go
@@ -97,6 +97,11 @@ func (msg *MsgBlock) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) er
 			"[count %d, max %d]", txCount, maxTxPerBlock)
 		return messageError("MsgBlock.BtcDecode", str)
 	}
+	if err := validateElementCount(
+		r, txCount, minTxPayload,
+	); err != nil {
+		return err
+	}
 
 	// A single arena is shared by every transaction in the block.  Each
 	// transaction's btcDecode rewinds it, which is safe because the
@@ -176,6 +181,11 @@ func (msg *MsgBlock) DeserializeTxLoc(r *bytes.Buffer) ([]TxLoc, error) {
 		str := fmt.Sprintf("too many transactions to fit into a block "+
 			"[count %d, max %d]", txCount, maxTxPerBlock)
 		return nil, messageError("MsgBlock.DeserializeTxLoc", str)
+	}
+	if err := validateElementCount(
+		r, txCount, minTxPayload,
+	); err != nil {
+		return nil, err
 	}
 
 	ar := borrowScriptArena(blockScriptChunkClass)

--- a/wire/msgcfcheckpt.go
+++ b/wire/msgcfcheckpt.go
@@ -83,6 +83,11 @@ func (msg *MsgCFCheckpt) BtcDecode(r io.Reader, pver uint32, _ MessageEncoding) 
 	if count > maxCFHeadersLen {
 		return ErrInsaneCFHeaderCount
 	}
+	if err := validateElementCount(
+		r, count, chainhash.HashSize,
+	); err != nil {
+		return err
+	}
 
 	if count == 0 {
 		msg.FilterHeaders = make([]*chainhash.Hash, 0)

--- a/wire/msgcfcheckpt.go
+++ b/wire/msgcfcheckpt.go
@@ -83,9 +83,10 @@ func (msg *MsgCFCheckpt) BtcDecode(r io.Reader, pver uint32, _ MessageEncoding) 
 	if count > maxCFHeadersLen {
 		return ErrInsaneCFHeaderCount
 	}
-	if err := validateElementCount(
+	preallocate, err := canPreallocateElements(
 		r, count, chainhash.HashSize,
-	); err != nil {
+	)
+	if err != nil {
 		return err
 	}
 
@@ -94,19 +95,40 @@ func (msg *MsgCFCheckpt) BtcDecode(r io.Reader, pver uint32, _ MessageEncoding) 
 		return nil
 	}
 
-	// Optimize memory allocation by creating a single backing array for
-	// all hashes. This reduces GC pressure and improves cache locality.
-	hashes := make([]chainhash.Hash, count)
-	msg.FilterHeaders = make([]*chainhash.Hash, count)
+	// Optimize memory allocation by creating a single backing array for all
+	// hashes. Buffered readers reserve the exact count, while streaming
+	// readers grow the array as hashes arrive.
+	var hashes []chainhash.Hash
+	if preallocate {
+		hashes = make([]chainhash.Hash, count)
+		msg.FilterHeaders = make([]*chainhash.Hash, count)
+	} else {
+		hashes = make(
+			[]chainhash.Hash, 0,
+			min(count, defaultStreamingElementCap),
+		)
+		msg.FilterHeaders = nil
+	}
 
 	// Now we'll read all the hashes directly into the backing array we've
 	// created above. We'll then point the underlying filter header hashes
 	// into this backing array.
 	for i := uint64(0); i < count; i++ {
+		if !preallocate {
+			hashes = append(hashes, chainhash.Hash{})
+		}
 		if _, err := io.ReadFull(r, hashes[i][:]); err != nil {
 			return err
 		}
-		msg.FilterHeaders[i] = &hashes[i]
+		if preallocate {
+			msg.FilterHeaders[i] = &hashes[i]
+		}
+	}
+	if !preallocate {
+		msg.FilterHeaders = make([]*chainhash.Hash, len(hashes))
+		for i := range hashes {
+			msg.FilterHeaders[i] = &hashes[i]
+		}
 	}
 
 	return nil

--- a/wire/msgcfheaders.go
+++ b/wire/msgcfheaders.go
@@ -80,6 +80,11 @@ func (msg *MsgCFHeaders) BtcDecode(r io.Reader, pver uint32, _ MessageEncoding) 
 			MaxBlockHeadersPerMsg)
 		return messageError("MsgCFHeaders.BtcDecode", str)
 	}
+	if err := validateElementCount(
+		r, count, chainhash.HashSize,
+	); err != nil {
+		return err
+	}
 
 	// Create a contiguous slice of hashes to deserialize into in order to
 	// reduce the number of allocations.

--- a/wire/msggetblocks.go
+++ b/wire/msggetblocks.go
@@ -70,6 +70,11 @@ func (msg *MsgGetBlocks) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding
 			"[count %v, max %v]", count, MaxBlockLocatorsPerMsg)
 		return messageError("MsgGetBlocks.BtcDecode", str)
 	}
+	if err := validateElementCount(
+		r, count, chainhash.HashSize,
+	); err != nil {
+		return err
+	}
 
 	// Create a contiguous slice of hashes to deserialize into in order to
 	// reduce the number of allocations.

--- a/wire/msggetdata.go
+++ b/wire/msggetdata.go
@@ -51,6 +51,11 @@ func (msg *MsgGetData) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) 
 		str := fmt.Sprintf("too many invvect in message [%v]", count)
 		return messageError("MsgGetData.BtcDecode", str)
 	}
+	if err := validateElementCount(
+		r, count, maxInvVectPayload,
+	); err != nil {
+		return err
+	}
 
 	// Create a contiguous slice of inventory vectors to deserialize into in
 	// order to reduce the number of allocations.

--- a/wire/msggetheaders.go
+++ b/wire/msggetheaders.go
@@ -67,6 +67,11 @@ func (msg *MsgGetHeaders) BtcDecode(r io.Reader, pver uint32, enc MessageEncodin
 			"[count %v, max %v]", count, MaxBlockLocatorsPerMsg)
 		return messageError("MsgGetHeaders.BtcDecode", str)
 	}
+	if err := validateElementCount(
+		r, count, chainhash.HashSize,
+	); err != nil {
+		return err
+	}
 
 	// Create a contiguous slice of hashes to deserialize into in order to
 	// reduce the number of allocations.

--- a/wire/msgheaders.go
+++ b/wire/msgheaders.go
@@ -51,6 +51,11 @@ func (msg *MsgHeaders) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) 
 			"[count %v, max %v]", count, MaxBlockHeadersPerMsg)
 		return messageError("MsgHeaders.BtcDecode", str)
 	}
+	if err := validateElementCount(
+		r, count, MaxBlockHeaderPayload+1,
+	); err != nil {
+		return err
+	}
 
 	// Create a contiguous slice of headers to deserialize into in order to
 	// reduce the number of allocations.

--- a/wire/msginv.go
+++ b/wire/msginv.go
@@ -59,6 +59,11 @@ func (msg *MsgInv) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) erro
 		str := fmt.Sprintf("too many invvect in message [%v]", count)
 		return messageError("MsgInv.BtcDecode", str)
 	}
+	if err := validateElementCount(
+		r, count, maxInvVectPayload,
+	); err != nil {
+		return err
+	}
 
 	// Create a contiguous slice of inventory vectors to deserialize into in
 	// order to reduce the number of allocations.

--- a/wire/msgmerkleblock.go
+++ b/wire/msgmerkleblock.go
@@ -72,6 +72,11 @@ func (msg *MsgMerkleBlock) BtcDecode(r io.Reader, pver uint32, enc MessageEncodi
 			"[count %v, max %v]", count, maxTxPerBlock)
 		return messageError("MsgMerkleBlock.BtcDecode", str)
 	}
+	if err := validateElementCount(
+		r, count, chainhash.HashSize,
+	); err != nil {
+		return err
+	}
 
 	// Create a contiguous slice of hashes to deserialize into in order to
 	// reduce the number of allocations.

--- a/wire/msgnotfound.go
+++ b/wire/msgnotfound.go
@@ -48,6 +48,11 @@ func (msg *MsgNotFound) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding)
 		str := fmt.Sprintf("too many invvect in message [%v]", count)
 		return messageError("MsgNotFound.BtcDecode", str)
 	}
+	if err := validateElementCount(
+		r, count, maxInvVectPayload,
+	); err != nil {
+		return err
+	}
 
 	// Create a contiguous slice of inventory vectors to deserialize into in
 	// order to reduce the number of allocations.

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -81,21 +81,6 @@ const (
 	// payload + min output payload.
 	minTxPayload = 10
 
-	// freeListMaxScriptSize is the size of each buffer in the free list
-	// that	is used for deserializing scripts from the wire before they are
-	// concatenated into a single contiguous buffers.  This value was chosen
-	// because it is slightly more than twice the size of the vast majority
-	// of all "standard" scripts.  Larger scripts are still deserialized
-	// properly as the free list will simply be bypassed for them.
-	freeListMaxScriptSize = 512
-
-	// freeListMaxItems is the number of buffers to keep in the free list
-	// to use for script deserialization.  This value allows up to 100
-	// scripts per transaction being simultaneously deserialized by 125
-	// peers.  Thus, the peak usage of the free list is 12,500 * 512 =
-	// 6,400,000 bytes.
-	freeListMaxItems = 125
-
 	// maxWitnessItemsPerInput is the maximum number of witness items to
 	// be read for the witness data for a single TxIn. This number is
 	// derived using a possible lower bound for the encoding of a witness
@@ -154,57 +139,6 @@ const (
 	// serialized transaction with witnesses from a legacy one.
 	WitnessFlag TxFlag = 0x01
 )
-
-const scriptSlabSize = 1 << 22
-
-type scriptSlab [scriptSlabSize]byte
-
-// scriptFreeList defines a free list of byte slices (up to the maximum number
-// defined by the freeListMaxItems constant) that have a cap according to the
-// freeListMaxScriptSize constant.  It is used to provide temporary buffers for
-// deserializing scripts in order to greatly reduce the number of allocations
-// required.
-//
-// The caller can obtain a buffer from the free list by calling the Borrow
-// function and should return it via the Return function when done using it.
-type scriptFreeList chan *scriptSlab
-
-// Borrow returns a byte slice from the free list with a length according the
-// provided size.  A new buffer is allocated if there are any items available.
-//
-// When the size is larger than the max size allowed for items on the free list
-// a new buffer of the appropriate size is allocated and returned.  It is safe
-// to attempt to return said buffer via the Return function as it will be
-// ignored and allowed to go the garbage collector.
-func (c scriptFreeList) Borrow() *scriptSlab {
-	var buf *scriptSlab
-	select {
-	case buf = <-c:
-	default:
-		buf = new(scriptSlab)
-	}
-	return buf
-}
-
-// Return puts the provided byte slice back on the free list when it has a cap
-// of the expected length.  The buffer is expected to have been obtained via
-// the Borrow function.  Any slices that are not of the appropriate size, such
-// as those whose size is greater than the largest allowed free list item size
-// are simply ignored so they can go to the garbage collector.
-func (c scriptFreeList) Return(buf *scriptSlab) {
-	// Return the buffer to the free list when it's not full.  Otherwise let
-	// it be garbage collected.
-	select {
-	case c <- buf:
-	default:
-		// Let it go to the garbage collector.
-	}
-}
-
-// Create the concurrent safe free list to use for script deserialization.  As
-// previously described, this free list is maintained to significantly reduce
-// the number of allocations.
-var scriptPool = make(scriptFreeList, freeListMaxItems)
 
 // OutPoint defines a bitcoin data type that is used to track previous
 // transaction outputs.
@@ -484,15 +418,20 @@ func (msg *MsgTx) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) error
 	buf := binarySerializer.Borrow()
 	defer binarySerializer.Return(buf)
 
-	sbuf := scriptPool.Borrow()
-	defer scriptPool.Return(sbuf)
+	ar := borrowScriptArena(txScriptChunkClass)
+	defer ar.release()
 
-	err := msg.btcDecode(r, pver, enc, buf, sbuf[:])
+	err := msg.btcDecode(r, pver, enc, buf, ar)
 	return err
 }
 
 func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
-	buf, sbuf []byte) error {
+	buf []byte, ar *scriptArena) error {
+
+	// Any script data staged by a previous transaction decoded with this
+	// arena has already been copied into its final exactly-sized buffer,
+	// so the arena memory can be reused from the start.
+	ar.rewind()
 
 	if _, err := io.ReadFull(r, buf[:4]); err != nil {
 		return err
@@ -548,12 +487,11 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 		// and needs to be returned to the pool on error.
 		ti := &txIns[i]
 		msg.TxIn[i] = ti
-		err = readTxInBuf(r, pver, msg.Version, ti, buf, sbuf)
+		err = readTxInBuf(r, pver, msg.Version, ti, buf, ar)
 		if err != nil {
 			return err
 		}
 		totalScriptSize += uint64(len(ti.SignatureScript))
-		sbuf = sbuf[len(ti.SignatureScript):]
 	}
 
 	count, err = ReadVarIntBuf(r, pver, buf)
@@ -579,12 +517,11 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 		// and needs to be returned to the pool on error.
 		to := &txOuts[i]
 		msg.TxOut[i] = to
-		err = readTxOutBuf(r, pver, msg.Version, to, buf, sbuf)
+		err = readTxOutBuf(r, pver, msg.Version, to, buf, ar)
 		if err != nil {
 			return err
 		}
 		totalScriptSize += uint64(len(to.PkScript))
-		sbuf = sbuf[len(to.PkScript):]
 	}
 
 	// If the transaction's flag byte isn't 0x00 at this point, then one or
@@ -614,13 +551,12 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 			txin.Witness = make([][]byte, witCount)
 			for j := uint64(0); j < witCount; j++ {
 				txin.Witness[j], err = readScriptBuf(
-					r, pver, buf, sbuf, "script witness item",
+					r, pver, buf, ar, "script witness item",
 				)
 				if err != nil {
 					return err
 				}
 				totalScriptSize += uint64(len(txin.Witness[j]))
-				sbuf = sbuf[len(txin.Witness[j]):]
 			}
 		}
 
@@ -1008,20 +944,22 @@ func writeOutPointBuf(w io.Writer, pver uint32, version int32, op *OutPoint,
 	return err
 }
 
-// readScript reads a variable length byte array that represents a transaction
-// script.  It is encoded as a varInt containing the length of the array
-// followed by the bytes themselves.  An error is returned if the length is
-// greater than the passed maxAllowed parameter which helps protect against
-// memory exhaustion attacks and forced panics through malformed messages.  The
-// fieldName parameter is only used for the error message so it provides more
-// context in the error.
+// readScriptBuf reads a variable length byte array that represents a
+// transaction script.  It is encoded as a varInt containing the length of the
+// array followed by the bytes themselves.  The script bytes are staged in the
+// provided arena, so the returned slice is only valid until the arena is
+// rewound or released.  An error is returned if the length is greater than
+// the max allowed script size which helps protect against memory exhaustion
+// attacks and forced panics through malformed messages.  The fieldName
+// parameter is only used for the error message so it provides more context in
+// the error.
 //
 // If b is non-nil, the provided buffer will be used for serializing small
 // values.  Otherwise a buffer will be drawn from the binarySerializer's pool
 // and return when the method finishes.
 //
 // NOTE: b MUST either be nil or at least an 8-byte slice.
-func readScriptBuf(r io.Reader, pver uint32, buf, s []byte,
+func readScriptBuf(r io.Reader, pver uint32, buf []byte, ar *scriptArena,
 	fieldName string) ([]byte, error) {
 
 	count, err := ReadVarIntBuf(r, pver, buf)
@@ -1039,20 +977,22 @@ func readScriptBuf(r io.Reader, pver uint32, buf, s []byte,
 		return nil, messageError("readScript", str)
 	}
 
-	// Ensure the claimed script length fits in the remaining
-	// decode slab.
-	if count > uint64(len(s)) {
+	// Stage the script in the decode arena.  This fails if the total
+	// script data staged for the transaction being decoded exceeds the
+	// arena capacity, which no valid transaction can reach.
+	s, err := ar.alloc(int(count))
+	if err != nil {
 		str := fmt.Sprintf("%s exceeds remaining buffer "+
 			"capacity [count %d, remaining %d]",
-			fieldName, count, len(s))
+			fieldName, count, ar.remaining())
 		return nil, messageError("readScript", str)
 	}
 
-	_, err = io.ReadFull(r, s[:count])
+	_, err = io.ReadFull(r, s)
 	if err != nil {
 		return nil, err
 	}
-	return s[:count], nil
+	return s, nil
 }
 
 // readTxInBuf reads the next sequence of bytes from r as a transaction input
@@ -1064,7 +1004,7 @@ func readScriptBuf(r io.Reader, pver uint32, buf, s []byte,
 //
 // NOTE: b MUST either be nil or at least an 8-byte slice.
 func readTxInBuf(r io.Reader, pver uint32, version int32, ti *TxIn,
-	buf, s []byte) error {
+	buf []byte, ar *scriptArena) error {
 
 	err := readOutPointBuf(r, pver, version, &ti.PreviousOutPoint, buf)
 	if err != nil {
@@ -1072,7 +1012,7 @@ func readTxInBuf(r io.Reader, pver uint32, version int32, ti *TxIn,
 	}
 
 	ti.SignatureScript, err = readScriptBuf(
-		r, pver, buf, s, "transaction input signature script",
+		r, pver, buf, ar, "transaction input signature script",
 	)
 	if err != nil {
 		return err
@@ -1113,13 +1053,25 @@ func writeTxInBuf(w io.Writer, pver uint32, version int32, ti *TxIn,
 // ReadTxOut reads the next sequence of bytes from r as a transaction output
 // (TxOut).
 func ReadTxOut(r io.Reader, pver uint32, version int32, to *TxOut) error {
-	var s scriptSlab
-
 	buf := binarySerializer.Borrow()
 	defer binarySerializer.Return(buf)
 
-	err := readTxOutBuf(r, pver, version, to, buf, s[:])
-	return err
+	ar := borrowScriptArena(txScriptChunkClass)
+	defer ar.release()
+
+	err := readTxOutBuf(r, pver, version, to, buf, ar)
+	if err != nil {
+		return err
+	}
+
+	// The script is staged in the arena, which is recycled once this
+	// function returns, so copy it into an exactly-sized allocation the
+	// returned output owns.
+	pkScript := make([]byte, len(to.PkScript))
+	copy(pkScript, to.PkScript)
+	to.PkScript = pkScript
+
+	return nil
 }
 
 // readTxOutBuf reads the next sequence of bytes from r as a transaction output
@@ -1127,7 +1079,7 @@ func ReadTxOut(r io.Reader, pver uint32, version int32, to *TxOut) error {
 // small values. Otherwise a buffer will be drawn from the binarySerializer's
 // pool and return when the method finishes.
 func readTxOutBuf(r io.Reader, pver uint32, version int32, to *TxOut,
-	buf, s []byte) error {
+	buf []byte, ar *scriptArena) error {
 
 	_, err := io.ReadFull(r, buf)
 	if err != nil {
@@ -1136,7 +1088,7 @@ func readTxOutBuf(r io.Reader, pver uint32, version int32, to *TxOut,
 	to.Value = int64(littleEndian.Uint64(buf))
 
 	to.PkScript, err = readScriptBuf(
-		r, pver, buf, s, "transaction output public key script",
+		r, pver, buf, ar, "transaction output public key script",
 	)
 	return err
 }

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -81,21 +81,6 @@ const (
 	// payload + min output payload.
 	minTxPayload = 10
 
-	// freeListMaxScriptSize is the size of each buffer in the free list
-	// that	is used for deserializing scripts from the wire before they are
-	// concatenated into a single contiguous buffers.  This value was chosen
-	// because it is slightly more than twice the size of the vast majority
-	// of all "standard" scripts.  Larger scripts are still deserialized
-	// properly as the free list will simply be bypassed for them.
-	freeListMaxScriptSize = 512
-
-	// freeListMaxItems is the number of buffers to keep in the free list
-	// to use for script deserialization.  This value allows up to 100
-	// scripts per transaction being simultaneously deserialized by 125
-	// peers.  Thus, the peak usage of the free list is 12,500 * 512 =
-	// 6,400,000 bytes.
-	freeListMaxItems = 125
-
 	// maxWitnessItemsPerInput is the maximum number of witness items to
 	// be read for the witness data for a single TxIn. This number is
 	// derived using a possible lower bound for the encoding of a witness
@@ -154,57 +139,6 @@ const (
 	// serialized transaction with witnesses from a legacy one.
 	WitnessFlag TxFlag = 0x01
 )
-
-const scriptSlabSize = 1 << 22
-
-type scriptSlab [scriptSlabSize]byte
-
-// scriptFreeList defines a free list of byte slices (up to the maximum number
-// defined by the freeListMaxItems constant) that have a cap according to the
-// freeListMaxScriptSize constant.  It is used to provide temporary buffers for
-// deserializing scripts in order to greatly reduce the number of allocations
-// required.
-//
-// The caller can obtain a buffer from the free list by calling the Borrow
-// function and should return it via the Return function when done using it.
-type scriptFreeList chan *scriptSlab
-
-// Borrow returns a byte slice from the free list with a length according the
-// provided size.  A new buffer is allocated if there are any items available.
-//
-// When the size is larger than the max size allowed for items on the free list
-// a new buffer of the appropriate size is allocated and returned.  It is safe
-// to attempt to return said buffer via the Return function as it will be
-// ignored and allowed to go the garbage collector.
-func (c scriptFreeList) Borrow() *scriptSlab {
-	var buf *scriptSlab
-	select {
-	case buf = <-c:
-	default:
-		buf = new(scriptSlab)
-	}
-	return buf
-}
-
-// Return puts the provided byte slice back on the free list when it has a cap
-// of the expected length.  The buffer is expected to have been obtained via
-// the Borrow function.  Any slices that are not of the appropriate size, such
-// as those whose size is greater than the largest allowed free list item size
-// are simply ignored so they can go to the garbage collector.
-func (c scriptFreeList) Return(buf *scriptSlab) {
-	// Return the buffer to the free list when it's not full.  Otherwise let
-	// it be garbage collected.
-	select {
-	case c <- buf:
-	default:
-		// Let it go to the garbage collector.
-	}
-}
-
-// Create the concurrent safe free list to use for script deserialization.  As
-// previously described, this free list is maintained to significantly reduce
-// the number of allocations.
-var scriptPool = make(scriptFreeList, freeListMaxItems)
 
 // OutPoint defines a bitcoin data type that is used to track previous
 // transaction outputs.
@@ -484,15 +418,20 @@ func (msg *MsgTx) BtcDecode(r io.Reader, pver uint32, enc MessageEncoding) error
 	buf := binarySerializer.Borrow()
 	defer binarySerializer.Return(buf)
 
-	sbuf := scriptPool.Borrow()
-	defer scriptPool.Return(sbuf)
+	ar := borrowScriptArena(txScriptChunkClass)
+	defer ar.release()
 
-	err := msg.btcDecode(r, pver, enc, buf, sbuf[:])
+	err := msg.btcDecode(r, pver, enc, buf, ar)
 	return err
 }
 
 func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
-	buf, sbuf []byte) error {
+	buf []byte, ar *scriptArena) error {
+
+	// Any script data staged by a previous transaction decoded with this
+	// arena has already been copied into its final exactly-sized buffer,
+	// so the arena memory can be reused from the start.
+	ar.rewind()
 
 	if _, err := io.ReadFull(r, buf[:4]); err != nil {
 		return err
@@ -544,16 +483,15 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 	txIns := make([]TxIn, count)
 	msg.TxIn = make([]*TxIn, count)
 	for i := uint64(0); i < count; i++ {
-		// The pointer is set now in case a script buffer is borrowed
-		// and needs to be returned to the pool on error.
+		// The pointer is assigned into the message before the decode
+		// call that populates it.
 		ti := &txIns[i]
 		msg.TxIn[i] = ti
-		err = readTxInBuf(r, pver, msg.Version, ti, buf, sbuf)
+		err = readTxInBuf(r, pver, msg.Version, ti, buf, ar)
 		if err != nil {
 			return err
 		}
 		totalScriptSize += uint64(len(ti.SignatureScript))
-		sbuf = sbuf[len(ti.SignatureScript):]
 	}
 
 	count, err = ReadVarIntBuf(r, pver, buf)
@@ -575,16 +513,15 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 	txOuts := make([]TxOut, count)
 	msg.TxOut = make([]*TxOut, count)
 	for i := uint64(0); i < count; i++ {
-		// The pointer is set now in case a script buffer is borrowed
-		// and needs to be returned to the pool on error.
+		// The pointer is assigned into the message before the decode
+		// call that populates it.
 		to := &txOuts[i]
 		msg.TxOut[i] = to
-		err = readTxOutBuf(r, pver, msg.Version, to, buf, sbuf)
+		err = readTxOutBuf(r, pver, msg.Version, to, buf, ar)
 		if err != nil {
 			return err
 		}
 		totalScriptSize += uint64(len(to.PkScript))
-		sbuf = sbuf[len(to.PkScript):]
 	}
 
 	// If the transaction's flag byte isn't 0x00 at this point, then one or
@@ -614,13 +551,12 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 			txin.Witness = make([][]byte, witCount)
 			for j := uint64(0); j < witCount; j++ {
 				txin.Witness[j], err = readScriptBuf(
-					r, pver, buf, sbuf, "script witness item",
+					r, pver, buf, ar, "script witness item",
 				)
 				if err != nil {
 					return err
 				}
 				totalScriptSize += uint64(len(txin.Witness[j]))
-				sbuf = sbuf[len(txin.Witness[j]):]
 			}
 		}
 
@@ -637,19 +573,18 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 	msg.LockTime = littleEndian.Uint32(buf[:4])
 
 	// Create a single allocation to house all of the scripts and set each
-	// input signature script and output public key script to the
-	// appropriate subslice of the overall contiguous buffer.  Then, return
-	// each individual script buffer back to the pool so they can be reused
-	// for future deserializations.  This is done because it significantly
-	// reduces the number of allocations the garbage collector needs to
-	// track, which in turn improves performance and drastically reduces the
-	// amount of runtime overhead that would otherwise be needed to keep
-	// track of millions of small allocations.
+	// input signature script, witness item, and output public key script
+	// to the appropriate subslice of the overall contiguous buffer.  This
+	// copies the scripts out of the transient decode arena into memory
+	// the transaction owns, which is what makes rewinding the arena for
+	// the next transaction safe.  A single backing allocation also
+	// significantly reduces the number of allocations the garbage
+	// collector needs to track, which in turn improves performance and
+	// drastically reduces the amount of runtime overhead that would
+	// otherwise be needed to keep track of millions of small allocations.
 	//
-	// NOTE: It is no longer valid to call the returnScriptBuffers closure
-	// after these blocks of code run because it is already done and the
-	// scripts in the transaction inputs and outputs no longer point to the
-	// buffers.
+	// NOTE: After these blocks of code run, no script in the transaction
+	// points into the arena any longer.
 	var offset uint64
 	scripts := make([]byte, totalScriptSize)
 	for i := 0; i < len(msg.TxIn); i++ {
@@ -1008,20 +943,22 @@ func writeOutPointBuf(w io.Writer, pver uint32, version int32, op *OutPoint,
 	return err
 }
 
-// readScript reads a variable length byte array that represents a transaction
-// script.  It is encoded as a varInt containing the length of the array
-// followed by the bytes themselves.  An error is returned if the length is
-// greater than the passed maxAllowed parameter which helps protect against
-// memory exhaustion attacks and forced panics through malformed messages.  The
-// fieldName parameter is only used for the error message so it provides more
-// context in the error.
+// readScriptBuf reads a variable length byte array that represents a
+// transaction script.  It is encoded as a varInt containing the length of the
+// array followed by the bytes themselves.  The script bytes are staged in the
+// provided arena, so the returned slice is only valid until the arena is
+// rewound or released.  An error is returned if the length is greater than
+// the max allowed script size which helps protect against memory exhaustion
+// attacks and forced panics through malformed messages.  The fieldName
+// parameter is only used for the error message so it provides more context in
+// the error.
 //
 // If b is non-nil, the provided buffer will be used for serializing small
 // values.  Otherwise a buffer will be drawn from the binarySerializer's pool
 // and return when the method finishes.
 //
 // NOTE: b MUST either be nil or at least an 8-byte slice.
-func readScriptBuf(r io.Reader, pver uint32, buf, s []byte,
+func readScriptBuf(r io.Reader, pver uint32, buf []byte, ar *scriptArena,
 	fieldName string) ([]byte, error) {
 
 	count, err := ReadVarIntBuf(r, pver, buf)
@@ -1039,20 +976,22 @@ func readScriptBuf(r io.Reader, pver uint32, buf, s []byte,
 		return nil, messageError("readScript", str)
 	}
 
-	// Ensure the claimed script length fits in the remaining
-	// decode slab.
-	if count > uint64(len(s)) {
+	// Stage the script in the decode arena.  This fails if the total
+	// script data staged for the transaction being decoded exceeds the
+	// arena capacity, which no valid transaction can reach.
+	s, err := ar.alloc(int(count))
+	if err != nil {
 		str := fmt.Sprintf("%s exceeds remaining buffer "+
 			"capacity [count %d, remaining %d]",
-			fieldName, count, len(s))
+			fieldName, count, ar.remaining())
 		return nil, messageError("readScript", str)
 	}
 
-	_, err = io.ReadFull(r, s[:count])
+	_, err = io.ReadFull(r, s)
 	if err != nil {
 		return nil, err
 	}
-	return s[:count], nil
+	return s, nil
 }
 
 // readTxInBuf reads the next sequence of bytes from r as a transaction input
@@ -1064,7 +1003,7 @@ func readScriptBuf(r io.Reader, pver uint32, buf, s []byte,
 //
 // NOTE: b MUST either be nil or at least an 8-byte slice.
 func readTxInBuf(r io.Reader, pver uint32, version int32, ti *TxIn,
-	buf, s []byte) error {
+	buf []byte, ar *scriptArena) error {
 
 	err := readOutPointBuf(r, pver, version, &ti.PreviousOutPoint, buf)
 	if err != nil {
@@ -1072,7 +1011,7 @@ func readTxInBuf(r io.Reader, pver uint32, version int32, ti *TxIn,
 	}
 
 	ti.SignatureScript, err = readScriptBuf(
-		r, pver, buf, s, "transaction input signature script",
+		r, pver, buf, ar, "transaction input signature script",
 	)
 	if err != nil {
 		return err
@@ -1113,13 +1052,25 @@ func writeTxInBuf(w io.Writer, pver uint32, version int32, ti *TxIn,
 // ReadTxOut reads the next sequence of bytes from r as a transaction output
 // (TxOut).
 func ReadTxOut(r io.Reader, pver uint32, version int32, to *TxOut) error {
-	var s scriptSlab
-
 	buf := binarySerializer.Borrow()
 	defer binarySerializer.Return(buf)
 
-	err := readTxOutBuf(r, pver, version, to, buf, s[:])
-	return err
+	ar := borrowScriptArena(txScriptChunkClass)
+	defer ar.release()
+
+	err := readTxOutBuf(r, pver, version, to, buf, ar)
+	if err != nil {
+		return err
+	}
+
+	// The script is staged in the arena, which is recycled once this
+	// function returns, so copy it into an exactly-sized allocation the
+	// returned output owns.
+	pkScript := make([]byte, len(to.PkScript))
+	copy(pkScript, to.PkScript)
+	to.PkScript = pkScript
+
+	return nil
 }
 
 // readTxOutBuf reads the next sequence of bytes from r as a transaction output
@@ -1127,7 +1078,7 @@ func ReadTxOut(r io.Reader, pver uint32, version int32, to *TxOut) error {
 // small values. Otherwise a buffer will be drawn from the binarySerializer's
 // pool and return when the method finishes.
 func readTxOutBuf(r io.Reader, pver uint32, version int32, to *TxOut,
-	buf, s []byte) error {
+	buf []byte, ar *scriptArena) error {
 
 	_, err := io.ReadFull(r, buf)
 	if err != nil {
@@ -1136,7 +1087,7 @@ func readTxOutBuf(r io.Reader, pver uint32, version int32, to *TxOut,
 	to.Value = int64(littleEndian.Uint64(buf))
 
 	to.PkScript, err = readScriptBuf(
-		r, pver, buf, s, "transaction output public key script",
+		r, pver, buf, ar, "transaction output public key script",
 	)
 	return err
 }

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -483,8 +483,8 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 	txIns := make([]TxIn, count)
 	msg.TxIn = make([]*TxIn, count)
 	for i := uint64(0); i < count; i++ {
-		// The pointer is set now in case a script buffer is borrowed
-		// and needs to be returned to the pool on error.
+		// The pointer is assigned into the message before the decode
+		// call that populates it.
 		ti := &txIns[i]
 		msg.TxIn[i] = ti
 		err = readTxInBuf(r, pver, msg.Version, ti, buf, ar)
@@ -513,8 +513,8 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 	txOuts := make([]TxOut, count)
 	msg.TxOut = make([]*TxOut, count)
 	for i := uint64(0); i < count; i++ {
-		// The pointer is set now in case a script buffer is borrowed
-		// and needs to be returned to the pool on error.
+		// The pointer is assigned into the message before the decode
+		// call that populates it.
 		to := &txOuts[i]
 		msg.TxOut[i] = to
 		err = readTxOutBuf(r, pver, msg.Version, to, buf, ar)
@@ -573,19 +573,18 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 	msg.LockTime = littleEndian.Uint32(buf[:4])
 
 	// Create a single allocation to house all of the scripts and set each
-	// input signature script and output public key script to the
-	// appropriate subslice of the overall contiguous buffer.  Then, return
-	// each individual script buffer back to the pool so they can be reused
-	// for future deserializations.  This is done because it significantly
-	// reduces the number of allocations the garbage collector needs to
-	// track, which in turn improves performance and drastically reduces the
-	// amount of runtime overhead that would otherwise be needed to keep
-	// track of millions of small allocations.
+	// input signature script, witness item, and output public key script
+	// to the appropriate subslice of the overall contiguous buffer.  This
+	// copies the scripts out of the transient decode arena into memory
+	// the transaction owns, which is what makes rewinding the arena for
+	// the next transaction safe.  A single backing allocation also
+	// significantly reduces the number of allocations the garbage
+	// collector needs to track, which in turn improves performance and
+	// drastically reduces the amount of runtime overhead that would
+	// otherwise be needed to keep track of millions of small allocations.
 	//
-	// NOTE: It is no longer valid to call the returnScriptBuffers closure
-	// after these blocks of code run because it is already done and the
-	// scripts in the transaction inputs and outputs no longer point to the
-	// buffers.
+	// NOTE: After these blocks of code run, no script in the transaction
+	// points into the arena any longer.
 	var offset uint64
 	scripts := make([]byte, totalScriptSize)
 	for i := 0; i < len(msg.TxIn); i++ {

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -477,6 +477,11 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 			maxTxInPerMessage)
 		return messageError("MsgTx.BtcDecode", str)
 	}
+	if err := validateElementCount(
+		r, count, minTxInPayload,
+	); err != nil {
+		return err
+	}
 
 	// Deserialize the inputs.
 	var totalScriptSize uint64
@@ -507,6 +512,11 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 			"max message size [count %d, max %d]", count,
 			maxTxOutPerMessage)
 		return messageError("MsgTx.BtcDecode", str)
+	}
+	if err := validateElementCount(
+		r, count, MinTxOutPayload,
+	); err != nil {
+		return err
 	}
 
 	// Deserialize the outputs.
@@ -543,6 +553,11 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 					"into max message size [count %d, max %d]",
 					witCount, maxWitnessItemsPerInput)
 				return messageError("MsgTx.BtcDecode", str)
+			}
+			if err := validateElementCount(
+				r, witCount, 1,
+			); err != nil {
+				return err
 			}
 
 			// Then for witCount number of stack items, each item

--- a/wire/msgtx.go
+++ b/wire/msgtx.go
@@ -477,26 +477,48 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 			maxTxInPerMessage)
 		return messageError("MsgTx.BtcDecode", str)
 	}
-	if err := validateElementCount(
+	preallocateInputs, err := canPreallocateElements(
 		r, count, minTxInPayload,
-	); err != nil {
+	)
+	if err != nil {
 		return err
 	}
 
 	// Deserialize the inputs.
 	var totalScriptSize uint64
-	txIns := make([]TxIn, count)
-	msg.TxIn = make([]*TxIn, count)
+	var txIns []TxIn
+	if preallocateInputs {
+		txIns = make([]TxIn, count)
+		msg.TxIn = make([]*TxIn, count)
+	} else {
+		txIns = make(
+			[]TxIn, 0, min(count, defaultStreamingElementCap),
+		)
+		msg.TxIn = nil
+	}
 	for i := uint64(0); i < count; i++ {
-		// The pointer is assigned into the message before the decode
-		// call that populates it.
+		if !preallocateInputs {
+			txIns = append(txIns, TxIn{})
+		}
+
+		// Buffered inputs can point into their final backing array before
+		// the decode call populates it. Streaming inputs are wired up once
+		// their backing array stops growing.
 		ti := &txIns[i]
-		msg.TxIn[i] = ti
+		if preallocateInputs {
+			msg.TxIn[i] = ti
+		}
 		err = readTxInBuf(r, pver, msg.Version, ti, buf, ar)
 		if err != nil {
 			return err
 		}
 		totalScriptSize += uint64(len(ti.SignatureScript))
+	}
+	if !preallocateInputs {
+		msg.TxIn = make([]*TxIn, len(txIns))
+		for i := range txIns {
+			msg.TxIn[i] = &txIns[i]
+		}
 	}
 
 	count, err = ReadVarIntBuf(r, pver, buf)
@@ -513,25 +535,47 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 			maxTxOutPerMessage)
 		return messageError("MsgTx.BtcDecode", str)
 	}
-	if err := validateElementCount(
+	preallocateOutputs, err := canPreallocateElements(
 		r, count, MinTxOutPayload,
-	); err != nil {
+	)
+	if err != nil {
 		return err
 	}
 
 	// Deserialize the outputs.
-	txOuts := make([]TxOut, count)
-	msg.TxOut = make([]*TxOut, count)
+	var txOuts []TxOut
+	if preallocateOutputs {
+		txOuts = make([]TxOut, count)
+		msg.TxOut = make([]*TxOut, count)
+	} else {
+		txOuts = make(
+			[]TxOut, 0, min(count, defaultStreamingElementCap),
+		)
+		msg.TxOut = nil
+	}
 	for i := uint64(0); i < count; i++ {
-		// The pointer is assigned into the message before the decode
-		// call that populates it.
+		if !preallocateOutputs {
+			txOuts = append(txOuts, TxOut{})
+		}
+
+		// Buffered outputs can point into their final backing array before
+		// the decode call populates it. Streaming outputs are wired up once
+		// their backing array stops growing.
 		to := &txOuts[i]
-		msg.TxOut[i] = to
+		if preallocateOutputs {
+			msg.TxOut[i] = to
+		}
 		err = readTxOutBuf(r, pver, msg.Version, to, buf, ar)
 		if err != nil {
 			return err
 		}
 		totalScriptSize += uint64(len(to.PkScript))
+	}
+	if !preallocateOutputs {
+		msg.TxOut = make([]*TxOut, len(txOuts))
+		for i := range txOuts {
+			msg.TxOut[i] = &txOuts[i]
+		}
 	}
 
 	// If the transaction's flag byte isn't 0x00 at this point, then one or
@@ -554,24 +598,37 @@ func (msg *MsgTx) btcDecode(r io.Reader, pver uint32, enc MessageEncoding,
 					witCount, maxWitnessItemsPerInput)
 				return messageError("MsgTx.BtcDecode", str)
 			}
-			if err := validateElementCount(
+			preallocateWitness, err := canPreallocateElements(
 				r, witCount, 1,
-			); err != nil {
+			)
+			if err != nil {
 				return err
 			}
 
 			// Then for witCount number of stack items, each item
 			// has a varint length prefix, followed by the witness
 			// item itself.
-			txin.Witness = make([][]byte, witCount)
+			if preallocateWitness {
+				txin.Witness = make([][]byte, witCount)
+			} else {
+				txin.Witness = make(
+					[][]byte, 0,
+					min(witCount, defaultStreamingElementCap),
+				)
+			}
 			for j := uint64(0); j < witCount; j++ {
-				txin.Witness[j], err = readScriptBuf(
+				item, err := readScriptBuf(
 					r, pver, buf, ar, "script witness item",
 				)
 				if err != nil {
 					return err
 				}
-				totalScriptSize += uint64(len(txin.Witness[j]))
+				if preallocateWitness {
+					txin.Witness[j] = item
+				} else {
+					txin.Witness = append(txin.Witness, item)
+				}
+				totalScriptSize += uint64(len(item))
 			}
 		}
 

--- a/wire/msgtx_test.go
+++ b/wire/msgtx_test.go
@@ -1168,17 +1168,17 @@ var multiWitnessTxEncodedNonZeroFlag = []byte{
 var multiWitnessTxPkScriptLocs = []int{58}
 
 // TestTxWitnessOverflowPanic ensures that decoding a witness tx where
-// cumulative witness item lengths exceed the script slab capacity
+// cumulative witness item lengths exceed the script arena capacity
 // returns a decode error instead of panicking on an out-of-bounds
 // slice.
 func TestTxWitnessOverflowPanic(t *testing.T) {
 	// Build a minimal witness tx with one input, zero outputs,
 	// and two witness items whose combined claimed lengths
-	// exceed the scriptSlabSize (4 MiB) decode buffer.
+	// exceed the scriptArenaMaxAlloc (4 MiB) decode limit.
 	//
-	// Item 1: 3 000 000 bytes  (fits in slab, < maxWitnessItemSize)
+	// Item 1: 3 000 000 bytes  (fits in arena, < maxWitnessItemSize)
 	// Item 2: 2 000 000 bytes  (passes maxWitnessItemSize but
-	//         overflows remaining slab capacity of ~1.19 MiB)
+	//         overflows remaining arena capacity of ~1.19 MiB)
 	const (
 		firstLen  = 3_000_000
 		secondLen = 2_000_000

--- a/wire/netaddress.go
+++ b/wire/netaddress.go
@@ -10,11 +10,17 @@ import (
 	"time"
 )
 
+const (
+	// minNetAddressPayload is the encoded size of an address without its
+	// optional timestamp.
+	minNetAddressPayload = 26
+)
+
 // maxNetAddressPayload returns the max payload size for a bitcoin NetAddress
 // based on the protocol version.
 func maxNetAddressPayload(pver uint32) uint32 {
 	// Services 8 bytes + ip 16 bytes + port 2 bytes.
-	plen := uint32(26)
+	plen := uint32(minNetAddressPayload)
 
 	// NetAddressTimeVersion added a timestamp field.
 	if pver >= NetAddressTimeVersion {

--- a/wire/netaddressv2.go
+++ b/wire/netaddressv2.go
@@ -14,6 +14,11 @@ import (
 )
 
 const (
+	// minNetAddressV2Payload is the minimum number of bytes needed to
+	// encode an address. An unknown network can carry an empty address, but
+	// still includes the timestamp, services, network ID, length, and port.
+	minNetAddressV2Payload = 9
+
 	// maxAddrV2Size is the maximum size an address may be in the addrv2
 	// message.
 	maxAddrV2Size = 512


### PR DESCRIPTION
In this PR, we replace the fixed 4 MiB script decode slab with a tiered arena allocator. Today every transaction decode borrows the full slab, even when the transaction contains only a few hundred bytes of script data. The channel-backed slab pool can also retain up to 125 slabs, or roughly 524 MB, outside the runtime's GC pressure heuristics. `ReadTxOut` goes a step further and returns a script backed by its staging slab, which keeps the full allocation live with the output.

The new arena draws from 16 KiB, 128 KiB, 1 MiB, and 4 MiB chunk classes. Standalone transactions and blocks both begin at 16 KiB. Block decoding shares one arena across the block and rewinds it after each transaction has copied its scripts into owned storage, so its live staging requirement is determined by the largest transaction rather than the aggregate block. Larger transactions promote through the chunk ladder on demand. The existing 4 MiB limit on staged bytes remains unchanged.

## Pooling and ownership

Each size class uses a `sync.Pool`, which keeps idle chunks visible to the runtime across GC cycles. The 1 MiB and 4 MiB classes also have bounded front caches of 16 and 8 chunks. Those caches cap deterministic retention at 48 MiB. Bursts beyond the front caches fall back to `sync.Pool` and remain reclaimable by the GC.

Arena storage has one lexical owner. A successful transaction decode copies every signature script, witness item, and output script into message-owned storage before the arena is rewound or released. `ReadTxOut` now makes the same ownership transfer and returns an exact-sized script. Release is idempotent, and use after release is rejected until the arena handle is borrowed again.

## Benchmarks

The following results compare public master at `ca0bb02cf` with this branch at `850492f46` on an Apple M4 Max using Go 1.26.1 on darwin/arm64.

The cold allocation measurements ran each benchmark once in a fresh process, repeated across ten processes:

```
                      │     master      │     arena      │
                      │      B/op       │      B/op      │
ReadTxOut-16             4096.20Ki ± 0%    20.85Ki ± 0%  -99.49% (p=0.000 n=10)
DeserializeTxSmall-16    4101.48Ki ± 0%    20.91Ki ± 0%  -99.49% (p=0.000 n=10)
DeserializeBlock-16        7.256Mi ± 0%     3.408Mi ± 0%  -53.03% (p=0.000 n=10)
```

Command, repeated ten times per benchmark and revision:

```
go test -run '^$' -bench '^Benchmark<Name>$' -benchmem -benchtime=1x -count=1 -cpu=16
```

The one-iteration timing samples are dominated by process and first-use noise, so the cold comparison is limited to allocation footprint.

Steady serial decode used eight one-second samples:

```
                      │    master     │    arena     │
                      │    sec/op     │    sec/op    │
ReadTxOut-16             66621.00n ± 21%   78.28n ± 3%  -99.88% (p=0.000 n=8)
DeserializeTxSmall-16       182.1n ±  1%   193.0n ± 5%    +6.01% (p=0.000 n=8)
DeserializeTxLarge-16       261.3µ ±  1%   260.3µ ± 1%         ~ (p=0.574 n=8)
DeserializeBlock-16         1.031m ±  2%   1.031m ± 2%         ~ (p=0.505 n=8)
```

```
go test -run '^$' -bench '^(BenchmarkReadTxOut|BenchmarkDeserializeTxSmall|BenchmarkDeserializeTxLarge|BenchmarkDeserializeBlock)$' -benchmem -benchtime=1s -count=8 -cpu=16
```

The parallel benchmark functions are new in this branch. For the base comparison, the same `bench_parallel_test.go` harness was applied unchanged to a detached master checkout. Ten base/head process pairs were run in alternating order:

```
                              │   master    │    arena    │
                              │   sec/op    │   sec/op    │
DeserializeTxLargeParallel-16    35.97µ ± 13%   48.87µ ± 9%  +35.85% (p=0.000 n=10)
DeserializeBlockParallel-16      220.2µ ± 14%   266.0µ ± 8%  +20.80% (p=0.002 n=10)
```

These parallel results expose the main throughput tradeoff for large transactions and blocks. The steady serial large-transaction and block paths are unchanged within noise, while parallel execution pays for allocator and pool coordination. The warm `B/op` figures do not include staging chunks retained by the pools, so they should not be read as peak or retained-memory measurements.

## Testing

The change adds table-driven allocator tests, Rapid property tests, concurrent decode coverage, and transaction/block fuzz targets. The ownership tests overwrite the exact chunks used by a decode before reserializing its result. The fuzz targets also reserialize the first decoded object after a second decode, checking that arena reuse leaves the earlier value stable.

The full repository unit suite, the wire suite under the race detector, `go vet`, and `git diff --check` pass on this branch.
