### PR TITLE
rpcserver: test null getblock verbosity

### DIFF
--- a/integration/rpcserver_test.go
+++ b/integration/rpcserver_test.go
@@ -10,6 +10,7 @@ package integration
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"runtime/debug"
@@ -17,6 +18,7 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/blockchain"
+	"github.com/btcsuite/btcd/btcjson"
 	"github.com/btcsuite/btcd/chaincfg/v2"
 	"github.com/btcsuite/btcd/chainhash/v2"
 	"github.com/btcsuite/btcd/integration/rpctest"
@@ -96,6 +98,39 @@ func testGetBlockHash(r *rpctest.Harness, t *testing.T) {
 	if !bytes.Equal(generatedBlockHashes[0][:], blockHash[:]) {
 		t.Fatalf("Block hashes do not match. Returned hash %v, wanted "+
 			"hash %v", blockHash, generatedBlockHashes[0][:])
+	}
+}
+
+func testGetBlockNullVerbosity(r *rpctest.Harness, t *testing.T) {
+	hash, err := r.Client.GetBestBlockHash()
+	if err != nil {
+		t.Fatalf("Unable to get best block hash: %v", err)
+	}
+
+	hashJSON, err := json.Marshal(hash.String())
+	if err != nil {
+		t.Fatalf("Unable to marshal block hash: %v", err)
+	}
+
+	resultJSON, err := r.Client.RawRequest(
+		"getblock", []json.RawMessage{
+			hashJSON, json.RawMessage("null"),
+		},
+	)
+	if err != nil {
+		t.Fatalf("Unable to get block with null verbosity: %v", err)
+	}
+
+	var result btcjson.GetBlockVerboseResult
+	if err := json.Unmarshal(resultJSON, &result); err != nil {
+		t.Fatalf("Unable to unmarshal verbose block result: %v", err)
+	}
+	if result.Hash != hash.String() {
+		t.Fatalf("Block hashes do not match. Got %v, wanted %v",
+			result.Hash, hash)
+	}
+	if len(result.Tx) == 0 {
+		t.Fatal("Verbose block result contains no transactions")
 	}
 }
 
@@ -293,6 +328,7 @@ var rpcTestCases = []rpctest.HarnessTestCase{
 	testGetBestBlock,
 	testGetBlockCount,
 	testGetBlockHash,
+	testGetBlockNullVerbosity,
 	testBulkClient,
 	testGetNetworkHashPS,
 	testGetNetworkHashPS2,


### PR DESCRIPTION
In this PR, we add the missing end-to-end regression test for #2597 and the fix merged in #2600. The test sends `getblock` through `RawRequest` with an explicit JSON `null` verbosity, then verifies that btcd applies the default verbose response rather than disconnecting the WebSocket client.

The same test fails on #2600 parent with `websocket: close 1006 unexpected EOF` and `the client has been disconnected`, and passes on current `master`.

## Testing

`make unit`

`golangci-lint run --timeout=5m --new-from-rev=a3f203843`