### PR TITLE
txscript: reject empty p2wsh witness

### DIFF
--- a/txscript/standard.go
+++ b/txscript/standard.go
@@ -836,6 +836,11 @@ func CalcScriptInfo(sigScript, pkScript []byte, witness wire.TxWitness,
 	// If segwit is active, and this is a p2wsh output, then we'll need to
 	// examine the witness script to generate accurate script info.
 	case si.PkScriptClass == WitnessV0ScriptHashTy && segwit:
+		if len(witness) == 0 {
+			return nil, scriptError(ErrWitnessProgramEmpty,
+				"witness program empty passed empty witness")
+		}
+
 		witnessScript := witness[len(witness)-1]
 		redeemClass := typeOfScript(scriptVersion, witnessScript)
 		shInputs := expectedInputs(witnessScript, redeemClass)

--- a/txscript/standard_regression_test.go
+++ b/txscript/standard_regression_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) 2013-2020 The btcsuite developers
+// Use of this source code is governed by an ISC
+// license that can be found in the LICENSE file.
+
+package txscript
+
+import "testing"
+
+// TestCalcScriptInfoEmptyP2WSHWitness ensures an empty P2WSH witness returns an
+// error instead of panicking while trying to access the witness script.
+func TestCalcScriptInfoEmptyP2WSHWitness(t *testing.T) {
+	t.Parallel()
+
+	pkScript := mustParseShortForm(
+		"0 DATA_32 0x00000000000000000000000000000000" +
+			"00000000000000000000000000000000",
+	)
+
+	_, err := CalcScriptInfo(nil, pkScript, nil, false, true)
+	if !IsErrorCode(err, ErrWitnessProgramEmpty) {
+		t.Fatalf("unexpected error -- got %v, want %v", err,
+			ErrWitnessProgramEmpty)
+	}
+}


### PR DESCRIPTION
## Change Description

`CalcScriptInfo` can panic when a P2WSH output is analyzed with an empty witness. This adds a guard before accessing the witness script and returns `ErrWitnessProgramEmpty`, with a regression test for the empty-witness case.

Issue: #2598

## Steps to Test

`go test ./txscript`