### PR TITLE
btcd: fix getblock panic triggered by rpc call

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1074,6 +1074,10 @@ func getDifficultyRatio(bits uint32, params *chaincfg.Params) float64 {
 // handleGetBlock implements the getblock command.
 func handleGetBlock(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (interface{}, error) {
 	c := cmd.(*btcjson.GetBlockCmd)
+	if c.Verbosity == nil {
+		c.Verbosity = new(int)
+		*c.Verbosity = 1
+	}
 
 	// Load the raw block bytes from the database.
 	hash, err := chainhash.NewHashFromStr(c.Hash)
@@ -1116,7 +1120,7 @@ func handleGetBlock(s *rpcServer, cmd interface{}, closeChan <-chan struct{}) (i
 	}
 
 	// If verbosity is 0, return the serialized block as a hex encoded string.
-	if c.Verbosity != nil && *c.Verbosity == 0 {
+	if *c.Verbosity == 0 {
 		return hex.EncodeToString(blkBytes), nil
 	}
 


### PR DESCRIPTION
## Change Description
This patch Fixes #2597

As stated on issue #2597, a JSONRPC request containing `null` as value for `GetBlockCmd.Verbosity` causes a panic in the `handleGetBlock` procedure.

This commit fixes it by setting the default value of `1` when `Verbosity` is `nil` in the start of the `handleGetBlock` procedure.

## Steps to Test

1. Start the Bitcoin node
```
$ go build .
$ ./btcd --regtest --rpcuser=bitcoin --rpcpass=bitcoin --rpclisten=127.0.0.1:8332
```

2. Send the payload
```
$ curl -k --user bitcoin:bitcoin -d   '{"jsonrpc":"2.0","id":0,"method":"getblock","params":["0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",null]}'  'https://127.0.0.1:8332'

{"jsonrpc":"2.0","result":{"hash":"0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206","confirmations":1,"strippedsize":285,"size":285,"weight":1140,"height":0,"version":1,"versionHex":"00000001","merkleroot":"4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b","tx":["4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b"],"time":1296688602,"nonce":2,"bits":"207fffff","difficulty":1,"previousblockhash":"0000000000000000000000000000000000000000000000000000000000000000"},"error":null,"id":0}
```

Before the patch, step `2` triggers panic and expected result is not returned.

## Pull Request Checklist
### Testing
- [X] Your PR passes all CI checks.
- [X] Tests covering the positive and negative (error paths) are included.
- [X] Bug fixes contain tests triggering the bug to prevent regressions.

### Code Style and Documentation
- [X] The change is not [insubstantial](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#substantial-contributions-only). Typo fixes are not accepted to fight bot spam.
- [X] The change obeys the [Code Documentation and Commenting](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#code-documentation-and-commenting) guidelines, and lines wrap at 80.
- [X] Commits follow the [Ideal Git Commit Structure](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md#model-git-commit-messages). 
- [X] Any new logging statements use an appropriate subsystem and logging level.

📝 Please see our [Contribution Guidelines](https://github.com/btcsuite/btcd/blob/master/docs/code_contribution_guidelines.md) for further guidance.