### PR TITLE
rpc: enforce BIP 145 SegWit rules in getblocktemplate

### DIFF
--- a/btcjson/chainsvrresults.go
+++ b/btcjson/chainsvrresults.go
@@ -308,6 +308,8 @@ type GetBlockTemplateResult struct {
 	// Block proposal from BIP 0023.
 	Capabilities []string `json:"capabilities,omitempty"`
 	RejectReason string   `json:"reject-reason,omitempty"`
+
+	Rules []string `json:"rules,omitempty"`
 }
 
 // GetMempoolEntryResult models the data returned from the getmempoolentry's

--- a/integration/rpcserver_test.go
+++ b/integration/rpcserver_test.go
@@ -13,14 +13,17 @@ import (
 	"fmt"
 	"os"
 	"runtime/debug"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/integration/rpctest"
 	"github.com/btcsuite/btcd/rpcclient"
+	"github.com/stretchr/testify/require"
 )
 
 func testGetBestBlock(r *rpctest.Harness, t *testing.T) {
@@ -289,6 +292,102 @@ func testGetNetworkHashPS3(r *rpctest.Harness, t *testing.T) {
 	}
 }
 
+func ensureSegwitActive(r *rpctest.Harness, t *testing.T) {
+	t.Helper()
+
+	for {
+		info, err := r.Client.GetBlockChainInfo()
+		require.NoError(t, err, "unable to get blockchain info")
+
+		require.NotNil(t, info.Bip9SoftForks,
+			"segwit softfork status not found in blockchain info")
+		require.NotNil(t, info.Bip9SoftForks["segwit"],
+			"segwit softfork status not found in blockchain info")
+
+		if info.Bip9SoftForks["segwit"].Status == "active" {
+			break
+		}
+
+		_, err = r.Client.Generate(100)
+		require.NoError(t, err, "unable to generate blocks to"+
+			" activate segwit")
+	}
+}
+
+func testGetBlockTemplateSegwitActiveNoRule(r *rpctest.Harness, t *testing.T) {
+	// Guarantee SegWit is fully active before testing
+	ensureSegwitActive(r, t)
+
+	// Call getblocktemplate with empty rules when segwit is active
+	req := &btcjson.TemplateRequest{
+		Rules: []string{},
+	}
+
+	_, err := r.Client.GetBlockTemplate(req)
+	require.Error(t, err, "Expected getblocktemplate to fail without "+
+		"'segwit' rule")
+
+	// Expect: ErrRPCInvalidParameter with correct message
+	var rpcErr *btcjson.RPCError
+	require.ErrorAs(t, err, &rpcErr)
+	require.Equal(t, btcjson.ErrRPCInvalidParameter, rpcErr.Code)
+
+	expectedMessage := "Support for 'segwit' rule requires explicit " +
+		"client support"
+
+	require.Equal(t, expectedMessage, rpcErr.Message)
+}
+
+func testGetBlockTemplateSegwitActiveWithRule(
+	r *rpctest.Harness, t *testing.T) {
+	// Guarantee SegWit is fully active before testing
+	ensureSegwitActive(r, t)
+
+	// Call getblocktemplate with 'segwit' rule when segwit is active
+	req := &btcjson.TemplateRequest{
+		Rules: []string{"segwit"},
+	}
+
+	result, err := r.Client.GetBlockTemplate(req)
+	require.NoError(t, err, "Expected getblocktemplate to succeed")
+	require.NotNil(t, result, "Expected non-nil result")
+
+	hasSegwitRule := slices.Contains(result.Rules, "segwit") ||
+		slices.Contains(result.Rules, "!segwit")
+
+	require.True(t, hasSegwitRule, "Expected 'segwit' rule to be present "+
+		"in the response")
+}
+
+func testGetBlockTemplateResponseRules(r *rpctest.Harness, t *testing.T) {
+	// Guarantee SegWit is fully active before testing
+	ensureSegwitActive(r, t)
+
+	// Call getblocktemplate with 'segwit' rule when segwit is active
+	req := &btcjson.TemplateRequest{
+		Rules: []string{"segwit"},
+	}
+
+	result, err := r.Client.GetBlockTemplate(req)
+	require.NoError(t, err, "Expected getblocktemplate to succeed")
+	require.NotNil(t, result, "Expected non-nil result")
+
+	// Verify blockTemplateResult includes "!segwit" in Rules when
+	// WitnessCommitment is non-nil and "segwit" when WitnessCommitment
+	// is nil.
+	hasNotSegwit := slices.Contains(result.Rules, "!segwit")
+	hasSegwit := slices.Contains(result.Rules, "segwit")
+
+	if result.DefaultWitnessCommitment != "" {
+		require.True(t, hasNotSegwit, "Expected Rules to contain "+
+			"'!segwit' because WitnessCommitment is present")
+
+	} else {
+		require.True(t, hasSegwit, "Expected Rules to contain "+
+			"'segwit' because WitnessCommitment is absent")
+	}
+}
+
 var rpcTestCases = []rpctest.HarnessTestCase{
 	testGetBestBlock,
 	testGetBlockCount,
@@ -297,6 +396,9 @@ var rpcTestCases = []rpctest.HarnessTestCase{
 	testGetNetworkHashPS,
 	testGetNetworkHashPS2,
 	testGetNetworkHashPS3,
+	testGetBlockTemplateSegwitActiveNoRule,
+	testGetBlockTemplateSegwitActiveWithRule,
+	testGetBlockTemplateResponseRules,
 }
 
 var primaryHarness *rpctest.Harness

--- a/rpcserver.go
+++ b/rpcserver.go
@@ -20,6 +20,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -124,6 +125,15 @@ var (
 	ErrRPCNoWallet = &btcjson.RPCError{
 		Code:    btcjson.ErrRPCNoWallet,
 		Message: "This implementation does not implement wallet commands",
+	}
+
+	// ErrSegwitRuleMismatch is an error returned to RPC clients when the
+	// client does not explicitly support the 'segwit' rule when SegWit
+	// is active.
+	ErrSegwitRuleMismatch = &btcjson.RPCError{
+		Code: btcjson.ErrRPCInvalidParameter,
+		Message: "Support for 'segwit' rule requires explicit " +
+			"client support",
 	}
 )
 
@@ -1688,7 +1698,10 @@ func (state *gbtWorkState) updateBlockTemplate(s *rpcServer, useCoinbaseValue bo
 // and returned to the caller.
 //
 // This function MUST be called with the state locked.
-func (state *gbtWorkState) blockTemplateResult(useCoinbaseValue bool, submitOld *bool) (*btcjson.GetBlockTemplateResult, error) {
+func (state *gbtWorkState) blockTemplateResult(
+	useCoinbaseValue, segwitActive bool,
+	submitOld *bool) (*btcjson.GetBlockTemplateResult, error) {
+
 	// Ensure the timestamps are still in valid range for the template.
 	// This should really only ever happen if the local clock is changed
 	// after the template is generated, but it's important to avoid serving
@@ -1785,10 +1798,21 @@ func (state *gbtWorkState) blockTemplateResult(useCoinbaseValue bool, submitOld 
 		NonceRange:   gbtNonceRange,
 		Capabilities: gbtCapabilities,
 	}
-	// If the generated block template includes transactions with witness
-	// data, then include the witness commitment in the GBT result.
+	// Per BIP 145, if the block template contains transactions with witness
+	// data, a witness commitment is mandatory, so the rule MUST be listed
+	// as "!segwit" (with the "!" prefix to require client enforcement).
+	// If no witness transactions are included but SegWit is active on the
+	// network, the rule MUST be listed as "segwit" (without the "!"
+	// prefix) to signal that SegWit is active while allowing unaware miners
+	// to still mine the block.
 	if template.WitnessCommitment != nil {
-		reply.DefaultWitnessCommitment = hex.EncodeToString(template.WitnessCommitment)
+		reply.DefaultWitnessCommitment = hex.EncodeToString(
+			template.WitnessCommitment,
+		)
+		reply.Rules = append(reply.Rules, "!segwit")
+
+	} else if segwitActive {
+		reply.Rules = append(reply.Rules, "segwit")
 	}
 
 	if useCoinbaseValue {
@@ -1839,7 +1863,10 @@ func (state *gbtWorkState) blockTemplateResult(useCoinbaseValue bool, submitOld 
 // has passed without finding a solution.
 //
 // See https://en.bitcoin.it/wiki/BIP_0022 for more details.
-func handleGetBlockTemplateLongPoll(s *rpcServer, longPollID string, useCoinbaseValue bool, closeChan <-chan struct{}) (interface{}, error) {
+func handleGetBlockTemplateLongPoll(
+	s *rpcServer, longPollID string, closeChan <-chan struct{},
+	useCoinbaseValue, segwitActive bool) (interface{}, error) {
+
 	state := s.gbtWorkState
 	state.Lock()
 	// The state unlock is intentionally not deferred here since it needs to
@@ -1855,7 +1882,9 @@ func handleGetBlockTemplateLongPoll(s *rpcServer, longPollID string, useCoinbase
 	// the caller is invalid.
 	prevHash, lastGenerated, err := decodeTemplateID(longPollID)
 	if err != nil {
-		result, err := state.blockTemplateResult(useCoinbaseValue, nil)
+		result, err := state.blockTemplateResult(
+			useCoinbaseValue, segwitActive, nil,
+		)
 		if err != nil {
 			state.Unlock()
 			return nil, err
@@ -1876,8 +1905,9 @@ func handleGetBlockTemplateLongPoll(s *rpcServer, longPollID string, useCoinbase
 		// old block template depending on whether or not a solution has
 		// already been found and added to the block chain.
 		submitOld := prevHash.IsEqual(prevTemplateHash)
-		result, err := state.blockTemplateResult(useCoinbaseValue,
-			&submitOld)
+		result, err := state.blockTemplateResult(
+			useCoinbaseValue, segwitActive, &submitOld,
+		)
 		if err != nil {
 			state.Unlock()
 			return nil, err
@@ -1917,7 +1947,9 @@ func handleGetBlockTemplateLongPoll(s *rpcServer, longPollID string, useCoinbase
 	// block template depending on whether or not a solution has already
 	// been found and added to the block chain.
 	submitOld := prevHash.IsEqual(&state.template.Block.Header.PrevBlock)
-	result, err := state.blockTemplateResult(useCoinbaseValue, &submitOld)
+	result, err := state.blockTemplateResult(
+		useCoinbaseValue, segwitActive, &submitOld,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -1986,12 +2018,27 @@ func handleGetBlockTemplateRequest(s *rpcServer, request *btcjson.TemplateReques
 		}
 	}
 
+	segwitState, err := s.cfg.Chain.ThresholdState(
+		chaincfg.DeploymentSegwit,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	segwitActive := segwitState == blockchain.ThresholdActive
+	hasSegwitRule := request != nil && slices.Contains(
+		request.Rules, "segwit",
+	)
+	if segwitActive && !hasSegwitRule {
+		return nil, ErrSegwitRuleMismatch
+	}
+
 	// When a long poll ID was provided, this is a long poll request by the
 	// client to be notified when block template referenced by the ID should
 	// be replaced with a new one.
 	if request != nil && request.LongPollID != "" {
 		return handleGetBlockTemplateLongPoll(s, request.LongPollID,
-			useCoinbaseValue, closeChan)
+			closeChan, useCoinbaseValue, segwitActive)
 	}
 
 	// Protect concurrent access when updating block templates.
@@ -2008,7 +2055,7 @@ func handleGetBlockTemplateRequest(s *rpcServer, request *btcjson.TemplateReques
 	if err := state.updateBlockTemplate(s, useCoinbaseValue); err != nil {
 		return nil, err
 	}
-	return state.blockTemplateResult(useCoinbaseValue, nil)
+	return state.blockTemplateResult(useCoinbaseValue, segwitActive, nil)
 }
 
 // chainErrToGBTErrString converts an error returned from btcchain to a string

--- a/rpcserverhelp.go
+++ b/rpcserverhelp.go
@@ -340,6 +340,7 @@ var helpDescsEnUS = map[string]string{
 	"getblocktemplateresult-reject-reason":              "Reason the proposal was invalid as-is (only applies to proposal responses)",
 	"getblocktemplateresult-default_witness_commitment": "The witness commitment itself. Will be populated if the block has witness data",
 	"getblocktemplateresult-weightlimit":                "The current limit on the max allowed weight of a block",
+	"getblocktemplateresult-rules":                      "List of rules the server requires the client to understand and support",
 
 	// GetBlockTemplateCmd help.
 	"getblocktemplate--synopsis": "Returns a JSON object with information necessary to construct a block to mine or accepts a proposal to validate.\n" +


### PR DESCRIPTION
## Change Description
This PR addresses issue #1738 by enforcing BIP 145 SegWit rules within the `getblocktemplate` RPC response. 

Specifically, this PR updates `rpcserver.go` to ensure that:
- Client requests are rejected with `ErrRPCInvalidParameter` if SegWit is active but the client does not explicitly include the `segwit` rule in their request.
- The `rules` array in the response conditionally includes `!segwit` if the generated block template contains transactions with witness data (indicating a witness commitment is required).
- The `rules` array includes `segwit` (without the `!` prefix) when SegWit is active but the template does not contain any witness transactions.


## Steps to Test
1. Run the RPC server integration tests using `go test -v -tags=rpctest -run=TestRpcServer ./integration`
2. Ensure the newly added `testGetBlockTemplateSegwitActiveNoRule`, `testGetBlockTemplateSegwitActiveWithRule`, and `testGetBlockTemplateResponseRules` tests pass successfully.

## Pull Request Checklist
### Testing
- [ ] Your PR passes all CI checks.
- [ ] Tests covering the positive and negative (error paths) are included.
- [ ] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [x] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [x] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [x] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [x] Any new logging statements use an appropriate subsystem and logging level.
