### PR TITLE
rpcserver: omit witness commitment from coinbasetxn

### DIFF
--- a/rpcserver.go
+++ b/rpcserver.go
@@ -1699,6 +1699,32 @@ func (state *gbtWorkState) updateBlockTemplate(s *rpcServer, useCoinbaseValue bo
 	return nil
 }
 
+// coinbaseTxForTemplate returns the coinbase transaction to expose through the
+// getblocktemplate coinbasetxn field. BIP 145 requires the witness commitment
+// to be omitted so the client can append the commitment for its final
+// transaction set.
+func coinbaseTxForTemplate(tx *wire.MsgTx, witnessCommitment []byte) *wire.MsgTx {
+	if len(witnessCommitment) == 0 || len(tx.TxOut) == 0 {
+		return tx
+	}
+
+	expectedScript := make(
+		[]byte, 0, len(blockchain.WitnessMagicBytes)+len(witnessCommitment),
+	)
+	expectedScript = append(expectedScript, blockchain.WitnessMagicBytes...)
+	expectedScript = append(expectedScript, witnessCommitment...)
+
+	lastOutput := len(tx.TxOut) - 1
+	if !bytes.Equal(tx.TxOut[lastOutput].PkScript, expectedScript) {
+		return tx
+	}
+
+	tx = tx.Copy()
+	tx.TxOut = tx.TxOut[:lastOutput]
+
+	return tx
+}
+
 // blockTemplateResult returns the current block template associated with the
 // state as a btcjson.GetBlockTemplateResult that is ready to be encoded to JSON
 // and returned to the caller.
@@ -1823,8 +1849,11 @@ func (state *gbtWorkState) blockTemplateResult(useCoinbaseValue bool, submitOld 
 			}
 		}
 
-		// Serialize the transaction for conversion to hex.
-		tx := msgBlock.Transactions[0]
+		// Serialize the transaction for conversion to hex. BIP 145 requires
+		// coinbasetxn to omit the witness commitment.
+		tx := coinbaseTxForTemplate(
+			msgBlock.Transactions[0], template.WitnessCommitment,
+		)
 		txBuf := bytes.NewBuffer(make([]byte, 0, tx.SerializeSize()))
 		if err := tx.Serialize(txBuf); err != nil {
 			context := "Failed to serialize transaction"

--- a/rpcserver_test.go
+++ b/rpcserver_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/btcsuite/btcd/blockchain"
 	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/btcutil/v2"
 	"github.com/btcsuite/btcd/chaincfg/v2"
@@ -199,6 +200,43 @@ func TestHandleDecodeRawTransactionRejectsTrailingBytes(t *testing.T) {
 
 	requireRPCErrorCode(t, err, btcjson.ErrRPCDeserialization)
 	require.Nil(t, result)
+}
+
+// TestCoinbaseTxForTemplate ensures the getblocktemplate coinbasetxn omits
+// the witness commitment without modifying the internal block template.
+func TestCoinbaseTxForTemplate(t *testing.T) {
+	t.Parallel()
+
+	paymentScript := []byte{0x51}
+	witnessCommitment := bytes.Repeat([]byte{0x01}, chainhash.HashSize)
+	witnessScript := append(
+		append([]byte{}, blockchain.WitnessMagicBytes...),
+		witnessCommitment...,
+	)
+
+	coinbase := wire.NewMsgTx(wire.TxVersion)
+	coinbase.AddTxOut(&wire.TxOut{
+		Value:    1,
+		PkScript: paymentScript,
+	})
+	coinbase.AddTxOut(&wire.TxOut{
+		PkScript: witnessScript,
+	})
+
+	result := coinbaseTxForTemplate(coinbase, witnessCommitment)
+	require.NotSame(t, coinbase, result)
+	require.Len(t, result.TxOut, 1)
+	require.Equal(t, paymentScript, result.TxOut[0].PkScript)
+
+	// The internal template must retain its commitment.
+	require.Len(t, coinbase.TxOut, 2)
+	require.Equal(t, witnessScript, coinbase.TxOut[1].PkScript)
+
+	// Transactions without the expected final commitment are unchanged.
+	require.Same(t, coinbase, coinbaseTxForTemplate(coinbase, nil))
+	require.Same(
+		t, coinbase, coinbaseTxForTemplate(coinbase, []byte{0x00}),
+	)
 }
 
 // TestHandleGetBlockTemplateProposalRejectsTrailingBytes ensures proposal mode


### PR DESCRIPTION
## Change Description

BIP 145 requires `coinbasetxn` to omit the witness commitment so miners can append a commitment for their final transaction set.

Keep the commitment in btcd's internal block template for validation, but strip the final commitment output from the copy serialized into `coinbasetxn`.

Adds regression coverage to ensure the internal coinbase remains unchanged.

Fixes #2572.

## Steps to Test

`go test .`