### PR TITLE
rpctest,integration: options struct instead of multiple args

### DIFF
--- a/integration/bip0009_test.go
+++ b/integration/bip0009_test.go
@@ -130,11 +130,13 @@ func assertSoftForkStatus(r *rpctest.Harness, t *testing.T, forkKey string, stat
 // specific soft fork deployment to test.
 func testBIP0009(t *testing.T, forkKey string, deploymentID uint32) {
 	// Initialize the primary mining node with only the genesis block.
-	r, err := rpctest.New(&chaincfg.RegressionNetParams, nil, nil, "")
+	r, err := rpctest.New(&rpctest.HarnessOpts{
+		ActiveNet: &chaincfg.RegressionNetParams,
+	})
 	if err != nil {
 		t.Fatalf("unable to create primary harness: %v", err)
 	}
-	if err := r.SetUp(false, 0); err != nil {
+	if err := r.SetUp(nil); err != nil {
 		t.Fatalf("unable to setup test chain: %v", err)
 	}
 	defer r.TearDown()
@@ -383,11 +385,11 @@ func TestBIP0009Mining(t *testing.T) {
 	t.Parallel()
 
 	// Initialize the primary mining node with only the genesis block.
-	r, err := rpctest.New(&chaincfg.SimNetParams, nil, nil, "")
+	r, err := rpctest.New(nil)
 	if err != nil {
 		t.Fatalf("unable to create primary harness: %v", err)
 	}
-	if err := r.SetUp(true, 0); err != nil {
+	if err := r.SetUp(nil); err != nil {
 		t.Fatalf("unable to setup test chain: %v", err)
 	}
 	defer r.TearDown()

--- a/integration/chain_test.go
+++ b/integration/chain_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil/v2"
-	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/integration/rpctest"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/txscript/v2"
@@ -26,12 +25,16 @@ func TestGetTxSpendingPrevOut(t *testing.T) {
 	t.Parallel()
 
 	// Boilerplate codetestDir to make a pruned node.
-	btcdCfg := []string{"--rejectnonstd", "--debuglevel=debug"}
-	r, err := rpctest.New(&chaincfg.SimNetParams, nil, btcdCfg, "")
+	r, err := rpctest.New(&rpctest.HarnessOpts{
+		ExtraArgs: []string{"--rejectnonstd", "--debuglevel=debug"},
+	})
 	require.NoError(t, err)
 
 	// Setup the node.
-	require.NoError(t, r.SetUp(true, 100))
+	require.NoError(t, r.SetUp(&rpctest.SetUpOpts{
+		CreateTestChain:  true,
+		NumMatureOutputs: 100,
+	}))
 	t.Cleanup(func() {
 		require.NoError(t, r.TearDown())
 	})

--- a/integration/csv_fork_test.go
+++ b/integration/csv_fork_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcutil/v2"
-	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/integration/rpctest"
 	"github.com/btcsuite/btcd/txscript/v2"
@@ -111,12 +110,16 @@ func makeTestOutput(r *rpctest.Harness, t *testing.T,
 func TestBIP0113Activation(t *testing.T) {
 	t.Parallel()
 
-	btcdCfg := []string{"--rejectnonstd"}
-	r, err := rpctest.New(&chaincfg.SimNetParams, nil, btcdCfg, "")
+	r, err := rpctest.New(&rpctest.HarnessOpts{
+		ExtraArgs: []string{"--rejectnonstd"},
+	})
 	if err != nil {
 		t.Fatal("unable to create primary harness: ", err)
 	}
-	if err := r.SetUp(true, 1); err != nil {
+	if err := r.SetUp(&rpctest.SetUpOpts{
+		CreateTestChain:  true,
+		NumMatureOutputs: 1,
+	}); err != nil {
 		t.Fatalf("unable to setup test chain: %v", err)
 	}
 	defer r.TearDown()
@@ -408,12 +411,16 @@ func TestBIP0068AndBIP0112Activation(t *testing.T) {
 	// (sequence locks) and BIP 112 rule-sets which add input-age based
 	// relative lock times.
 
-	btcdCfg := []string{"--rejectnonstd"}
-	r, err := rpctest.New(&chaincfg.SimNetParams, nil, btcdCfg, "")
+	r, err := rpctest.New(&rpctest.HarnessOpts{
+		ExtraArgs: []string{"--rejectnonstd"},
+	})
 	if err != nil {
 		t.Fatal("unable to create primary harness: ", err)
 	}
-	if err := r.SetUp(true, 1); err != nil {
+	if err := r.SetUp(&rpctest.SetUpOpts{
+		CreateTestChain:  true,
+		NumMatureOutputs: 1,
+	}); err != nil {
 		t.Fatalf("unable to setup test chain: %v", err)
 	}
 	defer r.TearDown()

--- a/integration/getchaintips_test.go
+++ b/integration/getchaintips_test.go
@@ -145,11 +145,13 @@ func TestGetChainTips(t *testing.T) {
 		"0000000000000000000000000000000000000000000000000000"
 
 	// Set up regtest chain.
-	r, err := rpctest.New(&chaincfg.RegressionNetParams, nil, nil, "")
+	r, err := rpctest.New(&rpctest.HarnessOpts{
+		ActiveNet: &chaincfg.RegressionNetParams,
+	})
 	if err != nil {
 		t.Fatal("TestGetChainTips fail. Unable to create primary harness: ", err)
 	}
-	if err := r.SetUp(true, 0); err != nil {
+	if err := r.SetUp(nil); err != nil {
 		t.Fatalf("TestGetChainTips fail. Unable to setup test chain: %v", err)
 	}
 	defer r.TearDown()

--- a/integration/invalidate_reconsider_block_test.go
+++ b/integration/invalidate_reconsider_block_test.go
@@ -9,12 +9,14 @@ import (
 
 func TestInvalidateAndReconsiderBlock(t *testing.T) {
 	// Set up regtest chain.
-	r, err := rpctest.New(&chaincfg.RegressionNetParams, nil, nil, "")
+	r, err := rpctest.New(&rpctest.HarnessOpts{
+		ActiveNet: &chaincfg.RegressionNetParams,
+	})
 	if err != nil {
 		t.Fatalf("TestInvalidateAndReconsiderBlock fail."+
 			"Unable to create primary harness: %v", err)
 	}
-	if err := r.SetUp(true, 0); err != nil {
+	if err := r.SetUp(nil); err != nil {
 		t.Fatalf("TestInvalidateAndReconsiderBlock fail. "+
 			"Unable to setup test chain: %v", err)
 	}

--- a/integration/p2a_test.go
+++ b/integration/p2a_test.go
@@ -29,10 +29,9 @@ func TestPayToAnchorSimple(t *testing.T) {
 	// default, but the sub-dust and non-empty-witness cases below rely on
 	// standardness checks running, so we start the node with
 	// --rejectnonstd.
-	btcdCfg := []string{"--rejectnonstd"}
-	harness, err := rpctest.New(
-		&chaincfg.SimNetParams, nil, btcdCfg, "",
-	)
+	harness, err := rpctest.New(&rpctest.HarnessOpts{
+		ExtraArgs: []string{"--rejectnonstd"},
+	})
 	if err != nil {
 		t.Fatalf("unable to create test harness: %v", err)
 	}
@@ -40,7 +39,10 @@ func TestPayToAnchorSimple(t *testing.T) {
 
 	// Initialize the test harness with mining enabled to confirm
 	// transactions.
-	err = harness.SetUp(true, 25)
+	err = harness.SetUp(&rpctest.SetUpOpts{
+		CreateTestChain:  true,
+		NumMatureOutputs: 25,
+	})
 	if err != nil {
 		t.Fatalf("unable to setup test harness: %v", err)
 	}
@@ -197,4 +199,3 @@ func TestPayToAnchorSimple(t *testing.T) {
 		}
 	})
 }
-

--- a/integration/prune_test.go
+++ b/integration/prune_test.go
@@ -11,7 +11,6 @@ package integration
 import (
 	"testing"
 
-	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/integration/rpctest"
 	"github.com/stretchr/testify/require"
 )
@@ -20,11 +19,12 @@ func TestPrune(t *testing.T) {
 	t.Parallel()
 
 	// Boilerplate code to make a pruned node.
-	btcdCfg := []string{"--prune=1536"}
-	r, err := rpctest.New(&chaincfg.SimNetParams, nil, btcdCfg, "")
+	r, err := rpctest.New(&rpctest.HarnessOpts{
+		ExtraArgs: []string{"--prune=1536"},
+	})
 	require.NoError(t, err)
 
-	if err := r.SetUp(false, 0); err != nil {
+	if err := r.SetUp(nil); err != nil {
 		require.NoError(t, err)
 	}
 	t.Cleanup(func() { r.TearDown() })

--- a/integration/rawtx_test.go
+++ b/integration/rawtx_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil/v2"
-	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/integration/rpctest"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/txscript/v2"
@@ -27,12 +26,16 @@ func TestTestMempoolAccept(t *testing.T) {
 	t.Parallel()
 
 	// Boilerplate codetestDir to make a pruned node.
-	btcdCfg := []string{"--rejectnonstd", "--debuglevel=debug"}
-	r, err := rpctest.New(&chaincfg.SimNetParams, nil, btcdCfg, "")
+	r, err := rpctest.New(&rpctest.HarnessOpts{
+		ExtraArgs: []string{"--rejectnonstd", "--debuglevel=debug"},
+	})
 	require.NoError(t, err)
 
 	// Setup the node.
-	require.NoError(t, r.SetUp(true, 100))
+	require.NoError(t, r.SetUp(&rpctest.SetUpOpts{
+		CreateTestChain:  true,
+		NumMatureOutputs: 100,
+	}))
 	t.Cleanup(func() {
 		require.NoError(t, r.TearDown())
 	})

--- a/integration/reorg_test.go
+++ b/integration/reorg_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcjson"
-	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/integration/rpctest"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/stretchr/testify/require"
@@ -33,14 +32,14 @@ func TestReorgFromForkPoint(t *testing.T) {
 		forkBranchLen = int32(shorterBlocks)
 	)
 
-	longer, err := rpctest.New(&chaincfg.SimNetParams, nil, []string{}, "")
+	longer, err := rpctest.New(nil)
 	require.NoError(t, err)
-	require.NoError(t, longer.SetUp(false, 0))
+	require.NoError(t, longer.SetUp(nil))
 	t.Cleanup(func() { require.NoError(t, longer.TearDown()) })
 
-	shorter, err := rpctest.New(&chaincfg.SimNetParams, nil, []string{}, "")
+	shorter, err := rpctest.New(nil)
 	require.NoError(t, err)
-	require.NoError(t, shorter.SetUp(false, 0))
+	require.NoError(t, shorter.SetUp(nil))
 	t.Cleanup(func() { require.NoError(t, shorter.TearDown()) })
 
 	// Mine the shared chain on the longer node before connecting so that

--- a/integration/rpcserver_test.go
+++ b/integration/rpcserver_test.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
-	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/integration/rpctest"
 	"github.com/btcsuite/btcd/rpcclient"
@@ -307,10 +306,9 @@ func TestMain(m *testing.M) {
 	// In order to properly test scenarios on as if we were on mainnet,
 	// ensure that non-standard transactions aren't accepted into the
 	// mempool or relayed.
-	btcdCfg := []string{"--rejectnonstd"}
-	primaryHarness, err = rpctest.New(
-		&chaincfg.SimNetParams, nil, btcdCfg, "",
-	)
+	primaryHarness, err = rpctest.New(&rpctest.HarnessOpts{
+		ExtraArgs: []string{"--rejectnonstd"},
+	})
 	if err != nil {
 		fmt.Println("unable to create primary harness: ", err)
 		os.Exit(1)
@@ -319,7 +317,10 @@ func TestMain(m *testing.M) {
 	// Initialize the primary mining node with a chain of length 125,
 	// providing 25 mature coinbases to allow spending from for testing
 	// purposes.
-	if err := primaryHarness.SetUp(true, 25); err != nil {
+	if err := primaryHarness.SetUp(&rpctest.SetUpOpts{
+		CreateTestChain:  true,
+		NumMatureOutputs: 25,
+	}); err != nil {
 		fmt.Println("unable to setup test chain: ", err)
 
 		// Even though the harness was not fully setup, it still needs

--- a/integration/rpctest/rpc_harness.go
+++ b/integration/rpctest/rpc_harness.go
@@ -127,30 +127,67 @@ type Harness struct {
 	sync.Mutex
 }
 
-// New creates and initializes new instance of the rpc test harness.
-// Optionally, websocket handlers and a specified configuration may be passed.
-// In the case that a nil config is passed, a default configuration will be
-// used. If a custom btcd executable is specified, it will be used to start the
-// harness node. Otherwise a new binary is built on demand.
+// HarnessOpts are options that can be passed to New when initializing the
+// harness instance.
+type HarnessOpts struct {
+	// ActiveNet are the parameters of the network to be used, if nil,
+	// SimNet will be used.
+	ActiveNet *chaincfg.Params
+
+	// Handlers are the RPC client notification handlers than can optionally
+	// be passed in.
+	Handlers *rpcclient.NotificationHandlers
+
+	// ExtraArgs are extra arguments to be passed to the btcd instance.
+	ExtraArgs []string
+
+	// CustomExePath sets the path of the btcd executable, if empty an
+	// executable is built on demand.
+	CustomExePath string
+}
+
+func (o *HarnessOpts) clone() *HarnessOpts {
+	if o == nil {
+		return &HarnessOpts{}
+	}
+
+	var opts HarnessOpts
+	opts.ActiveNet = o.ActiveNet
+	if o.Handlers != nil {
+		opts.Handlers = new(rpcclient.NotificationHandlers)
+		*opts.Handlers = *o.Handlers
+	}
+	opts.ExtraArgs = append(opts.ExtraArgs, o.ExtraArgs...)
+	opts.CustomExePath = o.CustomExePath
+
+	return &opts
+}
+
+// New creates and initializes a new instance of the rpctest Harness.
 //
 // NOTE: This function is safe for concurrent access.
-func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers,
-	extraArgs []string, customExePath string) (*Harness, error) {
-
+func New(opts *HarnessOpts) (*Harness, error) {
 	harnessStateMtx.Lock()
 	defer harnessStateMtx.Unlock()
 
+	opts = opts.clone()
+
+	// By default we run on SimNet.
+	if opts.ActiveNet == nil {
+		opts.ActiveNet = &chaincfg.SimNetParams
+	}
+
 	// Add a flag for the appropriate network type based on the provided
 	// chain params.
-	switch activeNet.Net {
+	switch opts.ActiveNet.Net {
 	case wire.MainNet:
 		// No extra flags since mainnet is the default
 	case wire.TestNet3:
-		extraArgs = append(extraArgs, "--testnet")
+		opts.ExtraArgs = append(opts.ExtraArgs, "--testnet")
 	case wire.TestNet:
-		extraArgs = append(extraArgs, "--regtest")
+		opts.ExtraArgs = append(opts.ExtraArgs, "--regtest")
 	case wire.SimNet:
-		extraArgs = append(extraArgs, "--simnet")
+		opts.ExtraArgs = append(opts.ExtraArgs, "--simnet")
 	default:
 		return nil, fmt.Errorf("rpctest.New must be called with one " +
 			"of the supported chain networks")
@@ -172,17 +209,16 @@ func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers,
 		return nil, err
 	}
 
-	wallet, err := newMemWallet(activeNet, uint32(numTestInstances))
+	wallet, err := newMemWallet(opts.ActiveNet, uint32(numTestInstances))
 	if err != nil {
 		return nil, err
 	}
 
 	miningAddr := fmt.Sprintf("--miningaddr=%s", wallet.coinbaseAddr)
-	extraArgs = append(extraArgs, miningAddr)
+	opts.ExtraArgs = append(opts.ExtraArgs, miningAddr)
 
-	config, err := newConfig(
-		nodeTestData, certFile, keyFile, extraArgs, customExePath,
-	)
+	config, err := newConfig(nodeTestData, certFile, keyFile,
+		opts.ExtraArgs, opts.CustomExePath)
 	if err != nil {
 		return nil, err
 	}
@@ -199,41 +235,45 @@ func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers,
 	nodeNum := numTestInstances
 	numTestInstances++
 
-	if handlers == nil {
-		handlers = &rpcclient.NotificationHandlers{}
+	if opts.Handlers == nil {
+		opts.Handlers = &rpcclient.NotificationHandlers{}
 	}
 
 	// If a handler for the OnFilteredBlock{Connected,Disconnected} callback
 	// callback has already been set, then create a wrapper callback which
 	// executes both the currently registered callback and the mem wallet's
 	// callback.
-	if handlers.OnFilteredBlockConnected != nil {
-		obc := handlers.OnFilteredBlockConnected
-		handlers.OnFilteredBlockConnected = func(height int32, header *wire.BlockHeader, filteredTxns []*btcutil.Tx) {
+	if opts.Handlers.OnFilteredBlockConnected != nil {
+		obc := opts.Handlers.OnFilteredBlockConnected
+		opts.Handlers.OnFilteredBlockConnected = func(height int32,
+			header *wire.BlockHeader, filteredTxns []*btcutil.Tx) {
+
 			wallet.IngestBlock(height, header, filteredTxns)
 			obc(height, header, filteredTxns)
 		}
 	} else {
 		// Otherwise, we can claim the callback ourselves.
-		handlers.OnFilteredBlockConnected = wallet.IngestBlock
+		opts.Handlers.OnFilteredBlockConnected = wallet.IngestBlock
 	}
-	if handlers.OnFilteredBlockDisconnected != nil {
-		obd := handlers.OnFilteredBlockDisconnected
-		handlers.OnFilteredBlockDisconnected = func(height int32, header *wire.BlockHeader) {
+	if opts.Handlers.OnFilteredBlockDisconnected != nil {
+		obd := opts.Handlers.OnFilteredBlockDisconnected
+		opts.Handlers.OnFilteredBlockDisconnected = func(height int32,
+			header *wire.BlockHeader) {
+
 			wallet.UnwindBlock(height, header)
 			obd(height, header)
 		}
 	} else {
-		handlers.OnFilteredBlockDisconnected = wallet.UnwindBlock
+		opts.Handlers.OnFilteredBlockDisconnected = wallet.UnwindBlock
 	}
 
 	h := &Harness{
-		handlers:               handlers,
+		handlers:               opts.Handlers,
 		node:                   node,
 		MaxConnRetries:         DefaultMaxConnectionRetries,
 		ConnectionRetryTimeout: DefaultConnectionRetryTimeout,
 		testNodeDir:            nodeTestData,
-		ActiveNet:              activeNet,
+		ActiveNet:              opts.ActiveNet,
 		nodeNum:                nodeNum,
 		wallet:                 wallet,
 	}
@@ -245,6 +285,28 @@ func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers,
 	return h, nil
 }
 
+// SetUpOpts are options that can be passed to SetUp when starting the harness
+// instance.
+type SetUpOpts struct {
+	// CreateTestChain tells the harness to generate blocks.
+	CreateTestChain bool
+
+	// NumMatureOutputs is the count of mature outputs to be generated.
+	NumMatureOutputs uint32
+}
+
+func (o *SetUpOpts) clone() *SetUpOpts {
+	if o == nil {
+		return &SetUpOpts{}
+	}
+
+	var opts SetUpOpts
+	opts.CreateTestChain = o.CreateTestChain
+	opts.NumMatureOutputs = o.NumMatureOutputs
+
+	return &opts
+}
+
 // SetUp initializes the rpc test state. Initialization includes: starting up a
 // simnet node, creating a websockets client and connecting to the started
 // node, and finally: optionally generating and submitting a testchain with a
@@ -252,7 +314,9 @@ func New(activeNet *chaincfg.Params, handlers *rpcclient.NotificationHandlers,
 //
 // NOTE: This method and TearDown should always be called from the same
 // goroutine as they are not concurrent safe.
-func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
+func (h *Harness) SetUp(opts *SetUpOpts) error {
+	opts = opts.clone()
+
 	// Start the btcd node itself. This spawns a new process which will be
 	// managed
 	if err := h.node.start(); err != nil {
@@ -279,9 +343,9 @@ func (h *Harness) SetUp(createTestChain bool, numMatureOutputs uint32) error {
 
 	// Create a test chain with the desired number of mature coinbase
 	// outputs.
-	if createTestChain && numMatureOutputs != 0 {
+	if opts.CreateTestChain && opts.NumMatureOutputs != 0 {
 		coinbaseMaturity := uint32(h.ActiveNet.CoinbaseMaturity)
-		numToGenerate := coinbaseMaturity + numMatureOutputs
+		numToGenerate := coinbaseMaturity + opts.NumMatureOutputs
 		_, err := h.Client.Generate(numToGenerate)
 		if err != nil {
 			return err

--- a/integration/rpctest/rpc_harness_test.go
+++ b/integration/rpctest/rpc_harness_test.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/btcutil/v2"
-	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/txscript/v2"
 	"github.com/btcsuite/btcd/wire/v2"
@@ -106,11 +105,11 @@ func assertConnectedTo(t *testing.T, nodeA *Harness, nodeB *Harness) {
 
 func testConnectNode(r *Harness, t *testing.T) {
 	// Create a fresh test harness.
-	harness, err := New(&chaincfg.SimNetParams, nil, nil, "")
+	harness, err := New(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := harness.SetUp(false, 0); err != nil {
+	if err := harness.SetUp(nil); err != nil {
 		t.Fatalf("unable to complete rpctest setup: %v", err)
 	}
 	defer harness.TearDown()
@@ -154,7 +153,7 @@ func testActiveHarnesses(r *Harness, t *testing.T) {
 	numInitialHarnesses := len(ActiveHarnesses())
 
 	// Create a single test harness.
-	harness1, err := New(&chaincfg.SimNetParams, nil, nil, "")
+	harness1, err := New(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -182,11 +181,11 @@ func testJoinMempools(r *Harness, t *testing.T) {
 	// Create a local test harness with only the genesis block.  The nodes
 	// will be synced below so the same transaction can be sent to both
 	// nodes without it being an orphan.
-	harness, err := New(&chaincfg.SimNetParams, nil, nil, "")
+	harness, err := New(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := harness.SetUp(false, 0); err != nil {
+	if err := harness.SetUp(nil); err != nil {
 		t.Fatalf("unable to complete rpctest setup: %v", err)
 	}
 	defer harness.TearDown()
@@ -282,11 +281,11 @@ func testJoinMempools(r *Harness, t *testing.T) {
 func testJoinBlocks(r *Harness, t *testing.T) {
 	// Create a second harness with only the genesis block so it is behind
 	// the main harness.
-	harness, err := New(&chaincfg.SimNetParams, nil, nil, "")
+	harness, err := New(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := harness.SetUp(false, 0); err != nil {
+	if err := harness.SetUp(nil); err != nil {
 		t.Fatalf("unable to complete rpctest setup: %v", err)
 	}
 	defer harness.TearDown()
@@ -470,11 +469,14 @@ func testGenerateAndSubmitBlockWithCustomCoinbaseOutputs(r *Harness,
 func testMemWalletReorg(r *Harness, t *testing.T) {
 	// Create a fresh harness, we'll be using the main harness to force a
 	// re-org on this local harness.
-	harness, err := New(&chaincfg.SimNetParams, nil, nil, "")
+	harness, err := New(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := harness.SetUp(true, 5); err != nil {
+	if err := harness.SetUp(&SetUpOpts{
+		CreateTestChain:  true,
+		NumMatureOutputs: 5,
+	}); err != nil {
 		t.Fatalf("unable to complete rpctest setup: %v", err)
 	}
 	defer harness.TearDown()
@@ -567,7 +569,7 @@ const (
 
 func TestMain(m *testing.M) {
 	var err error
-	mainHarness, err = New(&chaincfg.SimNetParams, nil, nil, "")
+	mainHarness, err = New(nil)
 	if err != nil {
 		fmt.Println("unable to create main harness: ", err)
 		os.Exit(1)
@@ -576,7 +578,10 @@ func TestMain(m *testing.M) {
 	// Initialize the main mining node with a chain of length 125,
 	// providing 25 mature coinbases to allow spending from for testing
 	// purposes.
-	if err = mainHarness.SetUp(true, numMatureOutputs); err != nil {
+	if err = mainHarness.SetUp(&SetUpOpts{
+		CreateTestChain:  true,
+		NumMatureOutputs: numMatureOutputs,
+	}); err != nil {
 		fmt.Println("unable to setup test chain: ", err)
 
 		// Even though the harness was not fully setup, it still needs

--- a/integration/sync_race_test.go
+++ b/integration/sync_race_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/integration/rpctest"
 	"github.com/btcsuite/btcd/rpcclient"
 	"github.com/btcsuite/btcd/wire/v2"
@@ -299,11 +298,11 @@ func TestSyncManagerRaceCorruption(t *testing.T) {
 	// This test deliberately opens more concurrent peers than the default
 	// inbound limit. Raise the harness limit so admission does not dilute the
 	// sync-manager lifecycle stress this test is intended to apply.
-	stressedHarness, err := rpctest.New(
-		&chaincfg.SimNetParams, nil, []string{"--maxpeers=400"}, "",
-	)
+	stressedHarness, err := rpctest.New(&rpctest.HarnessOpts{
+		ExtraArgs: []string{"--maxpeers=400"},
+	})
 	require.NoError(t, err)
-	require.NoError(t, stressedHarness.SetUp(true, 0))
+	require.NoError(t, stressedHarness.SetUp(nil))
 	t.Cleanup(func() {
 		require.NoError(t, stressedHarness.TearDown())
 	})
@@ -326,9 +325,9 @@ func TestSyncManagerRaceCorruption(t *testing.T) {
 	// Prove corruption: connect a live node and generate blocks. If
 	// the stressed node was corrupted (dead sync peer, 0 connected
 	// peers), it will not sync from the new one.
-	newHarness, err := rpctest.New(&chaincfg.SimNetParams, nil, nil, "")
+	newHarness, err := rpctest.New(nil)
 	require.NoError(t, err)
-	require.NoError(t, newHarness.SetUp(true, 0))
+	require.NoError(t, newHarness.SetUp(nil))
 	defer func() { _ = newHarness.TearDown() }()
 
 	require.NoError(t, rpctest.ConnectNode(stressedHarness, newHarness),
@@ -420,9 +419,9 @@ func dialPreVerackPeer(nodeAddr string) (net.Conn, error) {
 // produced (no peerAdd), since peerLifecycleHandler only sends
 // peerAdd when verAckCh is closed. The node must remain healthy.
 func TestPreVerackDisconnect(t *testing.T) {
-	harness, err := rpctest.New(&chaincfg.SimNetParams, nil, nil, "")
+	harness, err := rpctest.New(nil)
 	require.NoError(t, err)
-	require.NoError(t, harness.SetUp(true, 0))
+	require.NoError(t, harness.SetUp(nil))
 	t.Cleanup(func() { _ = harness.TearDown() })
 
 	nodeAddr := harness.P2PAddress()
@@ -463,9 +462,9 @@ func TestPreVerackDisconnect(t *testing.T) {
 
 	// Verify the node is still healthy: connect a real peer, generate
 	// blocks, and confirm the harness syncs them.
-	helper, err := rpctest.New(&chaincfg.SimNetParams, nil, nil, "")
+	helper, err := rpctest.New(nil)
 	require.NoError(t, err)
-	require.NoError(t, helper.SetUp(true, 0))
+	require.NoError(t, helper.SetUp(nil))
 	defer func() { _ = helper.TearDown() }()
 
 	require.NoError(t, rpctest.ConnectNode(harness, helper))


### PR DESCRIPTION
## Change Description

In the context of the issue #2560 and pull request #2571, the current patch
changes the RPC Harness API to use options structs instead of several parameters
being passed to `rpctest.New()` and `Harness.SetUp()`. Options struct was also
added to `Harness.TearDown()`.

The changes make the API cleaner when the default config is desired, e.g.
`rpctest.New(nil)` instead of
`rpctest.New(&chaincfg.SimNetParams, nil, nil, "")`.

Also, by using options structs we can extend functionality by adding new fields
without breaking the tests.

Improving testability creates incentives to increase the amount of tests, which
allows catching regressions.

## Steps to Test
run `make check`

## Pull Request Checklist
### Testing
- [X] Your PR passes all CI checks.
- [X] Tests covering the positive and negative (error paths) are included.
- [X] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [X] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [X] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [X] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [X] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.
