### PR TITLE
psbt: reject trailing final witness data

### DIFF
--- a/psbt/extractor.go
+++ b/psbt/extractor.go
@@ -46,24 +46,24 @@ func Extract(p *Packet) (*wire.MsgTx, error) {
 		// to extract that as well, parsing the lower-level transaction
 		// encoding.
 		if pInput.FinalScriptWitness != nil {
-			// In order to set the witness, need to re-deserialize
-			// the field as encoded within the PSBT packet.  For
-			// each input, the witness is encoded as a stack with
-			// one or more items.
+			// PSBT_IN_FINAL_SCRIPTWITNESS stores the complete
+			// scriptWitness for this transaction input. Decode that
+			// single serialized witness stack into TxWitness below.
 			witnessReader := bytes.NewReader(
 				pInput.FinalScriptWitness,
 			)
 
-			// First we extract the number of witness elements
-			// encoded in the above witnessReader.
+			// First extract the number of witness items encoded in
+			// the serialized scriptWitness.
 			witCount, err := wire.ReadVarInt(witnessReader, 0)
 			if err != nil {
 				return nil, err
 			}
 
-			// Now that we know how many inputs we'll need, we'll
-			// construct a packing slice, then read out each input
-			// (with a varint prefix) from the witnessReader.
+			// Allocate one slot per witness item, then read each
+			// varint-prefixed item from the witness value. The value
+			// must contain exactly this one stack, so the exhaustion
+			// check below rejects trailing bytes.
 			tin.Witness = make(wire.TxWitness, witCount)
 			for j := uint64(0); j < witCount; j++ {
 				wit, err := wire.ReadVarBytes(
@@ -74,6 +74,10 @@ func Extract(p *Packet) (*wire.MsgTx, error) {
 					return nil, err
 				}
 				tin.Witness[j] = wit
+			}
+
+			if err := assertFullyConsumed(witnessReader); err != nil {
+				return nil, err
 			}
 		}
 	}

--- a/psbt/psbt_test.go
+++ b/psbt/psbt_test.go
@@ -787,6 +787,32 @@ func TestPsbtExtractor(t *testing.T) {
 	}
 }
 
+// TestExtractRejectsTrailingFinalScriptWitnessData ensures a final witness
+// value must contain exactly one serialized witness stack.
+func TestExtractRejectsTrailingFinalScriptWitnessData(t *testing.T) {
+	tx := wire.NewMsgTx(2)
+	tx.AddTxIn(wire.NewTxIn(&wire.OutPoint{}, nil, nil))
+	tx.AddTxOut(wire.NewTxOut(0, []byte{0x6a}))
+
+	var witness bytes.Buffer
+	err := WriteTxWitness(&witness, [][]byte{{0x51}})
+	require.NoError(t, err)
+
+	finalWitness := append([]byte{}, witness.Bytes()...)
+	finalWitness = append(finalWitness, 0x00)
+
+	packet := &Packet{
+		UnsignedTx: tx,
+		Inputs: []PInput{{
+			FinalScriptWitness: finalWitness,
+		}},
+		Outputs: []POutput{{}},
+	}
+
+	_, err = Extract(packet)
+	require.ErrorIs(t, err, ErrInvalidPsbtFormat)
+}
+
 func TestFinalizerAddSigHashFlags(t *testing.T) {
 	var signedPsbtData = map[string]string{
 		"Default":            "70736274ff01005e0200000001f1aabce974f1b242b36913f4f8a9f138a8042914dddc4117a578813a4dc32ee10000000000ffffffff017b0a0000000000002251209c1f4b7970d790c99b7265b53adec03551708fd7d67db78359f9c472fe642ad1000000000001012b430b0000000000002251209c1f4b7970d790c99b7265b53adec03551708fd7d67db78359f9c472fe642ad1011340e80246ac1955def419572514e50e4be47f56ccd51beae41ec80ad30cb77ed59ebca3c38dd8506e1b7c28fafa4bdf7d821464be1ee152416bdaf2c056fb4fb3290117206b1a4876464d6bfc6a7c106dd4c5a0f08af94b45a8200e47e02a7dc6148fd7b00000",


### PR DESCRIPTION
## Change Description
Follow-up for https://github.com/btcsuite/btcd/pull/2558

Found one more case where an input with trailing bytes was accepted: final witness data in `psbt.Extract`.

## Steps to Test
```
go test -run TestExtractRejectsTrailingFinalScriptWitnessData -count=1 -v
```
then revert the fix commit and make sure it is failing:
```
=== RUN   TestExtractRejectsTrailingFinalScriptWitnessData
      psbt_test.go:827:
                Error Trace:    /tmp/btcd-bip322-revert-msg/psbt/psbt_test.go:827
                Error:          Target error should be in err chain:
                                expected: "Invalid PSBT serialization format"
                                in chain:
                Test:           TestExtractRejectsTrailingFinalScriptWitnessData
  --- FAIL: TestExtractRejectsTrailingFinalScriptWitnessData (0.00s)
```

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [ ] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [ ] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [ ] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [ ] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
