### PR TITLE
build: bump version to v0.26.2-beta

### DIFF
--- a/version.go
+++ b/version.go
@@ -18,11 +18,11 @@ const semanticAlphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqr
 const (
 	appMajor uint = 0
 	appMinor uint = 26
-	appPatch uint = 1
+	appPatch uint = 2
 
 	// appPreRelease MUST only contain characters from semanticAlphabet
 	// per the semantic versioning spec.
-	appPreRelease = "beta.rc1"
+	appPreRelease = "beta"
 )
 
 // appBuild is defined as a variable so it can be overridden during the build


### PR DESCRIPTION
In this PR, we move btcd past the v0.26.1 release candidate and set the
development version to v0.26.2-beta. This increments the patch series while
dropping the RC suffix, so the daemon and RPC server report the next
in-development version as work resumes on master.

## Testing

```text
GOWORK=off GOCACHE=/tmp/btcd-v0262-go-build go test .
```

A locally built binary reports `0.26.2-beta`.
