### PR TITLE
build: enforce format and lint checks in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,28 @@ env:
   GO_VERSION: 1.26.3
 
 jobs:
+  lint:
+    name: Format and lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check formatting
+        run: |
+          make fmt
+          git diff --exit-code
+
+      - name: Lint
+        run: make lint
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,4 @@
 version: "2"
 issues:
   # Only show newly introduced problems.
-  new-from-rev: 80b74d6c5a0088a66dc96df6777d21e15c04849c
+  new-from-rev: ca0bb02cf2a88a707734a596f8f7bea84d8df7cd

--- a/integration/p2a_test.go
+++ b/integration/p2a_test.go
@@ -197,4 +197,3 @@ func TestPayToAnchorSimple(t *testing.T) {
 		}
 	})
 }
-


### PR DESCRIPTION
## Change Description

Run the existing `fmt` and `lint` Makefile targets in CI.

The old golangci-lint baseline is no longer in the current master history, so this also moves `new-from-rev` to the current master and gives the lint job full git history.

Closes #2549

## Steps to Test

`make fmt && git diff --exit-code`

`make lint`